### PR TITLE
DXP-277 Bump eslint-config-frontend

### DIFF
--- a/packages/dev/eslint-config/configs/shared-package.cjs
+++ b/packages/dev/eslint-config/configs/shared-package.cjs
@@ -22,6 +22,7 @@ module.exports = {
 				'newlines-between': 'always',
 			},
 		],
+		'no-mixed-spaces-and-tabs': 'off',
 		'object-shorthand': ['error', 'always'],
 		'max-lines': ['error', { max: 600 }],
 		'max-params': ['error', { max: 4 }],

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -20,7 +20,7 @@
 		"lint:fix": "prettier --write ."
 	},
 	"dependencies": {
-		"@lokalise/eslint-config-frontend": "^4.4.0",
+		"@lokalise/eslint-config-frontend": "^4.6.0",
 		"@tanstack/eslint-plugin-query": "^5.28.6",
 		"@typescript-eslint/parser": "^7.3.1"
 	},


### PR DESCRIPTION
## Changes

Hopefully the last PR for this round 🥲 

- Updates eslint-config-frontend to include https://github.com/lokalise/eslint-config-frontend/pull/279
- Turns off [no-mixed-spaces-and-tabs](https://eslint.org/docs/latest/rules/no-mixed-spaces-and-tabs#:~:text=Most%20code%20conventions%20require%20either,with%20both%20tabs%20and%20spaces.) for backend too

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
