### PR TITLE
Accept any string as a correlationId

### DIFF
--- a/packages/app/events-common/src/baseEventSchemas.ts
+++ b/packages/app/events-common/src/baseEventSchemas.ts
@@ -5,7 +5,7 @@ export const BASE_EVENT_SCHEMA = z.object({
 	id: z.string().uuid().describe('event unique identifier'),
 	type: z.literal<string>('<replace.me>').describe('event type name'),
 	timestamp: z.string().datetime().describe('iso 8601 datetime'),
-	source: z.string().nonempty().describe('source service of the event'),
+	source: z.string().min(1).describe('source service of the event'),
 	payload: z.optional(z.object({})).describe('event payload based on type'),
 	metadata: z
 		.object({
@@ -13,11 +13,8 @@ export const BASE_EVENT_SCHEMA = z.object({
 			originalApp: z.string().nonempty().describe('app/service initiated workflow'),
 		})
 		.describe('event metadata'),
-	correlationId: z
-		.string()
-		.uuid()
-		.describe('unique identifier passed to all events in workflow chain'),
-	version: z.string().nonempty().describe('event payload version'),
+	correlationId: z.string().describe('unique identifier passed to all events in workflow chain'),
+	version: z.string().min(1).describe('event payload version'),
 })
 
 export type BaseEventType = z.infer<typeof BASE_EVENT_SCHEMA>

--- a/packages/app/events-common/src/baseEventSchemas.ts
+++ b/packages/app/events-common/src/baseEventSchemas.ts
@@ -9,8 +9,8 @@ export const BASE_EVENT_SCHEMA = z.object({
 	payload: z.optional(z.object({})).describe('event payload based on type'),
 	metadata: z
 		.object({
-			schemaVersion: z.string().nonempty().describe('base event schema version'),
-			originalApp: z.string().nonempty().describe('app/service initiated workflow'),
+			schemaVersion: z.string().min(1).describe('base event schema version'),
+			originalApp: z.string().min(1).describe('app/service initiated workflow'),
 		})
 		.describe('event metadata'),
 	correlationId: z.string().describe('unique identifier passed to all events in workflow chain'),


### PR DESCRIPTION
## Changes

We do not always control the correlationId of a request that initiates the chain, so we should be flexible in what we accept there.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
