### PR TITLE
Fix export type

### DIFF
--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lokalise/background-jobs-common",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"files": [
 		"dist",
 		"LICENSE",

--- a/packages/app/background-jobs-common/tsconfig.json
+++ b/packages/app/background-jobs-common/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"outDir": "dist",
-		"module": "ESNext",
+		"module": "CommonJS",
 		"target": "ES2022",
 		"lib": ["ES2022", "dom"],
 		"sourceMap": false,


### PR DESCRIPTION
## Changes

Autopilot is choking on ESM exports in backend for whatever reason, switched to CommonJS

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
