### PR TITLE
Crdb transaction retry

### DIFF
--- a/packages/app/prisma-utils/src/cockroachdbError.spec.ts
+++ b/packages/app/prisma-utils/src/cockroachdbError.spec.ts
@@ -33,19 +33,7 @@ describe('cockroachdbError', () => {
 		const error = new PrismaClientKnownRequestError('test', {
 			code: 'P100',
 			clientVersion: '1',
-			meta: { code: '40002', message: 'restart transaction' },
-		})
-
-		// When - Then
-		expect(isCockroachDBRetryTransaction(error)).toBe(false)
-	})
-
-	it('wrong meta.message', () => {
-		// Given
-		const error = new PrismaClientKnownRequestError('test', {
-			code: 'P100',
-			clientVersion: '1',
-			meta: { code: '40001', message: 'wrong message' },
+			meta: { code: '40002' },
 		})
 
 		// When - Then
@@ -57,7 +45,7 @@ describe('cockroachdbError', () => {
 		const error = new PrismaClientKnownRequestError('test', {
 			code: 'P100',
 			clientVersion: '1',
-			meta: { code: '40001', message: 'restart transaction' },
+			meta: { code: '40001' },
 		})
 
 		// When - Then

--- a/packages/app/prisma-utils/src/cockroachdbError.spec.ts
+++ b/packages/app/prisma-utils/src/cockroachdbError.spec.ts
@@ -1,0 +1,66 @@
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
+import { describe, expect, it } from 'vitest'
+
+import { isCockroachDBRetryTransaction } from './cockroachdbError'
+import { PRISMA_SERIALIZATION_ERROR } from './prismaError'
+
+describe('cockroachdbError', () => {
+	it('without meta should return false', () => {
+		// Given
+		const error = new PrismaClientKnownRequestError('test', {
+			code: PRISMA_SERIALIZATION_ERROR,
+			clientVersion: '1',
+		})
+
+		// When - Then
+		expect(isCockroachDBRetryTransaction(error)).toBe(false)
+	})
+
+	it('wrong meta field', () => {
+		// Given
+		const error = new PrismaClientKnownRequestError('test', {
+			code: 'P100',
+			clientVersion: '1',
+			meta: { wrong: 'meta' },
+		})
+
+		// When - Then
+		expect(isCockroachDBRetryTransaction(error)).toBe(false)
+	})
+
+	it('wrong meta.code', () => {
+		// Given
+		const error = new PrismaClientKnownRequestError('test', {
+			code: 'P100',
+			clientVersion: '1',
+			meta: { code: '40002', message: 'restart transaction' },
+		})
+
+		// When - Then
+		expect(isCockroachDBRetryTransaction(error)).toBe(false)
+	})
+
+	it('wrong meta.message', () => {
+		// Given
+		const error = new PrismaClientKnownRequestError('test', {
+			code: 'P100',
+			clientVersion: '1',
+			meta: { code: '40001', message: 'wrong message' },
+		})
+
+		// When - Then
+		expect(isCockroachDBRetryTransaction(error)).toBe(false)
+	})
+
+	it('is CockroachDb retry transaction error', () => {
+		// Given
+		const error = new PrismaClientKnownRequestError('test', {
+			code: 'P100',
+			clientVersion: '1',
+			meta: { code: '40001', message: 'restart transaction' },
+		})
+
+		// When - Then
+		expect(isCockroachDBRetryTransaction(error)).toBe(true)
+	})
+})

--- a/packages/app/prisma-utils/src/cockroachdbError.ts
+++ b/packages/app/prisma-utils/src/cockroachdbError.ts
@@ -1,0 +1,26 @@
+import type { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
+
+/**
+ * https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference#:~:text=To%20indicate%20that%20a%20transaction,the%20string%20%22restart%20transaction%22%20.
+ *
+ * All transaction retry errors use the SQLSTATE error code 40001, and emit error messages with the string restart transaction. Further, each error includes a specific error code to assist with targeted troubleshooting
+ */
+const COCKROACHDB_RETRY_TRANSACTION_CODE = '40001'
+const COCKROACHDB_RETRY_TRANSACTION_MESSAGE = 'restart transaction'
+
+/**
+ * Check if the error is a CockroachDB transaction retry error
+ *
+ * @param error
+ * TODO: add tests
+ */
+export const isCockroachDBRetryTransaction = (error: PrismaClientKnownRequestError): boolean => {
+	const meta = error.meta
+	if (!meta) return false
+
+	return (
+		meta.code === COCKROACHDB_RETRY_TRANSACTION_CODE &&
+		typeof meta.message === 'string' &&
+		meta.message.includes(COCKROACHDB_RETRY_TRANSACTION_MESSAGE)
+	)
+}

--- a/packages/app/prisma-utils/src/cockroachdbError.ts
+++ b/packages/app/prisma-utils/src/cockroachdbError.ts
@@ -12,7 +12,6 @@ const COCKROACHDB_RETRY_TRANSACTION_MESSAGE = 'restart transaction'
  * Check if the error is a CockroachDB transaction retry error
  *
  * @param error
- * TODO: add tests
  */
 export const isCockroachDBRetryTransaction = (error: PrismaClientKnownRequestError): boolean => {
 	const meta = error.meta

--- a/packages/app/prisma-utils/src/cockroachdbError.ts
+++ b/packages/app/prisma-utils/src/cockroachdbError.ts
@@ -3,10 +3,9 @@ import type { PrismaClientKnownRequestError } from '@prisma/client/runtime/libra
 /**
  * https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference#:~:text=To%20indicate%20that%20a%20transaction,the%20string%20%22restart%20transaction%22%20.
  *
- * All transaction retry errors use the SQLSTATE error code 40001, and emit error messages with the string restart transaction. Further, each error includes a specific error code to assist with targeted troubleshooting
+ * All transaction retry errors use the SQLSTATE error code 40001
  */
 const COCKROACHDB_RETRY_TRANSACTION_CODE = '40001'
-const COCKROACHDB_RETRY_TRANSACTION_MESSAGE = 'restart transaction'
 
 /**
  * Check if the error is a CockroachDB transaction retry error
@@ -17,9 +16,5 @@ export const isCockroachDBRetryTransaction = (error: PrismaClientKnownRequestErr
 	const meta = error.meta
 	if (!meta) return false
 
-	return (
-		meta.code === COCKROACHDB_RETRY_TRANSACTION_CODE &&
-		typeof meta.message === 'string' &&
-		meta.message.includes(COCKROACHDB_RETRY_TRANSACTION_MESSAGE)
-	)
+	return meta.code === COCKROACHDB_RETRY_TRANSACTION_CODE
 }

--- a/packages/app/prisma-utils/src/index.ts
+++ b/packages/app/prisma-utils/src/index.ts
@@ -1,3 +1,3 @@
 export * from './prismaError'
+export * from './types'
 export { prismaTransaction } from './prismaTransaction'
-export type { PrismaTransactionOptions, PrismaTransactionBasicOptions } from './prismaTransaction'

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -143,7 +143,6 @@ describe('prismaTransaction', () => {
 			expect(result.error).toBeInstanceOf(PrismaClientKnownRequestError)
 			expect((result.error as PrismaClientKnownRequestError).meta).toMatchObject({
 				code: '40001',
-				message: 'restart transaction',
 			})
 			expect(retrySpy).toHaveBeenCalledTimes(3)
 		})

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -130,7 +130,7 @@ describe('prismaTransaction', () => {
 				new PrismaClientKnownRequestError('test', {
 					code: 'P100',
 					clientVersion: '1',
-					meta: { code: '40001', message: 'restart transaction' },
+					meta: { code: '40001' },
 				}),
 			)
 

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -104,7 +104,7 @@ describe('prismaTransaction', () => {
 			expect(retrySpy).toHaveBeenCalledTimes(5)
 		})
 
-		it('Only PRISMA_SERIALIZATION_ERROR code is retried', async () => {
+		it('not all prisma code are retried', async () => {
 			// Given
 			const retrySpy = vitest.spyOn(prisma, '$transaction').mockRejectedValue(
 				new PrismaClientKnownRequestError('test', {
@@ -122,6 +122,30 @@ describe('prismaTransaction', () => {
 			expect(result.error).toBeInstanceOf(PrismaClientKnownRequestError)
 			expect((result.error as PrismaClientKnownRequestError).code).toBe(PRISMA_NOT_FOUND_ERROR)
 			expect(retrySpy).toHaveBeenCalledTimes(1)
+		})
+
+		it('CockroachDB retry transaction error is retried', async () => {
+			// Given
+			const retrySpy = vitest.spyOn(prisma, '$transaction').mockRejectedValue(
+				new PrismaClientKnownRequestError('test', {
+					code: 'P100',
+					clientVersion: '1',
+					meta: { code: '40001', message: 'restart transaction' },
+				}),
+			)
+
+			// When
+			const result = await prismaTransaction(prisma, (client) =>
+				client.item1.create({ data: TEST_ITEM_1 }),
+			)
+
+			// Then
+			expect(result.error).toBeInstanceOf(PrismaClientKnownRequestError)
+			expect((result.error as PrismaClientKnownRequestError).meta).toMatchObject({
+				code: '40001',
+				message: 'restart transaction',
+			})
+			expect(retrySpy).toHaveBeenCalledTimes(3)
 		})
 	})
 

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -1,0 +1,25 @@
+import type * as runtime from '@prisma/client/runtime/library'
+
+type ObjectValues<T> = T[keyof T]
+
+export const DbDriverEnum = {
+	COCKROACHDB: 'CockroachDb',
+} as const
+export type DbDriver = ObjectValues<typeof DbDriverEnum>
+
+export type PrismaTransactionOptions = {
+	retriesAllowed: number
+	maxWait?: number
+	timeout?: number
+	isolationLevel?: string
+	DbDriver?: DbDriver
+}
+
+export type PrismaTransactionBasicOptions = Pick<
+	PrismaTransactionOptions,
+	'retriesAllowed' | 'isolationLevel' | 'DbDriver'
+>
+
+export type PrismaTransactionClient<P> = Omit<P, runtime.ITXClientDenyList>
+
+export type PrismaTransactionFn<T, P> = (prisma: PrismaTransactionClient<P>) => Promise<T>

--- a/packages/app/prisma-utils/vitest.config.mts
+++ b/packages/app/prisma-utils/vitest.config.mts
@@ -16,6 +16,8 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.ts'],
       exclude: [
+        'src/index.ts',
+        'src/types.ts'
       ],
       reporter: ['text'],
       all: true,


### PR DESCRIPTION
## Changes

We have the following error:

```
Transaction failed with unrecoverable error: {"name":"PrismaClientKnownRequestError","code":"P2010","clientVersion":"5.13.0","meta":{"code":"40001","message":"restart transaction: TransactionRetryWithProtoRefreshError: WriteTooOldError: write for key ...
```

Following [crdb doc](https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference#:~:text=To%20indicate%20that%20a%20transaction,the%20string%20%22restart%20transaction%22%20.)
> All transaction retry errors use the SQLSTATE error code 40001, and emit error messages with the string [restart transaction](https://www.cockroachlabs.com/docs/v24.1/common-errors#restart-transaction). Further, each error includes a [specific error code](https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference#transaction-retry-error-reference) to assist with targeted troubleshooting.All transaction retry errors use the SQLSTATE error code 40001, and emit error messages with the string [restart transaction](https://www.cockroachlabs.com/docs/v24.1/common-errors#restart-transaction). Further, each error includes a [specific error code](https://www.cockroachlabs.com/docs/stable/transaction-retry-error-reference#transaction-retry-error-reference) to assist with targeted troubleshooting.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
