### PR TITLE
Add dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    labels:
+      - 'skip-release'
+    ignore:
+      - dependency-name: 'eslint'
+      - dependency-name: 'eslint-plugin-vitest'
+
     groups:
       lint:
         patterns:


### PR DESCRIPTION
## Changes

ESLint 9 requires migration, and next vitest semver minor requires ESLint 9

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
