### PR TITLE
Fix Arabic (Morocco) showing as Arabic (Macao)

### DIFF
--- a/packages/app/supported-languages/package.json
+++ b/packages/app/supported-languages/package.json
@@ -42,6 +42,7 @@
 		"@lokalise/eslint-config": "*",
 		"@lokalise/prettier-config": "*",
 		"@rollup/plugin-typescript": "^11.1.3",
+		"@vitest/coverage-v8": "^0.34.6",
 		"prettier": "^3.0.3",
 		"rimraf": "^5.0.1",
 		"rollup": "^4.4.1",

--- a/packages/app/supported-languages/src/standard-locales.ts
+++ b/packages/app/supported-languages/src/standard-locales.ts
@@ -11,7 +11,7 @@ export const standardLocales = [
 	'ar-KW', // Arabic - Kuwait
 	'ar-LB', // Arabic - Lebanon
 	'ar-LY', // Arabic - Libya
-	'ar-MO', // Arabic - Morocco
+	'ar-MA', // Arabic - Morocco
 	'ar-OM', // Arabic - Oman
 	'ar-QA', // Arabic - Qatar
 	'ar-SA', // Arabic - Saudi Arabia


### PR DESCRIPTION
Fixed region for Arabic (Morocco) from `MO` to `MA` (see region [here](https://github.com/lokalise/shared-ts-libs/blob/39520855b0318335e78e55c513188e2698ac47e1/packages/app/supported-languages/src/regions.ts#L187)) as it was wrong and causing the language to be displayed as Arabic (Macao).