### PR TITLE
fix: update cursor as part of getPaginatedEntriesByHasMore

### DIFF
--- a/packages/app/api-common/src/paginationUtils.ts
+++ b/packages/app/api-common/src/paginationUtils.ts
@@ -191,11 +191,12 @@ export async function getPaginatedEntriesByHasMore<T extends Record<string, unkn
 ): Promise<T[]> {
 	const resultArray: T[] = []
 	let hasMore: boolean | undefined
-	const currentCursor: string | undefined = pagination.after
+	let currentCursor: string | undefined = pagination.after
 	do {
 		const pageResult = await apiCall({ ...pagination, after: currentCursor })
 		resultArray.push(...pageResult.data)
 		hasMore = pageResult.meta.hasMore
+		currentCursor = pageResult.meta.cursor
 	} while (hasMore)
 
 	return resultArray


### PR DESCRIPTION
## Changes

Update cursor position as part of `getPaginatedEntriesByHasMore` fx

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
