### PR TITLE
Prisma transaction retry delay

### DIFF
--- a/packages/app/prisma-utils/package.json
+++ b/packages/app/prisma-utils/package.json
@@ -45,18 +45,18 @@
 		"@lokalise/node-core": "^9.16.0"
 	},
 	"peerDependencies": {
-		"prisma": "^5.12.1",
-		"@prisma/client": "^5.12.1"
+		"prisma": "^5.14.0",
+		"@prisma/client": "^5.14.0"
 	},
 	"devDependencies": {
-		"@prisma/client": "^5.13.0",
+		"@prisma/client": "^5.14.0",
 		"@lokalise/eslint-config": "*",
 		"@lokalise/prettier-config": "*",
 		"@lokalise/package-vite-config": "*",
 		"@vitest/coverage-v8": "^1.5.3",
 		"cross-env": "^7.0.3",
 		"dotenv-cli": "^7.4.1",
-		"prisma": "^5.13.0",
+		"prisma": "^5.14.0",
 		"prettier": "^3.2.5",
 		"rimraf": "^5.0.1",
 		"typescript": "5.4.5",

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -162,8 +162,8 @@ describe('prismaTransaction', () => {
 			})
 			expect(diffs).toHaveLength(2)
 
-			expect(diffs[0] >= 10 && diffs[0] < 20).toBe(true)
-			expect(diffs[1] >= 10 && diffs[1] < 20).toBe(true)
+			expect(diffs[0] >= 10 && diffs[0] < 100).toBe(true)
+			expect(diffs[1] >= 10 && diffs[1] < 100).toBe(true)
 		})
 
 		it('not all prisma code are retried', async () => {

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -85,7 +85,7 @@ describe('prismaTransaction', () => {
 
 			const diffs = []
 			callsTimestamps.forEach((t, i) => {
-				if (i > 0) diffs.push(Math.round(t - callsTimestamps[i - 1] / 100) * 100)
+				if (i > 0) diffs.push(Math.round((t - callsTimestamps[i - 1]) / 100) * 100)
 			})
 			expect(diffs).toHaveLength(2)
 			expect(diffs[0]).toBe(100)

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -88,8 +88,8 @@ describe('prismaTransaction', () => {
 				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
 			})
 			expect(diffs).toHaveLength(2)
-			expect(diffs[0] >= 100 && diffs[0] < 105).toBe(true)
-			expect(diffs[1] >= 200 && diffs[1] < 205).toBe(true)
+			expect(diffs[0]).toBeGreaterThanOrEqual(100)
+			expect(diffs[1]).toBeGreaterThanOrEqual(200)
 		})
 
 		it('modifying max number of retries and base delay', async () => {
@@ -123,10 +123,11 @@ describe('prismaTransaction', () => {
 				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
 			})
 			expect(diffs).toHaveLength(4)
-			expect(diffs[0] >= 50 && diffs[0] < 55).toBe(true)
-			expect(diffs[1] >= 100 && diffs[1] < 105).toBe(true)
-			expect(diffs[2] >= 200 && diffs[2] < 205).toBe(true)
-			expect(diffs[3] >= 400 && diffs[3] < 405).toBe(true)
+
+			expect(diffs[0]).toBeGreaterThanOrEqual(50)
+			expect(diffs[1]).toBeGreaterThanOrEqual(100)
+			expect(diffs[2]).toBeGreaterThanOrEqual(200)
+			expect(diffs[3]).toBeGreaterThanOrEqual(400)
 		})
 
 		it('not all prisma code are retried', async () => {

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -162,7 +162,6 @@ describe('prismaTransaction', () => {
 			})
 			expect(diffs).toHaveLength(2)
 
-			expect(diffs).toEqual([10, 10]) // test
 			expect(diffs[0] >= 10 && diffs[0] < 100).toBe(true)
 			expect(diffs[1] >= 10 && diffs[1] < 100).toBe(true)
 		})

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -49,8 +49,6 @@ describe('prismaTransaction', () => {
 
 			// Then
 			expect(result.result).toMatchObject(TEST_ITEM_1)
-			// following assertions are to make sure types are correct
-			expect(result.result.value).toMatchObject(TEST_ITEM_1.value)
 		})
 
 		it('interactive transaction returns correct types', async () => {

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -162,6 +162,7 @@ describe('prismaTransaction', () => {
 			})
 			expect(diffs).toHaveLength(2)
 
+			expect(diffs).toEqual([10, 10]) // test
 			expect(diffs[0] >= 10 && diffs[0] < 100).toBe(true)
 			expect(diffs[1] >= 10 && diffs[1] < 100).toBe(true)
 		})

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -85,11 +85,11 @@ describe('prismaTransaction', () => {
 
 			const diffs = []
 			callsTimestamps.forEach((t, i) => {
-				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
+				if (i > 0) diffs.push(Math.round(t - callsTimestamps[i - 1] / 100) * 100)
 			})
 			expect(diffs).toHaveLength(2)
-			expect(diffs[0]).toBeGreaterThanOrEqual(100)
-			expect(diffs[1]).toBeGreaterThanOrEqual(200)
+			expect(diffs[0]).toBe(100)
+			expect(diffs[1]).toBe(200)
 		})
 
 		it('modifying max number of retries and base delay', async () => {
@@ -120,14 +120,14 @@ describe('prismaTransaction', () => {
 
 			const diffs = []
 			callsTimestamps.forEach((t, i) => {
-				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
+				if (i > 0) diffs.push(Math.round((t - callsTimestamps[i - 1]) / 10) * 10)
 			})
 			expect(diffs).toHaveLength(4)
 
-			expect(diffs[0]).toBeGreaterThanOrEqual(50)
-			expect(diffs[1]).toBeGreaterThanOrEqual(100)
-			expect(diffs[2]).toBeGreaterThanOrEqual(200)
-			expect(diffs[3]).toBeGreaterThanOrEqual(400)
+			expect(diffs[0]).toBe(50)
+			expect(diffs[1]).toBe(100)
+			expect(diffs[2]).toBe(200)
+			expect(diffs[3]).toBe(400)
 		})
 
 		it('max delay is respected', async () => {
@@ -158,12 +158,12 @@ describe('prismaTransaction', () => {
 
 			const diffs = []
 			callsTimestamps.forEach((t, i) => {
-				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
+				if (i > 0) diffs.push(Math.round((t - callsTimestamps[i - 1]) / 10) * 10)
 			})
 			expect(diffs).toHaveLength(2)
 
-			expect(diffs[0] >= 10 && diffs[0] < 100).toBe(true)
-			expect(diffs[1] >= 10 && diffs[1] < 100).toBe(true)
+			expect(diffs[0]).toBe(10)
+			expect(diffs[1]).toBe(10)
 		})
 
 		it('not all prisma code are retried', async () => {

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -53,15 +53,9 @@ describe('prismaTransaction', () => {
 
 		it('interactive transaction returns correct types', async () => {
 			// When
-			const result = await prismaTransaction(
-				prisma,
-				async (client) => {
-					return await client.item1.create({ data: TEST_ITEM_1 })
-				},
-				{
-					DbDriver: 'CockroachDb',
-				},
-			)
+			const result = await prismaTransaction(prisma, async (client) => {
+				return await client.item1.create({ data: TEST_ITEM_1 })
+			})
 
 			// Then
 			expect(result.result.value).toMatchObject(TEST_ITEM_1.value)

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -43,77 +43,98 @@ describe('prismaTransaction', () => {
 	describe('with function callback', () => {
 		it('first try works', async () => {
 			// When
-			const result: Either<unknown, Item1> = await prismaTransaction(
+			const result: Either<unknown, Item1> = await prismaTransaction(prisma, (client) =>
+				client.item1.create({ data: TEST_ITEM_1 }),
+			)
+
+			// Then
+			expect(result.result).toMatchObject(TEST_ITEM_1)
+			// following assertions are to make sure types are correct
+			expect(result.result.value).toMatchObject(TEST_ITEM_1.value)
+		})
+
+		it('interactive transaction returns correct types', async () => {
+			// When
+			const result = await prismaTransaction(
 				prisma,
-				(client) => client.item1.create({ data: TEST_ITEM_1 }),
+				async (client) => {
+					return await client.item1.create({ data: TEST_ITEM_1 })
+				},
 				{
 					DbDriver: 'CockroachDb',
 				},
 			)
 
 			// Then
-			expect(result.result).toMatchObject(TEST_ITEM_1)
+			expect(result.result.value).toMatchObject(TEST_ITEM_1.value)
+			expect(result.result.id).toBeDefined()
 		})
 
-		it('interactive transaction returns correct types', async () => {
-			expect.assertions(1)
-
-			// When
-			await prismaTransaction(
-				prisma,
-				async (client) => {
-					const item1 = await client.item1.create({ data: TEST_ITEM_1 })
-					expect(item1.value).toMatchObject(TEST_ITEM_1.value)
-				},
-				{
-					DbDriver: 'CockroachDb',
-				},
-			)
-		})
-
-		it('by default, 3 retries in case of PRISMA_SERIALIZATION_ERROR', async () => {
+		it('default reties (3) and delay (100)', async () => {
 			// Given
-			const retrySpy = vitest.spyOn(prisma, '$transaction').mockRejectedValue(
-				new PrismaClientKnownRequestError('test', {
+			const callsTimestamps: number[] = []
+			const retrySpy = vitest.spyOn(prisma, '$transaction').mockImplementation(() => {
+				callsTimestamps.push(Date.now())
+				throw new PrismaClientKnownRequestError('test', {
 					code: PRISMA_SERIALIZATION_ERROR,
 					clientVersion: '1',
-				}),
-			)
+				})
+			})
 
 			// When
-			const result = await prismaTransaction(
-				prisma,
-				(client) => client.item1.create({ data: TEST_ITEM_1 }),
-				{ DbDriver: 'CockroachDb' },
+			const result = await prismaTransaction(prisma, (client) =>
+				client.item1.create({ data: TEST_ITEM_1 }),
 			)
 
 			// Then
 			expect(result.error).toBeInstanceOf(PrismaClientKnownRequestError)
 			expect((result.error as PrismaClientKnownRequestError).code).toBe(PRISMA_SERIALIZATION_ERROR)
 			expect(retrySpy).toHaveBeenCalledTimes(3)
+
+			const diffs = []
+			callsTimestamps.forEach((t, i) => {
+				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
+			})
+			expect(diffs).toHaveLength(2)
+			expect(diffs[0] >= 100 && diffs[0] < 105).toBe(true)
+			expect(diffs[1] >= 200 && diffs[1] < 205).toBe(true)
 		})
 
-		it('Modifying max number of retries', async () => {
+		it('modifying max number of retries and base delay', async () => {
 			// Given
 			const retriesAllowed = 5
-			const retrySpy = vitest.spyOn(prisma, '$transaction').mockRejectedValue(
-				new PrismaClientKnownRequestError('test', {
+			const baseRetryDelayMs = 50
+
+			const callsTimestamps: number[] = []
+			const retrySpy = vitest.spyOn(prisma, '$transaction').mockImplementation(() => {
+				callsTimestamps.push(Date.now())
+				throw new PrismaClientKnownRequestError('test', {
 					code: PRISMA_SERIALIZATION_ERROR,
 					clientVersion: '1',
-				}),
-			)
+				})
+			})
 
 			// When
 			const result = await prismaTransaction(
 				prisma,
 				(client) => client.item1.create({ data: TEST_ITEM_1 }),
-				{ DbDriver: 'CockroachDb', retriesAllowed },
+				{ retriesAllowed, baseRetryDelayMs },
 			)
 
 			// Then
 			expect(result.error).toBeInstanceOf(PrismaClientKnownRequestError)
 			expect((result.error as PrismaClientKnownRequestError).code).toBe(PRISMA_SERIALIZATION_ERROR)
 			expect(retrySpy).toHaveBeenCalledTimes(5)
+
+			const diffs = []
+			callsTimestamps.forEach((t, i) => {
+				if (i > 0) diffs.push(t - callsTimestamps[i - 1])
+			})
+			expect(diffs).toHaveLength(4)
+			expect(diffs[0] >= 50 && diffs[0] < 55).toBe(true)
+			expect(diffs[1] >= 100 && diffs[1] < 105).toBe(true)
+			expect(diffs[2] >= 200 && diffs[2] < 205).toBe(true)
+			expect(diffs[3] >= 400 && diffs[3] < 405).toBe(true)
 		})
 
 		it('not all prisma code are retried', async () => {
@@ -126,10 +147,8 @@ describe('prismaTransaction', () => {
 			)
 
 			// When
-			const result = await prismaTransaction(
-				prisma,
-				(client) => client.item1.create({ data: TEST_ITEM_1 }),
-				{ DbDriver: 'CockroachDb' },
+			const result = await prismaTransaction(prisma, (client) =>
+				client.item1.create({ data: TEST_ITEM_1 }),
 			)
 
 			// Then
@@ -167,14 +186,28 @@ describe('prismaTransaction', () => {
 	describe('with array', () => {
 		it('works', async () => {
 			// When
-			const result: Either<unknown, [Item1, Item2]> = await prismaTransaction(
-				prisma,
-				[prisma.item1.create({ data: TEST_ITEM_1 }), prisma.item2.create({ data: TEST_ITEM_2 })],
-				{ DbDriver: 'CockroachDb' },
-			)
+			const result: Either<unknown, [Item1, Item2]> = await prismaTransaction(prisma, [
+				prisma.item1.create({ data: TEST_ITEM_1 }),
+				prisma.item2.create({ data: TEST_ITEM_2 }),
+			])
 
 			// Then
 			expect(result.result).toMatchObject([TEST_ITEM_1, TEST_ITEM_2])
+		})
+
+		it('returns proper types', async () => {
+			// When
+			const result = await prismaTransaction(prisma, [
+				prisma.item1.create({ data: TEST_ITEM_1 }),
+				prisma.item2.create({ data: TEST_ITEM_2 }),
+			])
+
+			// Then
+			expect(result.result).toMatchObject([TEST_ITEM_1, TEST_ITEM_2])
+			expect(result.result[0].value).toBe(TEST_ITEM_1.value)
+			expect(result.result[0].id).toBeDefined()
+			expect(result.result[1].value).toBe(TEST_ITEM_2.value)
+			expect(result.result[1].id).toBeDefined()
 		})
 	})
 })

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -43,8 +43,12 @@ describe('prismaTransaction', () => {
 	describe('with function callback', () => {
 		it('first try works', async () => {
 			// When
-			const result: Either<unknown, Item1> = await prismaTransaction(prisma, (client) =>
-				client.item1.create({ data: TEST_ITEM_1 }),
+			const result: Either<unknown, Item1> = await prismaTransaction(
+				prisma,
+				(client) => client.item1.create({ data: TEST_ITEM_1 }),
+				{
+					DbDriver: 'CockroachDb',
+				},
 			)
 
 			// Then
@@ -55,10 +59,16 @@ describe('prismaTransaction', () => {
 			expect.assertions(1)
 
 			// When
-			await prismaTransaction(prisma, async (client) => {
-				const item1 = await client.item1.create({ data: TEST_ITEM_1 })
-				expect(item1.value).toMatchObject(TEST_ITEM_1.value)
-			})
+			await prismaTransaction(
+				prisma,
+				async (client) => {
+					const item1 = await client.item1.create({ data: TEST_ITEM_1 })
+					expect(item1.value).toMatchObject(TEST_ITEM_1.value)
+				},
+				{
+					DbDriver: 'CockroachDb',
+				},
+			)
 		})
 
 		it('by default, 3 retries in case of PRISMA_SERIALIZATION_ERROR', async () => {
@@ -71,8 +81,10 @@ describe('prismaTransaction', () => {
 			)
 
 			// When
-			const result = await prismaTransaction(prisma, (client) =>
-				client.item1.create({ data: TEST_ITEM_1 }),
+			const result = await prismaTransaction(
+				prisma,
+				(client) => client.item1.create({ data: TEST_ITEM_1 }),
+				{ DbDriver: 'CockroachDb' },
 			)
 
 			// Then
@@ -95,7 +107,7 @@ describe('prismaTransaction', () => {
 			const result = await prismaTransaction(
 				prisma,
 				(client) => client.item1.create({ data: TEST_ITEM_1 }),
-				{ retriesAllowed },
+				{ DbDriver: 'CockroachDb', retriesAllowed },
 			)
 
 			// Then
@@ -114,8 +126,10 @@ describe('prismaTransaction', () => {
 			)
 
 			// When
-			const result = await prismaTransaction(prisma, (client) =>
-				client.item1.create({ data: TEST_ITEM_1 }),
+			const result = await prismaTransaction(
+				prisma,
+				(client) => client.item1.create({ data: TEST_ITEM_1 }),
+				{ DbDriver: 'CockroachDb' },
 			)
 
 			// Then
@@ -135,8 +149,10 @@ describe('prismaTransaction', () => {
 			)
 
 			// When
-			const result = await prismaTransaction(prisma, (client) =>
-				client.item1.create({ data: TEST_ITEM_1 }),
+			const result = await prismaTransaction(
+				prisma,
+				(client) => client.item1.create({ data: TEST_ITEM_1 }),
+				{ DbDriver: 'CockroachDb' },
 			)
 
 			// Then
@@ -151,10 +167,11 @@ describe('prismaTransaction', () => {
 	describe('with array', () => {
 		it('works', async () => {
 			// When
-			const result: Either<unknown, [Item1, Item2]> = await prismaTransaction(prisma, [
-				prisma.item1.create({ data: TEST_ITEM_1 }),
-				prisma.item2.create({ data: TEST_ITEM_2 }),
-			])
+			const result: Either<unknown, [Item1, Item2]> = await prismaTransaction(
+				prisma,
+				[prisma.item1.create({ data: TEST_ITEM_1 }), prisma.item2.create({ data: TEST_ITEM_2 })],
+				{ DbDriver: 'CockroachDb' },
+			)
 
 			// Then
 			expect(result.result).toMatchObject([TEST_ITEM_1, TEST_ITEM_2])

--- a/packages/app/prisma-utils/src/prismaTransaction.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.ts
@@ -18,8 +18,9 @@ type PrismaTransactionReturnType<T> = Either<
 
 const DEFAULT_OPTIONS = {
 	retriesAllowed: 3,
+	DbDriver: 'CockroachDb',
 	baseRetryDelayMs: 100,
-} satisfies Pick<PrismaTransactionOptions, 'retriesAllowed' | 'baseRetryDelayMs'>
+} satisfies Pick<PrismaTransactionOptions, 'retriesAllowed' | 'DbDriver' | 'baseRetryDelayMs'>
 
 /**
  * Perform a Prisma DB transaction with automatic retries if needed.
@@ -33,7 +34,7 @@ const DEFAULT_OPTIONS = {
 export const prismaTransaction = (async <T, P extends PrismaClient>(
 	prisma: P,
 	arg: PrismaTransactionFn<T, P> | Prisma.PrismaPromise<unknown>[],
-	options: PrismaTransactionOptions | PrismaTransactionBasicOptions,
+	options?: PrismaTransactionOptions | PrismaTransactionBasicOptions,
 ): Promise<PrismaTransactionReturnType<T>> => {
 	const optionsWithDefaults = { ...DEFAULT_OPTIONS, ...options }
 	let result: PrismaTransactionReturnType<T> | undefined = undefined
@@ -55,19 +56,19 @@ export const prismaTransaction = (async <T, P extends PrismaClient>(
 	<T, P extends PrismaClient>(
 		prisma: P,
 		fn: PrismaTransactionFn<T, P>,
-		options: PrismaTransactionOptions,
+		options?: PrismaTransactionOptions,
 	): Promise<Either<unknown, T>>
 	<T extends Prisma.PrismaPromise<unknown>[], P extends PrismaClient>(
 		prisma: P,
 		args: [...T],
-		options: PrismaTransactionBasicOptions,
+		options?: PrismaTransactionBasicOptions,
 	): Promise<Either<unknown, runtime.Types.Utils.UnwrapTuple<T>>>
 }
 
 const executeTransactionTry = async <T, P extends PrismaClient>(
 	prisma: P,
 	arg: PrismaTransactionFn<T, P> | Prisma.PrismaPromise<unknown>[],
-	options: PrismaTransactionOptions,
+	options?: PrismaTransactionOptions,
 ): Promise<PrismaTransactionReturnType<T>> => {
 	try {
 		return {

--- a/packages/app/prisma-utils/src/prismaTransaction.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.ts
@@ -41,7 +41,9 @@ export const prismaTransaction = (async <T, P extends PrismaClient>(
 
 	let retries = 0
 	while (retries < optionsWithDefaults.retriesAllowed) {
-		if (retries > 0) await sleep(calculateRetryDelay(retries, optionsWithDefaults.baseRetryDelayMs))
+		if (retries > 0) {
+			await setTimeout(calculateRetryDelay(retries, optionsWithDefaults.baseRetryDelayMs))
+		}
 
 		result = await executeTransactionTry(prisma, arg, options)
 		if (result.result || !isRetryAllowed(result, optionsWithDefaults.DbDriver)) {
@@ -79,8 +81,6 @@ const executeTransactionTry = async <T, P extends PrismaClient>(
 		return { error }
 	}
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const calculateRetryDelay = (retries: number, baseRetryDelayMs: number): number => {
 	// exponential backoff -> 2^(retry-1) * baseRetryDelayMs

--- a/packages/app/prisma-utils/src/prismaTransaction.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.ts
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises'
+
 import type { Either } from '@lokalise/node-core'
 import type { PrismaClient, Prisma } from '@prisma/client'
 import type * as runtime from '@prisma/client/runtime/library'

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -9,7 +9,7 @@ export type DbDriver = ObjectValues<typeof DbDriverEnum>
 
 export type PrismaTransactionOptions = {
 	// Prisma utils library custom options
-	DbDriver: DbDriver
+	DbDriver?: DbDriver
 	retriesAllowed?: number
 	baseRetryDelayMs?: number
 

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -12,6 +12,7 @@ export type PrismaTransactionOptions = {
 	DbDriver?: DbDriver
 	retriesAllowed?: number
 	baseRetryDelayMs?: number
+	maxRetryDelayMs?: number
 
 	// Prisma $transaction options
 	maxWait?: number

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -8,17 +8,19 @@ export const DbDriverEnum = {
 export type DbDriver = ObjectValues<typeof DbDriverEnum>
 
 export type PrismaTransactionOptions = {
-	retriesAllowed: number
+	// Prisma utils library custom options
+	DbDriver: DbDriver
+	retriesAllowed?: number
+	baseRetryDelayMs?: number
+
+	// Prisma $transaction options
 	maxWait?: number
 	timeout?: number
 	isolationLevel?: string
-	DbDriver?: DbDriver
 }
 
-export type PrismaTransactionBasicOptions = Pick<
-	PrismaTransactionOptions,
-	'retriesAllowed' | 'isolationLevel' | 'DbDriver'
->
+// Prisma $transaction with array of ops does not support maxWait and timeout options
+export type PrismaTransactionBasicOptions = Omit<PrismaTransactionOptions, 'maxWait' | 'timeout'>
 
 export type PrismaTransactionClient<P> = Omit<P, runtime.ITXClientDenyList>
 

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -19,7 +19,7 @@ export type PrismaTransactionOptions = {
 	isolationLevel?: string
 }
 
-// Prisma $transaction with array of ops does not support maxWait and timeout options
+// Prisma $transaction with array does not support maxWait and timeout options
 export type PrismaTransactionBasicOptions = Omit<PrismaTransactionOptions, 'maxWait' | 'timeout'>
 
 export type PrismaTransactionClient<P> = Omit<P, runtime.ITXClientDenyList>


### PR DESCRIPTION
## Changes

Prisma transaction incorporates a exponential backoff retry with 100ms as default base delay

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
