### PR TITLE
publish config

### DIFF
--- a/packages/app/non-translatable-markup/package.json
+++ b/packages/app/non-translatable-markup/package.json
@@ -20,6 +20,9 @@
 			"import": "./dist/index.js"
 		}
 	},
+	"publishConfig": {
+		"access": "public"
+	},
 	"scripts": {
 		"build": "rimraf dist && vite build",
 		"dev": "vite watch",


### PR DESCRIPTION
## Changes

Fixing publish error on `non-translatable-content` package
```
code E402
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@lokalise%2fnon-translatable-markup - You must sign up for private packages
```

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
