### PR TITLE
Bump the limit for max statements slightly

### DIFF
--- a/packages/dev/eslint-config/configs/shared-package.cjs
+++ b/packages/dev/eslint-config/configs/shared-package.cjs
@@ -27,7 +27,7 @@ module.exports = {
 		'object-shorthand': ['error', 'always'],
 		'max-lines': ['error', { max: 600 }],
 		'max-params': ['error', { max: 4 }],
-		'max-statements': ['error', { max: 20 }],
+		'max-statements': ['error', { max: 18 }],
 		complexity: ['error', { max: 20 }],
 	},
 	overrides: [


### PR DESCRIPTION
## Changes

Our current limit seems to be arbitrarily too low, and we are already ignoring the check in pretty reasonably sized places

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
