### PR TITLE
feat: accept DisplayNamesOptions in getLocalisedLanguageName and default to standard languageDisplay

### DIFF
--- a/packages/app/supported-languages/src/index.test.ts
+++ b/packages/app/supported-languages/src/index.test.ts
@@ -201,7 +201,7 @@ describe('supported-languages package', () => {
 		it('get language name in English', () => {
 			expect(getLanguageNameInEnglish('es')).toBe('Spanish')
 			expect(getLanguageNameInEnglish('en')).toBe('English')
-			expect(getLanguageNameInEnglish('en-US')).toBe('American English')
+			expect(getLanguageNameInEnglish('en-US')).toBe('English (United States)')
 			expect(getLanguageNameInEnglish('bs-Latn-BA')).toBe('Bosnian (Latin, Bosnia & Herzegovina)')
 		})
 
@@ -214,7 +214,10 @@ describe('supported-languages package', () => {
 	describe('getLocalisedLanguageName', () => {
 		it('get language name in French', () => {
 			expect(getLocalisedLanguageName('es', 'fr')).toBe('espagnol')
-			expect(getLocalisedLanguageName('en-US', 'fr')).toBe('anglais américain')
+			expect(getLocalisedLanguageName('en-US', 'fr')).toBe('anglais (États-Unis)')
+			expect(getLocalisedLanguageName('en-US', 'fr', { languageDisplay: 'dialect' })).toBe(
+				'anglais américain',
+			)
 			expect(getLocalisedLanguageName('bs-Latn-BA', 'fr')).toBe(
 				'bosniaque (latin, Bosnie-Herzégovine)',
 			)

--- a/packages/app/supported-languages/src/index.ts
+++ b/packages/app/supported-languages/src/index.ts
@@ -171,12 +171,17 @@ export const getLanguageNameInEnglish = (tag: LocaleString): string | null => {
 export const getLocalisedLanguageName = (
 	tag: LocaleString,
 	destinationTag: LocaleString,
+	options?: Omit<Partial<Intl.DisplayNamesOptions>, 'type'>,
 ): string | null => {
 	if (!isSupportedLocale(tag) || !isSupportedLocale(destinationTag)) {
 		return null
 	}
 
-	const displayNames = new Intl.DisplayNames([destinationTag], { type: 'language' })
+	const displayNames = new Intl.DisplayNames([destinationTag], {
+		type: 'language',
+		languageDisplay: 'standard',
+		...options,
+	})
 
 	try {
 		const displayName = displayNames.of(tag)


### PR DESCRIPTION
AP-1967

- Sets default `languageDisplay` to `standard` instead of `dialect`.
- Accepts optional `Intl.DisplayNamesOptions` arg, to override `Intl.DisplayNames` constructor options except for `type` (since this shared function is specifically for returning a language name, not region names).