### PR TITLE
Fix error-utils exports

### DIFF
--- a/packages/app/background-jobs-common/vitest.config.mts
+++ b/packages/app/background-jobs-common/vitest.config.mts
@@ -19,6 +19,7 @@ export default defineConfig({
 			},
 		},
 		coverage: {
+			provider: 'v8',
 			all: false,
 			thresholds: {
 				lines: 98,

--- a/packages/app/error-utils/package.json
+++ b/packages/app/error-utils/package.json
@@ -1,29 +1,22 @@
 {
 	"name": "@lokalise/error-utils",
-	"version": "1.2.0",
-	"type": "module",
+	"version": "1.2.1",
 	"license": "Apache-2.0",
 	"files": [
-		"dist"
+		"dist/**",
+		"LICENSE.md",
+		"README.md"
 	],
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.js",
+	"type": "commonjs",
+	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"homepage": "https://github.com/lokalise/shared-ts-libs",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/lokalise/shared-ts-libs.git"
 	},
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"require": "./dist/index.cjs",
-			"import": "./dist/index.js"
-		}
-	},
 	"scripts": {
-		"build": "rimraf dist && vite build",
-		"dev": "vite watch",
+		"build": "rimraf dist && tsc",
 		"clean": "rimraf dist .eslintcache",
 		"lint": "eslint --cache --max-warnings=0  && prettier --check --log-level warn src \"**/*.{json,md}\" && tsc --noEmit",
 		"lint:fix": "eslint  --fix && prettier --write src \"**/*.{json,md}\"",
@@ -39,7 +32,7 @@
 		"@lokalise/node-core": "^9.6.1",
 		"@lokalise/prettier-config": "latest",
 		"@lokalise/package-vite-config": "latest",
-		"@vitest/coverage-v8": "^1.1.3",
+		"@vitest/coverage-v8": "^1.6.0",
 		"prettier": "^3.2.5",
 		"rimraf": "^5.0.1",
 		"typescript": "5.4.5",

--- a/packages/app/error-utils/tsconfig.lint.json
+++ b/packages/app/error-utils/tsconfig.lint.json
@@ -1,5 +1,5 @@
 {
 	"extends": ["./tsconfig.json"],
-	"include": ["src/**/*", "vite.config.ts"],
+	"include": ["src/**/*", "vitest.config.mts"],
 	"exclude": []
 }

--- a/packages/app/error-utils/vitest.config.mts
+++ b/packages/app/error-utils/vitest.config.mts
@@ -9,8 +9,24 @@ export default defineConfig({
 	entry: resolve(__dirname, 'src/index.ts'),
 	dependencies: Object.keys(packageJson.dependencies),
 	test: {
+		setupFiles: ['./test/setup.ts'],
+		hookTimeout: 60000,
+		restoreMocks: true,
+		poolOptions: {
+			threads: {
+				singleThread: true,
+				isolate: false,
+			},
+		},
 		coverage: {
-			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/**/*Types.ts', 'src/bugsnag.ts', 'src/index.ts'],
+			provider: 'v8',
+			all: false,
+			thresholds: {
+				lines: 98,
+				functions: 98,
+				branches: 90,
+				statements: 98,
+			},
 		},
 	},
 })


### PR DESCRIPTION
## Changes

vite-based build configuration wasn't working well for a node-only library, and a big bunch of dependencies from node_modules were included in the generated dist bundle

this probably can be fixed via vite configuration, but as a quick fix I've replaced the library config with what we use for other node-only libraries.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
