### PR TITLE
Filling errorDetails for unknown errors

### DIFF
--- a/packages/app/error-utils/src/bugsnag.ts
+++ b/packages/app/error-utils/src/bugsnag.ts
@@ -1,8 +1,12 @@
 import type { Event, NotifiableError } from '@bugsnag/js'
 import Bugsnag from '@bugsnag/js'
 import type { NodeConfig } from '@bugsnag/node'
-import type { ErrorReporter } from '@lokalise/node-core'
-import { isInternalError, isPublicNonRecoverableError } from '@lokalise/node-core'
+import type { ErrorReporter, FreeformRecord } from '@lokalise/node-core'
+import { isError, isInternalError, isPublicNonRecoverableError } from '@lokalise/node-core'
+
+const hasDetails = (
+	error: NotifiableError,
+): error is NotifiableError & { details: FreeformRecord } => isError(error) && 'details' in error
 
 export type Severity = Event['severity']
 
@@ -27,6 +31,15 @@ export const reportErrorToBugsnag = ({
 				...computedContext,
 				errorDetails: error.details,
 				errorCode: error.errorCode,
+			}
+		} else if (hasDetails(error)) {
+			/**
+			 * This is a special case for other errors that have details but are not `PublicNonRecoverableError`
+			 * or `InternalError`
+			 */
+			computedContext = {
+				...computedContext,
+				errorDetails: error.details,
 			}
 		}
 


### PR DESCRIPTION
## Changes

With this PR we expect to cover all types of error containing `details` field

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
