### PR TITLE
AP-2910 Allow reorder of non translatable regions

### DIFF
--- a/packages/app/non-translatable-markup/package.json
+++ b/packages/app/non-translatable-markup/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lokalise/non-translatable-markup",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"files": [
 		"dist"
 	],
@@ -36,9 +36,9 @@
 		"zod": "^3.22.0"
 	},
 	"devDependencies": {
-		"@lokalise/eslint-config": "*",
-		"@lokalise/prettier-config": "*",
-		"@lokalise/package-vite-config": "*",
+		"@lokalise/eslint-config": "latest",
+		"@lokalise/prettier-config": "latest",
+		"@lokalise/package-vite-config": "latest",
 		"@vitest/coverage-v8": "^1.1.3",
 		"prettier": "3.2.5",
 		"rimraf": "^5.0.1",

--- a/packages/app/non-translatable-markup/src/nonTranslatableContentHelper.ts
+++ b/packages/app/non-translatable-markup/src/nonTranslatableContentHelper.ts
@@ -37,8 +37,11 @@ export const isAttemptToEditNonTranslatableContent = (
 		return true
 	}
 
-	for (let i = 0; i < nonTranslatableContentInText.length; i++) {
-		if (nonTranslatableContentInText[i] !== nonTranslatableContentInUpdatedText[i]) {
+	const sortedNonTranslatableContentInText = nonTranslatableContentInText.sort()
+	const sortedNonTranslatableContentInUpdatedText = nonTranslatableContentInUpdatedText.sort()
+
+	for (let i = 0; i < sortedNonTranslatableContentInText.length; i++) {
+		if (sortedNonTranslatableContentInText[i] !== sortedNonTranslatableContentInUpdatedText[i]) {
 			return true
 		}
 	}

--- a/packages/app/non-translatable-markup/test/nonTranslatableContentHelper.spec.ts
+++ b/packages/app/non-translatable-markup/test/nonTranslatableContentHelper.spec.ts
@@ -50,6 +50,10 @@ describe('nonTranslatableContentHelper', () => {
 				'\uE101{% if MyVariable %}\uE102 Hello \uE101{% else %}\uE102 Goodbye \uE101{% endif %}\uE102 world',
 				'\uE101{% if MyVariable %}\uE102 Hello \uE101{% else %}\uE102 Sayonara \uE101{% endif %}\uE102 world',
 			],
+			[
+				'Sie haben sich am \uE101{% date %}\uE102 \uE101{% engaged %}\uE102',
+				'Am \uE101{% date %}\uE102 haben sie sich \uE101{% engaged %}\uE102',
+			], // swapped non translatable content
 		])('returns false if non translatable content is not edited', (originalValue, updatedValue) => {
 			expect(isAttemptToEditNonTranslatableContent(originalValue, updatedValue)).toBeFalsy()
 		})
@@ -58,7 +62,6 @@ describe('nonTranslatableContentHelper', () => {
 			'\uE101{% if MyVariable %}\uE102 Hello \uE101{% else %}\uE102 Goodbye \uE101{% endif %} my\uE102 world', // edited non translatable content
 			'\uE101{% if MyVariable %}\uE102 Hello \uE101{% endif %}\uE102 world', // removed non translatable content
 			'\uE101{% if MyVariable %}\uE102 Hello \uE101{% else %}\uE102 Goodbye \uE101{% endif %} world', // unbalanced tags
-			'\uE101{% if MyVariable %}\uE102 Hello \uE101{% endif %}\uE102 Goodbye \uE101{% else %}\uE102 world', // swapped non translatable content
 			'\uE101{% if MyVariable %} Hello {% endif %} Goodbye {% else %}\uE102', // whole content is non-translatable
 		])('returns true if non translatable content is edited', (updatedValue) => {
 			const originalValue =


### PR DESCRIPTION
## Changes

Changes `isAttemptToEditNonTranslatableContent()` to allow reordering of non translatable regions based on [this feedback](https://lokalise.slack.com/archives/C0583820D5K/p1711554993683989).

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
