### PR TITLE
Add support for scheduled job spies

### DIFF
--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -34,18 +34,18 @@
 		"package-version": "echo $npm_package_version"
 	},
 	"dependencies": {
-		"@lokalise/id-utils": "1.0.0",
-		"@lokalise/node-core": "^10.0.0",
-		"pino": "^9.1.0",
+		"@lokalise/id-utils": "^2.1.0",
+		"@lokalise/node-core": "^10.0.1",
+		"pino": "^9.2.0",
 		"ts-deepmerge": "^7.0.0"
 	},
 	"peerDependencies": {
 		"bullmq": "^5.7.15"
 	},
 	"devDependencies": {
-		"@types/node": "^20.14.2",
+		"@types/node": "^20.14.8",
 		"@lokalise/eslint-config": "latest",
-		"@lokalise/fastify-extras": "^21.0.0",
+		"@lokalise/fastify-extras": "^21.2.2",
 		"@lokalise/prettier-config": "latest",
 		"@lokalise/package-vite-config": "latest",
 		"@vitest/coverage-v8": "^1.6.0",
@@ -53,7 +53,7 @@
 		"ioredis": "^5.4.1",
 		"prettier": "3.3.2",
 		"rimraf": "^5.0.7",
-		"typescript": "5.4.5",
+		"typescript": "5.5.2",
 		"vitest": "^1.6.0"
 	},
 	"prettier": "@lokalise/prettier-config"

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spy.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spy.spec.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { DependencyMocks } from '../../../test/dependencyMocks'
+import { TestFailingBackgroundJobProcessor } from '../../../test/processors/TestFailingBackgroundJobProcessor'
+import { TestReturnValueBackgroundJobProcessor } from '../../../test/processors/TestReturnValueBackgroundJobProcessor'
+import { BaseJobPayload } from '../types'
+
+import { FakeBackgroundJobProcessor } from './FakeBackgroundJobProcessor'
+import { BackgroundJobProcessorDependencies } from './types'
+
+type JobData = {
+	id: string
+	value: string
+} & BaseJobPayload
+
+describe('AbstractBackgroundJobProcessor Spy', () => {
+	let mocks: DependencyMocks
+	let deps: BackgroundJobProcessorDependencies<JobData, any>
+
+	beforeEach(() => {
+		mocks = new DependencyMocks()
+		deps = mocks.create()
+	})
+
+	afterEach(async () => {
+		await mocks.dispose()
+	})
+
+	describe('spy', () => {
+		it('throws error when spy accessed in non-test mode', async () => {
+			const processor = new TestFailingBackgroundJobProcessor<JobData>(
+				deps,
+				'AbstractBackgroundJobProcessor_spy',
+				false,
+			)
+
+			expect(() => processor.spy).throws(
+				'spy was not instantiated, it is only available on test mode. Please use `config.isTest` to enable it.',
+			)
+
+			await processor.dispose()
+		})
+
+		it('spy contain returnValue', async () => {
+			type JobReturn = { result: string }
+
+			const returnValue: JobReturn = { result: 'done' }
+			const processor = new TestReturnValueBackgroundJobProcessor<JobData, JobReturn>(
+				deps,
+				returnValue,
+			)
+			await processor.start()
+
+			const jobId = await processor.schedule({
+				id: 'test_id',
+				value: 'test',
+				metadata: { correlationId: 'correlation_id' },
+			})
+			const jobSpy = await processor.spy.waitForFinishedJobWithId(jobId, 'completed')
+
+			expect(jobSpy.returnvalue).toMatchObject(returnValue)
+
+			await processor.dispose()
+		})
+
+		it('can await job to be scheduled', async () => {
+			const jobProcessor = new FakeBackgroundJobProcessor<JobData>(deps, 'queue1')
+			await jobProcessor.schedule({
+				id: '123',
+				value: 'val1',
+				metadata: {
+					correlationId: '111',
+				},
+			})
+
+			const awaitResult = await jobProcessor.spy.waitForScheduledJob((job) => job.value === 'val1')
+			expect(awaitResult.data).toMatchInlineSnapshot(`
+				{
+				  "id": "123",
+				  "metadata": {
+				    "correlationId": "111",
+				  },
+				  "value": "val1",
+				}
+			`)
+		})
+	})
+})

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -251,6 +251,12 @@ export abstract class AbstractBackgroundJobProcessor<
 			throw new Error('Some scheduled job IDs are undefined')
 		}
 
+		if (this._spy && jobs) {
+			for (const job of jobs) {
+				this._spy.addJobScheduled(job)
+			}
+		}
+
 		return jobIds as string[]
 	}
 

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/FakeBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/FakeBackgroundJobProcessor.spec.ts
@@ -34,7 +34,7 @@ describe('FakeBackgroundJobProcessor', () => {
 		const data = { value: 'test', metadata: { correlationId: generateMonotonicUuid() } }
 		await processor.schedule(data)
 
-		await processor.spy?.waitForJob((data) => data.value === 'test', 'completed')
+		await processor.spy?.waitForFinishedJob((data) => data.value === 'test', 'completed')
 		expect(processor.processCalls).toHaveLength(1)
 		expect(processor.processCalls[0]).toEqual(data)
 

--- a/packages/app/background-jobs-common/src/background-job-processor/spy/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/spy/types.ts
@@ -8,15 +8,19 @@ export type JobSpyResult<JobData extends object, jobReturn> = Pick<
 	'data' | 'attemptsMade' | 'id' | 'progress' | 'returnvalue' | 'failedReason' | 'finishedOn'
 >
 
-export interface BackgroundJobProcessorSpyInterface<JobData extends object, jobReturn> {
+export interface BackgroundJobProcessorSpyInterface<JobData extends object, JobReturn> {
 	clear(): void
-	waitForJob(
+	waitForFinishedJob(
 		jobSelector: JobDataSelector<JobData>,
 		state: JobFinalState,
-	): Promise<JobSpyResult<JobData, jobReturn>>
+	): Promise<JobSpyResult<JobData, JobReturn>>
 
-	waitForJobWithId(
+	waitForFinishedJobWithId(
 		id: string | undefined,
 		awaitedState: JobFinalState,
-	): Promise<JobSpyResult<JobData, jobReturn>>
+	): Promise<JobSpyResult<JobData, JobReturn>>
+
+	waitForScheduledJob(
+		jobSelector: JobDataSelector<JobData>,
+	): Promise<JobSpyResult<JobData, JobReturn>>
 }


### PR DESCRIPTION
## Changes

Previously it was only possible to wait for jobs to finish. Now we can also wait for jobs to be scheduled

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
