### PR TITLE
Transaction auto increase timeout

### DIFF
--- a/packages/app/prisma-utils/src/prismaError.ts
+++ b/packages/app/prisma-utils/src/prismaError.ts
@@ -17,6 +17,9 @@ export const isPrismaClientKnownRequestError = (
 	typeof error.code === 'string' &&
 	error.code.startsWith('P')
 
+export const isPrismaTransactionClosedError = (error: PrismaClientKnownRequestError): boolean =>
+	error.code === PRISMA_TRANSACTION_ERROR && error.message.includes('Transaction already closed')
+
 /*
  * Prisma error code P2025 indicates that the operation failed because it depends on one or more
  * records that were required but not found
@@ -35,3 +38,9 @@ export const PRISMA_SERIALIZATION_ERROR = 'P2034'
  * violated. This can happen if you try to create a record with a unique field that already exists
  */
 export const PRISMA_UNIQUE_CONSTRAINT_ERROR = 'P2002'
+
+/*
+ * Prisma error code P2028 indicates a transaction API error, essentially a placeholder for errors that do not fit into
+ * a more specific category. You should look into the error message for more details
+ */
+export const PRISMA_TRANSACTION_ERROR = 'P2028'

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -1,12 +1,15 @@
 import { Either } from '@lokalise/node-core'
 import { PrismaClient } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
-import { c } from 'vite/dist/node/types.d-aGj9QkWt'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vitest } from 'vitest'
 
 import { cleanTables, DB_MODEL } from '../test/DbCleaner'
 
