### PR TITLE
Align CommonErrorResponse with what errorHandler actually returns

### DIFF
--- a/packages/app/api-common/src/apiSchemas.ts
+++ b/packages/app/api-common/src/apiSchemas.ts
@@ -20,9 +20,12 @@ export const zMeta = z.object({
 export type PaginationMeta = z.infer<typeof zMeta>
 
 export const COMMON_ERROR_RESPONSE_SCHEMA = z.object({
-	message: z.string(),
-	errorCode: z.string(),
-	details: z.any().optional(),
+	statusCode: z.number(),
+	payload: z.object({
+		message: z.string(),
+		errorCode: z.string(),
+		details: z.any().optional(),
+	}),
 })
 
 export type CommonErrorResponse = z.infer<typeof COMMON_ERROR_RESPONSE_SCHEMA>


### PR DESCRIPTION
See https://github.com/lokalise/fastify-extras/blob/main/lib/errors/errorHandler.ts

Our existing schema doesn't seem to be accurate. We probably didn't notice, because we don't currently use it for anything other than route definition.