### PR TITLE
Use correct plugin version

### DIFF
--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -23,7 +23,7 @@
 		"package-version": "echo $npm_package_version"
 	},
 	"dependencies": {
-		"@lokalise/eslint-config-frontend": "^4.6.0",
+		"@lokalise/eslint-config-frontend": "^4.6.1",
 		"@tanstack/eslint-plugin-query": "^5.35.6",
 		"@typescript-eslint/parser": "^7.12.0"
 	},


### PR DESCRIPTION
## Changes

This fixes compatibility with ESLint 8 by using correct vitest plugin version

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
