### PR TITLE
Allow non-null assertions in tests

### DIFF
--- a/packages/dev/biome-config/configs/biome-base.jsonc
+++ b/packages/dev/biome-config/configs/biome-base.jsonc
@@ -68,6 +68,9 @@
       "include": ["./**/*.spec.ts"],
       "linter": {
         "rules": {
+          "style": {
+            "noNonNullAssertion": "off"
+          },
           "suspicious": {
             "noExplicitAny": "off"
           }


### PR DESCRIPTION
## Changes

It is pretty normal to use non-null assertions in tests.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
