### PR TITLE
Bugsnag report error details

### DIFF
--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -31,7 +31,7 @@ describe('bugsnag', () => {
 			expect(notifySpy).toHaveBeenCalled()
 
 			const callback = notifySpy.mock.calls[0][1]
-			const event = {} as any
+			const event = { addMetadata: (_, __) => undefined } as any
 			await callback(event, () => {})
 			expect(event).toMatchObject({ severity: 'error', unhandled: true })
 		})
@@ -48,7 +48,7 @@ describe('bugsnag', () => {
 			expect(notifySpy).toHaveBeenCalled()
 
 			const callback = notifySpy.mock.calls[0][1]
-			const event = {} as any
+			const event = { addMetadata: (_, __) => undefined } as any
 			await callback(event, () => {})
 			expect(event).toMatchObject({ severity: 'info', unhandled: false })
 		})

--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -1,0 +1,126 @@
+import Bugsnag from '@bugsnag/js'
+import { InternalError, PublicNonRecoverableError } from '@lokalise/node-core'
+import { describe, expect, it, vi } from 'vitest'
+
+import { reportErrorToBugsnag } from './bugsnag'
+
+describe('bugsnag', () => {
+	describe('reportErrorToBugsnag', () => {
+		it('not started', () => {
+			// Given
+			const startSpy = vi.spyOn(Bugsnag, 'isStarted').mockReturnValue(false)
+			const notifySpy = vi.spyOn(Bugsnag, 'notify')
+
+			// When
+			reportErrorToBugsnag({ error: new Error('test') })
+
+			// Then
+			expect(startSpy).toHaveBeenCalled()
+			expect(notifySpy).not.toHaveBeenCalled()
+		})
+
+		it('using Error', async () => {
+			// Given
+			vi.spyOn(Bugsnag, 'isStarted').mockReturnValue(true)
+			const notifySpy = vi.spyOn(Bugsnag, 'notify').mockReturnValue(undefined)
+
+			// When
+			reportErrorToBugsnag({ error: new Error('test') })
+
+			// Then
+			expect(notifySpy).toHaveBeenCalled()
+
+			const callback = notifySpy.mock.calls[0][1]
+			const event = {} as any
+			await callback(event, () => {})
+			expect(event).toMatchObject({ severity: 'error', unhandled: true })
+		})
+
+		it('custom severity and unhandled', async () => {
+			// Given
+			vi.spyOn(Bugsnag, 'isStarted').mockReturnValue(true)
+			const notifySpy = vi.spyOn(Bugsnag, 'notify').mockReturnValue(undefined)
+
+			// When
+			reportErrorToBugsnag({ error: new Error('test'), severity: 'info', unhandled: false })
+
+			// Then
+			expect(notifySpy).toHaveBeenCalled()
+
+			const callback = notifySpy.mock.calls[0][1]
+			const event = {} as any
+			await callback(event, () => {})
+			expect(event).toMatchObject({ severity: 'info', unhandled: false })
+		})
+
+		it('internal error', async () => {
+			// Given
+			vi.spyOn(Bugsnag, 'isStarted').mockReturnValue(true)
+			const notifySpy = vi.spyOn(Bugsnag, 'notify').mockReturnValue(undefined)
+
+			// When
+			reportErrorToBugsnag({
+				error: new InternalError({
+					errorCode: 'TEST_ERROR_CODE',
+					message: 'test',
+					details: { hello: 'world' },
+				}),
+				context: { good: 'bye' },
+			})
+
+			// Then
+			expect(notifySpy).toHaveBeenCalled()
+
+			const callback = notifySpy.mock.calls[0][1]
+			let context = {}
+			const event = {
+				addMetadata: (key, obj) => {
+					if (key === 'Context') context = obj
+					else throw new Error('wrong key')
+				},
+			} as any
+			await callback(event, () => {})
+			expect(event).toMatchObject({ severity: 'error', unhandled: true })
+			expect(context).toMatchObject({
+				good: 'bye',
+				errorCode: 'TEST_ERROR_CODE',
+				errorDetails: { hello: 'world' },
+			})
+		})
+
+		it('public non recoverable error', async () => {
+			// Given
+			vi.spyOn(Bugsnag, 'isStarted').mockReturnValue(true)
+			const notifySpy = vi.spyOn(Bugsnag, 'notify').mockReturnValue(undefined)
+
+			// When
+			reportErrorToBugsnag({
+				error: new PublicNonRecoverableError({
+					errorCode: 'TEST_ERROR_CODE',
+					message: 'test',
+					details: { hello: 'world' },
+				}),
+				context: { good: 'bye' },
+			})
+
+			// Then
+			expect(notifySpy).toHaveBeenCalled()
+
+			const callback = notifySpy.mock.calls[0][1]
+			let context = {}
+			const event = {
+				addMetadata: (key, obj) => {
+					if (key === 'Context') context = obj
+					else throw new Error('wrong key')
+				},
+			} as any
+			await callback(event, () => {})
+			expect(event).toMatchObject({ severity: 'error', unhandled: true })
+			expect(context).toMatchObject({
+				good: 'bye',
+				errorCode: 'TEST_ERROR_CODE',
+				errorDetails: { hello: 'world' },
+			})
+		})
+	})
+})

--- a/packages/app/error-utils/src/index.spec.ts
+++ b/packages/app/error-utils/src/index.spec.ts
@@ -1,9 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-// TODO: Dummy test to satisfy test runner. Delete one introducing actual tests.
-
-describe('dummy', () => {
-	it('dummy test', () => {
-		expect(true).toBe(true)
-	})
-})


### PR DESCRIPTION
## Changes

Adding internal error and public error details to Bugsnag context by default so we can avoid doing it manually

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