-import { PRISMA_NOT_FOUND_ERROR, PRISMA_SERIALIZATION_ERROR } from './prismaError'
+import {
+	PRISMA_NOT_FOUND_ERROR,
+	PRISMA_SERIALIZATION_ERROR,
+	PRISMA_TRANSACTION_ERROR,
+} from './prismaError'
 import { prismaTransaction } from './prismaTransaction'
 
 type Item1 = {
@@ -185,6 +188,46 @@ describe('prismaTransaction', () => {
 			expect(result.error).toBeInstanceOf(PrismaClientKnownRequestError)
 			expect((result.error as PrismaClientKnownRequestError).code).toBe(PRISMA_NOT_FOUND_ERROR)
 			expect(retrySpy).toHaveBeenCalledTimes(1)
+		})
+
+		it('timeout auto increase', async () => {
+			// Given
+			const spy = vitest.spyOn(prisma, '$transaction').mockRejectedValue(
+				new PrismaClientKnownRequestError(
+					'Transaction already closed: Could not perform operation.',
+					{
+						code: PRISMA_TRANSACTION_ERROR,
+						clientVersion: '1',
+					},
+				),
+			)
+
+			// When
+			const resultWithDefaults = await prismaTransaction(prisma, (client) =>
+				client.item1.create({ data: TEST_ITEM_1 }),
+			)
+			const resultWithCustomTimeout = await prismaTransaction(
+				prisma,
+				(client) => client.item1.create({ data: TEST_ITEM_1 }),
+				{ timeout: 1000, maxTimeout: 2000 },
+			)
+
+			// Then
+			expect(resultWithDefaults.error).toBeInstanceOf(PrismaClientKnownRequestError)
+			expect(resultWithCustomTimeout.error).toBeInstanceOf(PrismaClientKnownRequestError)
+			expect(spy).toHaveBeenCalledTimes(6) // 3 per transaction call
+
+			const callsOptions = spy.mock.calls.map(([_, options]) => options)
+			expect(callsOptions).toMatchObject([
+				// resultWithDefaults call
+				{ timeout: 5000 },
+				{ timeout: 10000 },
+				{ timeout: 20000 },
+				// resultWithCustomTimeout call
+				{ timeout: 1000 },
+				{ timeout: 2000 },
+				{ timeout: 2000 },
+			])
 		})
 
 		it('CockroachDB retry transaction error is retried', async () => {

--- a/packages/app/prisma-utils/src/prismaTransaction.spec.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.spec.ts
@@ -1,6 +1,7 @@
 import { Either } from '@lokalise/node-core'
 import { PrismaClient } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
+import { c } from 'vite/dist/node/types.d-aGj9QkWt'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vitest } from 'vitest'
 
 import { cleanTables, DB_MODEL } from '../test/DbCleaner'

--- a/packages/app/prisma-utils/src/prismaTransaction.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.ts
@@ -41,7 +41,7 @@ export const prismaTransaction = (async <T, P extends PrismaClient>(
 	arg: PrismaTransactionFn<T, P> | Prisma.PrismaPromise<unknown>[],
 	options?: PrismaTransactionOptions | PrismaTransactionBasicOptions,
 ): Promise<PrismaTransactionReturnType<T>> => {
-	const optionsWithDefaults = { ...DEFAULT_OPTIONS, ...options }
+	let optionsWithDefaults = { ...DEFAULT_OPTIONS, ...options }
 	let result: PrismaTransactionReturnType<T> | undefined = undefined
 
 	let retries = 0
@@ -62,8 +62,12 @@ export const prismaTransaction = (async <T, P extends PrismaClient>(
 		const retryAllowed = isRetryAllowed(result, optionsWithDefaults.DbDriver)
 		if (!retryAllowed) break
 
-		if (retryAllowed === 'increase-timeout')
-			Math.min((optionsWithDefaults.timeout *= 2), optionsWithDefaults.maxTimeout)
+		if (retryAllowed === 'increase-timeout') {
+			optionsWithDefaults = {
+				...optionsWithDefaults,
+				timeout: Math.min((optionsWithDefaults.timeout *= 2), optionsWithDefaults.maxTimeout),
+			}
+		}
 
 		retries++
 	}

--- a/packages/app/prisma-utils/src/prismaTransaction.ts
+++ b/packages/app/prisma-utils/src/prismaTransaction.ts
@@ -1,6 +1,7 @@
 import { setTimeout } from 'node:timers/promises'
 
 import type { Either } from '@lokalise/node-core'
+import { deepClone } from '@lokalise/node-core'
 import type { PrismaClient, Prisma } from '@prisma/client'
 import type * as runtime from '@prisma/client/runtime/library'
 
@@ -63,10 +64,11 @@ export const prismaTransaction = (async <T, P extends PrismaClient>(
 		if (!retryAllowed) break
 
 		if (retryAllowed === 'increase-timeout') {
-			optionsWithDefaults = {
-				...optionsWithDefaults,
-				timeout: Math.min((optionsWithDefaults.timeout *= 2), optionsWithDefaults.maxTimeout),
-			}
+			optionsWithDefaults = deepClone(optionsWithDefaults)
+			optionsWithDefaults.timeout = Math.min(
+				(optionsWithDefaults.timeout *= 2),
+				optionsWithDefaults.maxTimeout,
+			)
 		}
 
 		retries++

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -22,7 +22,10 @@ export type PrismaTransactionOptions = {
 }
 
 // Prisma $transaction with array does not support maxWait and timeout options
-export type PrismaTransactionBasicOptions = Omit<PrismaTransactionOptions, 'maxWait' | 'timeout'>
+export type PrismaTransactionBasicOptions = Omit<
+	PrismaTransactionOptions,
+	'maxWait' | 'timeout' | 'maxTimeout'
+>
 
 export type PrismaTransactionClient<P> = Omit<P, runtime.ITXClientDenyList>
 

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -1,3 +1,5 @@
+import type { Either } from '@lokalise/node-core'
+import type { Prisma } from '@prisma/client'
 import type * as runtime from '@prisma/client/runtime/library'
 
 type ObjectValues<T> = T[keyof T]
@@ -30,3 +32,8 @@ export type PrismaTransactionBasicOptions = Omit<
 export type PrismaTransactionClient<P> = Omit<P, runtime.ITXClientDenyList>
 
 export type PrismaTransactionFn<T, P> = (prisma: PrismaTransactionClient<P>) => Promise<T>
+
+export type PrismaTransactionReturnType<T> = Either<
+	unknown,
+	T | runtime.Types.Utils.UnwrapTuple<Prisma.PrismaPromise<unknown>[]>
+>

--- a/packages/app/prisma-utils/src/types.ts
+++ b/packages/app/prisma-utils/src/types.ts
@@ -13,6 +13,7 @@ export type PrismaTransactionOptions = {
 	retriesAllowed?: number
 	baseRetryDelayMs?: number
 	maxRetryDelayMs?: number
+	maxTimeout?: number
 
 	// Prisma $transaction options
 	maxWait?: number


### PR DESCRIPTION
## Changes

Feature to auto-increase timeout in case it is the error on the transaction

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
