### PR TITLE
Add requestLabel to request zod errors

### DIFF
--- a/packages/app/backend-http-client/.eslintrc.json
+++ b/packages/app/backend-http-client/.eslintrc.json
@@ -23,6 +23,7 @@
 		"@typescript-eslint/no-non-null-assertion": "warn",
 		"@typescript-eslint/no-var-requires": "off",
 		"@typescript-eslint/indent": "off",
+		"@typescript-eslint/no-unsafe-member-access": "off",
 		"@typescript-eslint/no-unsafe-assignment": "off",
 		"@typescript-eslint/no-explicit-any": "warn",
 		"@typescript-eslint/explicit-function-return-type": "off",
@@ -59,7 +60,6 @@
 				"@typescript-eslint/no-var-requires": "off",
 				"@typescript-eslint/indent": "off",
 				"@typescript-eslint/no-explicit-any": "warn",
-				"@typescript-eslint/no-unsafe-member-access": "off",
 				"@typescript-eslint/explicit-function-return-type": "off",
 				"@typescript-eslint/consistent-type-imports": "warn",
 				"@typescript-eslint/no-unused-vars": [

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -459,10 +459,21 @@ describe('httpClient', () => {
 					{
 						responseSchema: schema,
 						validateResponse: true,
-						requestLabel: 'dummy',
+						requestLabel: 'Test request',
 					},
 				),
-			).rejects.toThrow(/Expected string, received number/)
+			).rejects.toThrow(`[
+  {
+    "code": "invalid_type",
+    "expected": "string",
+    "received": "number",
+    "path": [
+      "id"
+    ],
+    "message": "Expected string, received number",
+    "requestLabel": "Test request"
+  }
+]`)
 		})
 
 		it('validates response structure with provided schema, passes validation', async () => {

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -362,7 +362,17 @@ function resolveResult<T>(
 		throw requestResult.error
 	}
 	if (requestResult.result && validateResponse) {
-		requestResult.result.body = validationSchema.parse(requestResult.result.body)
+		try {
+			requestResult.result.body = validationSchema.parse(requestResult.result.body)
+			// @ts-ignore
+		} catch (err: ZodError) {
+			// @ts-ignore
+			for (const issue of err.issues) {
+				issue.requestLabel = requestLabel
+			}
+			err.requestLabel = requestLabel
+			throw err
+		}
 	}
 
 	return requestResult as DefiniteEither<RequestResult<unknown>, RequestResult<T>>


### PR DESCRIPTION
## Changes

Make it easier to identify which requests failed with validation errors by adding requestLabel

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
