### PR TITLE
http client 204 support

### DIFF
--- a/packages/app/backend-http-client/README.md
+++ b/packages/app/backend-http-client/README.md
@@ -43,6 +43,7 @@ All _send_ methods accept a type parameter and the following arguments:
   - `clientOptions`;
   - `responseSchema`, used both for inferring the response type of the call, and also (if `validateResponse` is `true`) for validating the response structure;
   - `validateResponse`;
+  - `isEmptyResponseExpected`, used to specify if a 204 response should be treated as an error or not
 
   The following options are applied by default:
 
@@ -57,6 +58,7 @@ All _send_ methods accept a type parameter and the following arguments:
       retryOnTimeout: false,
   }
   ```
+  For `sendDelete()` `isEmptyResponseExpected` by default is set to `true`, for all other methods it is `false`.
 
 Additionally, `sendPost()`, `sendPut()`, `sendPutBinary()`, and `sendPatch()` also accept a `body` parameter.
 

--- a/packages/app/backend-http-client/README.md
+++ b/packages/app/backend-http-client/README.md
@@ -43,7 +43,7 @@ All _send_ methods accept a type parameter and the following arguments:
   - `clientOptions`;
   - `responseSchema`, used both for inferring the response type of the call, and also (if `validateResponse` is `true`) for validating the response structure;
   - `validateResponse`;
-  - `isEmptyResponseExpected`, used to specify if a 204 response should be treated as an error or not
+  - `isEmptyResponseExpected`, used to specify if a 204 response should be treated as an error or not. when `true` the response body type is adjusted to include potential `null`
 
   The following options are applied by default:
 

--- a/packages/app/backend-http-client/index.ts
+++ b/packages/app/backend-http-client/index.ts
@@ -2,9 +2,9 @@ export type {
   RequestOptions,
   HttpRequestContext,
   RequestResultDefinitiveEither,
-} from "./src/client/types";
+} from './src/client/types'
 
-export { JSON_HEADERS } from "./src/client/constants";
+export { JSON_HEADERS } from './src/client/constants'
 
 export {
   sendPut,
@@ -16,9 +16,9 @@ export {
   sendPostBinary,
   httpClient,
   buildClient,
-} from "./src/client/httpClient";
+} from './src/client/httpClient'
 
 export {
   isResponseStatusError,
   ResponseStatusError,
-} from "./src/errors/ResponseStatusError";
+} from './src/errors/ResponseStatusError'

--- a/packages/app/backend-http-client/index.ts
+++ b/packages/app/backend-http-client/index.ts
@@ -1,15 +1,11 @@
-export {
-  type RequestOptions,
-  type HttpRequestContext,
-  type ResponseSchema,
-  type Response,
+export type {
+  RequestOptions,
+  HttpRequestContext,
+  ResponseSchema,
+  RequestResultDefinitiveEither,
 } from "./src/client/types";
 
-export {
-  TEST_OPTIONS,
-  NO_CONTENT_RESPONSE_SCHEMA,
-  UNKNOWN_RESPONSE_SCHEMA,
-} from "./src/client/constants";
+export { JSON_HEADERS } from "./src/client/constants";
 
 export {
   sendPut,
@@ -21,7 +17,6 @@ export {
   sendPostBinary,
   httpClient,
   buildClient,
-  JSON_HEADERS,
 } from "./src/client/httpClient";
 
 export {

--- a/packages/app/backend-http-client/index.ts
+++ b/packages/app/backend-http-client/index.ts
@@ -4,7 +4,11 @@ export type {
   RequestResultDefinitiveEither,
 } from './src/client/types'
 
-export { JSON_HEADERS } from './src/client/constants'
+export {
+  JSON_HEADERS,
+  TEST_OPTIONS,
+  NO_CONTENT_RESPONSE_SCHEMA,
+} from './src/client/constants'
 
 export {
   sendPut,

--- a/packages/app/backend-http-client/index.ts
+++ b/packages/app/backend-http-client/index.ts
@@ -1,7 +1,6 @@
 export type {
   RequestOptions,
   HttpRequestContext,
-  ResponseSchema,
   RequestResultDefinitiveEither,
 } from "./src/client/types";
 

--- a/packages/app/backend-http-client/index.ts
+++ b/packages/app/backend-http-client/index.ts
@@ -1,4 +1,17 @@
 export {
+  type RequestOptions,
+  type HttpRequestContext,
+  type ResponseSchema,
+  type Response,
+} from "./src/client/types";
+
+export {
+  TEST_OPTIONS,
+  NO_CONTENT_RESPONSE_SCHEMA,
+  UNKNOWN_RESPONSE_SCHEMA,
+} from "./src/client/constants";
+
+export {
   sendPut,
   sendPutBinary,
   sendDelete,
@@ -8,14 +21,10 @@ export {
   sendPostBinary,
   httpClient,
   buildClient,
-  type RequestOptions,
-  type Response,
-  type HttpRequestContext,
-  type ResponseSchema,
-  TEST_OPTIONS,
   JSON_HEADERS,
-  NO_CONTENT_RESPONSE_SCHEMA,
-  UNKNOWN_RESPONSE_SCHEMA,
-} from './src/client/httpClient'
+} from "./src/client/httpClient";
 
-export { isResponseStatusError, ResponseStatusError } from './src/errors/ResponseStatusError'
+export {
+  isResponseStatusError,
+  ResponseStatusError,
+} from "./src/errors/ResponseStatusError";

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -4,22 +4,6 @@ import { z } from "zod";
 
 import type { RequestOptions } from "./types";
 
-/**
- * Technically 204 will send an empty body, but undici-retry defaults to parsing unknown mimetype as text for compatibility reasons, so we should expect to get an empty string here
- */
-export const NO_CONTENT_RESPONSE_SCHEMA = z.string().length(0); // TODO: not export this constant, use it only in tests
-
-/**
- * This schema is to be used when we don't really care about the response type and are prepared to accept any value
- */
-export const UNKNOWN_RESPONSE_SCHEMA = z.unknown(); // TODO: not export this constant, use it only in tests
-
-// TODO: not export this constant, use it only in tests
-export const TEST_OPTIONS: RequestOptions<unknown, any> = {
-  requestLabel: "test",
-  responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-};
-
 export const DEFAULT_OPTIONS = {
   validateResponse: true,
   throwOnError: true,

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -1,8 +1,7 @@
-import type { MayOmit } from "@lokalise/node-core";
-import type { Client } from "undici";
-import { z } from "zod";
+import type { MayOmit } from '@lokalise/node-core'
+import type { Client } from 'undici'
 
-import type { RequestOptions } from "./types";
+import type { RequestOptions } from './types'
 
 export const DEFAULT_OPTIONS = {
   validateResponse: true,
@@ -10,14 +9,14 @@ export const DEFAULT_OPTIONS = {
   timeout: 30000,
 } satisfies MayOmit<
   RequestOptions<unknown, any>,
-  "requestLabel" | "responseSchema" | "isEmptyResponseExpected"
->;
+  'requestLabel' | 'responseSchema' | 'isEmptyResponseExpected'
+>
 
 export const defaultClientOptions: Partial<Client.Options> = {
   keepAliveMaxTimeout: 300_000,
   keepAliveTimeout: 4000,
-};
+}
 
 export const JSON_HEADERS = {
-  "Content-Type": "application/json",
-};
+  'Content-Type': 'application/json',
+}

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_OPTIONS = {
   throwOnError: true,
   timeout: 30000,
 } satisfies MayOmit<
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   RequestOptions<unknown, any>,
   'requestLabel' | 'responseSchema' | 'isEmptyResponseExpected'
 >

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -15,7 +15,7 @@ export const NO_CONTENT_RESPONSE_SCHEMA = z.string().length(0); // TODO: not exp
 export const UNKNOWN_RESPONSE_SCHEMA = z.unknown(); // TODO: not export this constant, use it only in tests
 
 // TODO: not export this constant, use it only in tests
-export const TEST_OPTIONS: RequestOptions<unknown> = {
+export const TEST_OPTIONS: RequestOptions<unknown, any> = {
   requestLabel: "test",
   responseSchema: UNKNOWN_RESPONSE_SCHEMA,
 };
@@ -25,11 +25,15 @@ export const DEFAULT_OPTIONS = {
   throwOnError: true,
   timeout: 30000,
 } satisfies MayOmit<
-  RequestOptions<unknown>,
+  RequestOptions<unknown, any>,
   "requestLabel" | "responseSchema" | "isEmptyResponseExpected"
 >;
 
 export const defaultClientOptions: Partial<Client.Options> = {
   keepAliveMaxTimeout: 300_000,
   keepAliveTimeout: 4000,
+};
+
+export const JSON_HEADERS = {
+  "Content-Type": "application/json",
 };

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -1,0 +1,35 @@
+import type { MayOmit } from "@lokalise/node-core";
+import type { Client } from "undici";
+import { z } from "zod";
+
+import type { RequestOptions } from "./types";
+
+/**
+ * Technically 204 will send an empty body, but undici-retry defaults to parsing unknown mimetype as text for compatibility reasons, so we should expect to get an empty string here
+ */
+export const NO_CONTENT_RESPONSE_SCHEMA = z.string().length(0); // TODO: not export this constant, use it only in tests
+
+/**
+ * This schema is to be used when we don't really care about the response type and are prepared to accept any value
+ */
+export const UNKNOWN_RESPONSE_SCHEMA = z.unknown(); // TODO: not export this constant, use it only in tests
+
+// TODO: not export this constant, use it only in tests
+export const TEST_OPTIONS: RequestOptions<unknown> = {
+  requestLabel: "test",
+  responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+};
+
+export const DEFAULT_OPTIONS = {
+  validateResponse: true,
+  throwOnError: true,
+  timeout: 30000,
+} satisfies MayOmit<
+  RequestOptions<unknown>,
+  "requestLabel" | "responseSchema" | "isEmptyResponseExpected"
+>;
+
+export const defaultClientOptions: Partial<Client.Options> = {
+  keepAliveMaxTimeout: 300_000,
+  keepAliveTimeout: 4000,
+};

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -1,6 +1,7 @@
 import type { MayOmit } from '@lokalise/node-core'
 import type { Client } from 'undici'
 
+import { z } from 'zod'
 import type { RequestOptions } from './types'
 
 export const DEFAULT_OPTIONS = {
@@ -21,3 +22,11 @@ export const defaultClientOptions: Partial<Client.Options> = {
 export const JSON_HEADERS = {
   'Content-Type': 'application/json',
 }
+
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export const TEST_OPTIONS: RequestOptions<unknown, any> = {
+  requestLabel: 'test',
+  responseSchema: z.unknown(),
+}
+
+export const NO_CONTENT_RESPONSE_SCHEMA = z.string().length(0)

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -101,7 +101,12 @@ describe('httpClient', () => {
 
       expect(result.result.body).toEqual(mockProduct1)
     })
+
     it('validates response structure with provided schema, skips validation', async () => {
+      const schema = z.object({
+        id: z.string(),
+      })
+
       client
         .intercept({
           path: '/products/1',
@@ -110,9 +115,9 @@ describe('httpClient', () => {
         .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       const result = await sendGet(client, '/products/1', {
-        responseSchema: z.number(),
+        responseSchema: schema,
         requestLabel: 'dummy',
-        validateResponse: true,
+        validateResponse: false,
       })
 
       expect(result.result.body).toEqual(mockProduct1)

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -1,14 +1,10 @@
-import type { Interceptable } from 'undici'
-import { Client, MockAgent, setGlobalDispatcher } from 'undici'
-import { isInternalRequestError } from 'undici-retry'
-import { beforeEach, describe, expect, it } from 'vitest'
-import { z } from 'zod'
+import type { Interceptable } from "undici";
+import { Client, MockAgent, setGlobalDispatcher } from "undici";
+import { isInternalRequestError, RequestResult } from "undici-retry";
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 
-import type { HttpRequestContext } from './httpClient'
 import {
-  JSON_HEADERS,
-  NO_CONTENT_RESPONSE_SCHEMA,
-  UNKNOWN_RESPONSE_SCHEMA,
   buildClient,
   sendDelete,
   sendGet,
@@ -17,60 +13,66 @@ import {
   sendPostBinary,
   sendPut,
   sendPutBinary,
-} from './httpClient'
-import mockProduct1 from './mock-data/mockProduct1.json'
-import mockProductsLimit3 from './mock-data/mockProductsLimit3.json'
+} from "./httpClient";
+import mockProduct1 from "./mock-data/mockProduct1.json";
+import mockProductsLimit3 from "./mock-data/mockProductsLimit3.json";
+import { HttpRequestContext } from "./types";
+import {
+  JSON_HEADERS,
+  NO_CONTENT_RESPONSE_SCHEMA,
+  UNKNOWN_RESPONSE_SCHEMA,
+} from "./constants";
 
 const TEXT_HEADERS = {
-  'content-type': 'text/plain',
-}
+  "content-type": "text/plain",
+};
 
-const baseUrl = 'https://fakestoreapi.com'
+const baseUrl = "https://fakestoreapi.com";
 const reqContext: HttpRequestContext = {
-  reqId: 'dummyId',
-}
+  reqId: "dummyId",
+};
 
-describe('httpClient', () => {
-  let mockAgent: MockAgent
-  let client: Client & Interceptable
+describe("httpClient", () => {
+  let mockAgent: MockAgent;
+  let client: Client & Interceptable;
   beforeEach(() => {
-    mockAgent = new MockAgent()
-    mockAgent.disableNetConnect()
-    setGlobalDispatcher(mockAgent)
-    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable
-  })
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable;
+  });
 
-  describe('buildClient', () => {
-    it('creates a client', () => {
-      const client = buildClient(baseUrl)
-      expect(client).toBeInstanceOf(Client)
-    })
-  })
+  describe("buildClient", () => {
+    it("creates a client", () => {
+      const client = buildClient(baseUrl);
+      expect(client).toBeInstanceOf(Client);
+    });
+  });
 
-  describe('GET', () => {
-    it('validates response structure with provided schema, throws an error', async () => {
+  describe("GET", () => {
+    it("validates response structure with provided schema, throws an error", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       await expect(
-        sendGet(client, '/products/1', {
+        sendGet(client, "/products/1", {
           responseSchema: schema,
           reqContext,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
           validateResponse: true,
         }),
-      ).rejects.toThrow(/Expected string, received number/)
-    })
+      ).rejects.toThrow(/Expected string, received number/);
+    });
 
-    it('validates response structure with provided schema, passes validation', async () => {
+    it("validates response structure with provided schema, passes validation", async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -82,384 +84,471 @@ describe('httpClient', () => {
           rate: z.number(),
         }),
         title: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: schema,
-        requestLabel: 'dummy',
+        requestLabel: "dummy",
         validateResponse: true,
-      })
+      });
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('validates response structure with provided schema, skips validation', async () => {
+    it("validates response structure with provided schema, skips validation", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: schema,
-        requestLabel: 'dummy',
+        requestLabel: "dummy",
 
         validateResponse: false,
-      })
+      });
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('returns original payload when breaking during parsing and throw on error is true', async () => {
-      expect.assertions(1)
+    it("unexpected 204 response is validated", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
+        .reply(204);
+
+      await expect(
+        sendGet(client, "/products/1", {
+          responseSchema: z.object({ id: z.string() }),
+          requestLabel: "dummy",
+          validateResponse: true,
+        }),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "object",
+            "received": "string",
+            "path": [],
+            "message": "Expected object, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204 without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "GET",
+        })
+        .reply(204);
+
+      const result = await sendGet(client, "/products/1", {
+        responseSchema: z.number(),
+        requestLabel: "dummy",
+        validateResponse: true,
+        isEmptyResponseExpected: false,
+      });
+
+      const typedResult: RequestResult<number> = result.result;
+
+      await expect(
+        sendGet(client, "/products/1", {
+          responseSchema: z.object({ id: z.string() }),
+          requestLabel: "dummy",
+          validateResponse: true,
+        }),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "object",
+            "received": "string",
+            "path": [],
+            "message": "Expected object, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("expected 204 skips validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "GET",
+        })
+        .reply(204);
+
+      const result = await sendGet(client, "/products/1", {
+        responseSchema: z.number(),
+        requestLabel: "dummy",
+        validateResponse: true,
+        isEmptyResponseExpected: true,
+      });
+
+      const typedResult = result.result;
+      expect(typedResult).toMatchObject({
+        body: null,
+        statusCode: 204,
+      });
+    });
+
+    it("returns original payload when breaking during parsing and throw on error is true", async () => {
+      expect.assertions(1);
+      client
+        .intercept({
+          path: "/products/1",
+          method: "GET",
+        })
+        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
 
       try {
-        await sendGet(client, '/products/1', {
+        await sendGet(client, "/products/1", {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
           throwOnError: true,
           safeParseJson: true,
-          requestLabel: 'label',
-        })
+          requestLabel: "label",
+        });
       } catch (err) {
         // This is needed, because built-in error assertions do not assert nested fields
         // eslint-disable-next-line vitest/no-conditional-expect
         expect(err).toMatchObject({
-          message: 'Error while parsing HTTP JSON response',
-          errorCode: 'INVALID_HTTP_RESPONSE_JSON',
+          message: "Error while parsing HTTP JSON response",
+          errorCode: "INVALID_HTTP_RESPONSE_JSON",
           details: {
-            rawBody: 'this is not a real json',
-            requestLabel: 'label',
+            rawBody: "this is not a real json",
+            requestLabel: "label",
           },
-        })
+        });
       }
-    })
+    });
 
-    it('does not throw if broken during parsing but throwOnError is false', async () => {
-      expect.assertions(1)
+    it("does not throw if broken during parsing but throwOnError is false", async () => {
+      expect.assertions(1);
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
+        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         throwOnError: false,
         safeParseJson: true,
-        requestLabel: 'label',
-      })
+        requestLabel: "label",
+      });
 
       expect(result.error).toMatchObject({
-        message: 'Error while parsing HTTP JSON response',
-        errorCode: 'INVALID_HTTP_RESPONSE_JSON',
+        message: "Error while parsing HTTP JSON response",
+        errorCode: "INVALID_HTTP_RESPONSE_JSON",
         details: {
-          rawBody: 'this is not a real json',
-          requestLabel: 'label',
+          rawBody: "this is not a real json",
+          requestLabel: "label",
         },
-      })
-    })
+      });
+    });
 
-    it('GET without queryParams', async () => {
+    it("GET without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('GET returning text', async () => {
+    it("GET returning text", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'just text', {
+        .reply(200, "just text", {
           headers: TEXT_HEADERS,
-        })
+        });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toBe('just text')
-    })
+      expect(result.result.body).toBe("just text");
+    });
 
-    it('GET returning text without content type', async () => {
+    it("GET returning text without content type", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'just text', {})
+        .reply(200, "just text", {});
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toBe('just text')
-    })
+      expect(result.result.body).toBe("just text");
+    });
 
-    it('GET with queryParams', async () => {
+    it("GET with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS })
+        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products', {
+      const result = await sendGet(client, "/products", {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual(mockProductsLimit3)
-    })
+      expect(result.result.body).toEqual(mockProductsLimit3);
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendGet(client, '/products', {
+        sendGet(client, "/products", {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
+        message: "connection error",
+      });
+    });
 
-    it('Throws an error with a label on internal error', async () => {
-      expect.assertions(2)
+    it("Throws an error with a label on internal error", async () => {
+      expect.assertions(2);
       const query = {
         limit: 3,
-      }
+      };
 
       try {
-        await sendGet(buildClient('http://127.0.0.1:999'), '/dummy', {
-          requestLabel: 'label',
+        await sendGet(buildClient("http://127.0.0.1:999"), "/dummy", {
+          requestLabel: "label",
           throwOnError: true,
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        })
+        });
       } catch (err) {
         if (!isInternalRequestError(err)) {
-          throw new Error('Invalid error type')
+          throw new Error("Invalid error type");
         }
-        expect(err.message).toBe('connect ECONNREFUSED 127.0.0.1:999')
-        expect(err.requestLabel).toBe('label')
+        expect(err.message).toBe("connect ECONNREFUSED 127.0.0.1:999");
+        expect(err.requestLabel).toBe("label");
       }
-    })
+    });
 
-    it('Returns error response', async () => {
-      expect.assertions(1)
+    it("Returns error response", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(400, 'Invalid request')
+        .reply(400, "Invalid request");
 
       await expect(
-        sendGet(client, '/products', {
+        sendGet(client, "/products", {
           query,
-          requestLabel: 'label',
+          requestLabel: "label",
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         }),
       ).rejects.toMatchObject({
-        message: 'Response status code 400',
+        message: "Response status code 400",
         response: {
-          body: 'Invalid request',
+          body: "Invalid request",
           statusCode: 400,
         },
         details: {
-          requestLabel: 'label',
+          requestLabel: "label",
           response: {
-            body: 'Invalid request',
+            body: "Invalid request",
             statusCode: 400,
           },
         },
-      })
-    })
+      });
+    });
 
-    it('Works with retry', async () => {
-      expect.assertions(1)
+    it("Works with retry", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(500, 'Invalid request')
+        .reply(500, "Invalid request");
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(200, 'OK')
+        .reply(200, "OK");
 
-      const response = await sendGet(client, '/products', {
+      const response = await sendGet(client, "/products", {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
+        requestLabel: "dummy",
         retryConfig: {
           statusCodesToRetry: [500],
           retryOnTimeout: false,
           delayBetweenAttemptsInMsecs: 0,
           maxAttempts: 2,
         },
-      })
+      });
 
-      expect(response.result.body).toBe('OK')
-    })
-  })
+      expect(response.result.body).toBe("OK");
+    });
+  });
 
-  describe('DELETE', () => {
-    it('DELETE without queryParams', async () => {
+  describe("DELETE", () => {
+    it("DELETE without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'DELETE',
+          path: "/products/1",
+          method: "DELETE",
         })
-        .reply(204, undefined)
+        .reply(204, undefined);
 
-      const result = await sendDelete(client, '/products/1', {
+      const result = await sendDelete(client, "/products/1", {
         reqContext,
         responseSchema: NO_CONTENT_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.statusCode).toBe(204)
-      expect(result.result.body).toBe('')
-    })
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
 
-    it('DELETE with queryParams', async () => {
+    it("DELETE with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'DELETE',
+          path: "/products",
+          method: "DELETE",
           query,
         })
-        .reply(204)
+        .reply(204);
 
-      const result = await sendDelete(client, '/products', {
+      const result = await sendDelete(client, "/products", {
         query,
         responseSchema: NO_CONTENT_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.statusCode).toBe(204)
-      expect(result.result.body).toBe('')
-    })
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'DELETE',
+          path: "/products",
+          method: "DELETE",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendDelete(client, '/products', {
+        sendDelete(client, "/products", {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('POST', () => {
-    it('validates response structure with provided schema, throws an error', async () => {
+  describe("POST", () => {
+    it("validates response structure with provided schema, throws an error", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       await expect(
         sendPost(
           client,
-          '/products/1',
+          "/products/1",
           {},
           {
             responseSchema: schema,
             validateResponse: true,
-            requestLabel: 'Test request',
+            requestLabel: "Test request",
           },
         ),
       ).rejects.toThrow(`[
@@ -473,10 +562,10 @@ describe('httpClient', () => {
     "message": "Expected string, received number",
     "requestLabel": "Test request"
   }
-]`)
-    })
+]`);
+    });
 
-    it('validates response structure with provided schema, passes validation', async () => {
+    it("validates response structure with provided schema, passes validation", async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -488,175 +577,175 @@ describe('httpClient', () => {
           rate: z.number(),
         }),
         title: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       const result = await sendPost(
         client,
-        '/products/1',
+        "/products/1",
         {},
         {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
           reqContext,
         },
-      )
+      );
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('validates response structure with provided schema, skips validation', async () => {
+    it("validates response structure with provided schema, skips validation", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       const result = await sendPost(
         client,
-        '/products/1',
+        "/products/1",
         {},
         {
           responseSchema: schema,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
           validateResponse: false,
         },
-      )
+      );
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('POST without queryParams', async () => {
+    it("POST without queryParams", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPost(client, '/products', mockProduct1, {
+      const result = await sendPost(client, "/products", mockProduct1, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST without body', async () => {
+    it("POST without body", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPost(client, '/products', undefined, {
+      const result = await sendPost(client, "/products", undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST with queryParams', async () => {
+    it("POST with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPost(client, '/products', mockProduct1, {
+      const result = await sendPost(client, "/products", mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST that returns 400 throws an error', async () => {
+    it("POST that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPost(client, '/products', mockProduct1, {
+        sendPost(client, "/products", mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow('Response status code 400')
-    })
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPost(client, '/products', undefined, {
+        sendPost(client, "/products", undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('POST binary', () => {
-    it('validates response structure with provided schema, throws an error', async () => {
+  describe("POST binary", () => {
+    it("validates response structure with provided schema, throws an error", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       await expect(
-        sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow(/Expected string, received number/)
-    })
+      ).rejects.toThrow(/Expected string, received number/);
+    });
 
-    it('validates response structure with provided schema, passes validation', async () => {
+    it("validates response structure with provided schema, passes validation", async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -668,411 +757,436 @@ describe('httpClient', () => {
           rate: z.number(),
         }),
         title: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
-        responseSchema: schema,
-        validateResponse: true,
-        requestLabel: 'dummy',
-        reqContext,
-      })
+      const result = await sendPostBinary(
+        client,
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
+        {
+          responseSchema: schema,
+          validateResponse: true,
+          requestLabel: "dummy",
+          reqContext,
+        },
+      );
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('validates response structure with provided schema, skips validation', async () => {
+    it("validates response structure with provided schema, skips validation", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
-
-      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
-        responseSchema: schema,
-        requestLabel: 'dummy',
-        validateResponse: false,
-      })
-
-      expect(result.result.body).toEqual(mockProduct1)
-    })
-
-    it('POST without queryParams', async () => {
-      client
-        .intercept({
-          path: '/products',
-          method: 'POST',
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       const result = await sendPostBinary(
         client,
-        '/products',
-        Buffer.from(JSON.stringify(mockProduct1)),
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
         {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          responseSchema: schema,
+          requestLabel: "dummy",
+          validateResponse: false,
         },
-      )
+      );
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('POST with queryParams', async () => {
-      const query = {
-        limit: 3,
-      }
-
+    it("POST without queryParams", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
-          query,
+          path: "/products",
+          method: "POST",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
       const result = await sendPostBinary(
         client,
-        '/products',
+        "/products",
+        Buffer.from(JSON.stringify(mockProduct1)),
+        {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        },
+      );
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("POST with queryParams", async () => {
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products",
+          method: "POST",
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPostBinary(
+        client,
+        "/products",
         Buffer.from(JSON.stringify(mockProduct1)),
         {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         },
-      )
+      );
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST that returns 400 throws an error', async () => {
+    it("POST that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPostBinary(client, '/products', Buffer.from(JSON.stringify(mockProduct1)), {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
-        }),
-      ).rejects.toThrow('Response status code 400')
-    })
+        sendPostBinary(
+          client,
+          "/products",
+          Buffer.from(JSON.stringify(mockProduct1)),
+          {
+            responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+            requestLabel: "dummy",
+          },
+        ),
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPostBinary(client, '/products', Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, "/products", Buffer.from(JSON.stringify({})), {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('PUT', () => {
-    it('PUT without queryParams', async () => {
+  describe("PUT", () => {
+    it("PUT without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPut(client, '/products/1', mockProduct1, {
+      const result = await sendPut(client, "/products/1", mockProduct1, {
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT without body', async () => {
+    it("PUT without body", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPut(client, '/products/1', undefined, {
+      const result = await sendPut(client, "/products/1", undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT with queryParams', async () => {
+    it("PUT with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPut(client, '/products/1', mockProduct1, {
+      const result = await sendPut(client, "/products/1", mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT that returns 400 throws an error', async () => {
+    it("PUT that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPut(client, '/products/1', mockProduct1, {
+        sendPut(client, "/products/1", mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow('Response status code 400')
-    })
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'PUT',
+          path: "/products",
+          method: "PUT",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPut(client, '/products', undefined, {
+        sendPut(client, "/products", undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('PUT binary', () => {
-    it('PUT without queryParams', async () => {
+  describe("PUT binary", () => {
+    it("PUT without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
+      const result = await sendPutBinary(
+        client,
+        "/products/1",
+        Buffer.from("text"),
+        {
+          reqContext,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        },
+      );
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PUT with queryParams", async () => {
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPutBinary(
+        client,
+        "/products/1",
+        Buffer.from("text"),
+        {
+          query,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        },
+      );
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PUT that returns 400 throws an error", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+
+      await expect(
+        sendPutBinary(client, "/products/1", Buffer.from("text"), {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        }),
+      ).rejects.toThrow("Response status code 400");
+    });
+
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products",
+          method: "PUT",
+          query,
+        })
+        .replyWithError(new Error("connection error"));
+
+      await expect(
+        sendPutBinary(client, "/products", null, {
+          query,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        }),
+      ).rejects.toMatchObject({
+        message: "connection error",
+      });
+    });
+  });
+
+  describe("PATCH", () => {
+    it("PATCH without queryParams", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPatch(client, "/products/1", mockProduct1, {
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: "dummy",
+      });
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PATCH without body", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPatch(client, "/products/1", undefined, {
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: "dummy",
+      });
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PATCH with queryParams", async () => {
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPatch(client, "/products/1", mockProduct1, {
+        query,
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT with queryParams', async () => {
-      const query = {
-        limit: 3,
-      }
-
+    it("PATCH that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
-          query,
+          path: "/products/1",
+          method: "PATCH",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
-        query,
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PUT that returns 400 throws an error', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PUT',
-        })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPutBinary(client, '/products/1', Buffer.from('text'), {
+        sendPatch(client, "/products/1", mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow('Response status code 400')
-    })
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'PUT',
+          path: "/products",
+          method: "PATCH",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPutBinary(client, '/products', null, {
+        sendPatch(client, "/products", undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
-
-  describe('PATCH', () => {
-    it('PATCH without queryParams', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPatch(client, '/products/1', mockProduct1, {
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PATCH without body', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPatch(client, '/products/1', undefined, {
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PATCH with queryParams', async () => {
-      const query = {
-        limit: 3,
-      }
-
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-          query,
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPatch(client, '/products/1', mockProduct1, {
-        query,
-        reqContext,
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PATCH that returns 400 throws an error', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-        })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
-
-      await expect(
-        sendPatch(client, '/products/1', mockProduct1, {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
-        }),
-      ).rejects.toThrow('Response status code 400')
-    })
-
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
-      const query = {
-        limit: 3,
-      }
-
-      client
-        .intercept({
-          path: '/products',
-          method: 'PATCH',
-          query,
-        })
-        .replyWithError(new Error('connection error'))
-
-      await expect(
-        sendPatch(client, '/products', undefined, {
-          query,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
-        }),
-      ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
-})
+        message: "connection error",
+      });
+    });
+  });
+});

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -1,10 +1,10 @@
-import type { Interceptable } from 'undici'
-import { Client, MockAgent, setGlobalDispatcher } from 'undici'
-import { isInternalRequestError } from 'undici-retry'
-import { beforeEach, describe, expect, it } from 'vitest'
-import { z } from 'zod'
+import type { Interceptable } from "undici";
+import { Client, MockAgent, setGlobalDispatcher } from "undici";
+import { isInternalRequestError } from "undici-retry";
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 
-import { JSON_HEADERS } from './constants'
+import { JSON_HEADERS } from "./constants";
 import {
   buildClient,
   sendDelete,
@@ -14,65 +14,65 @@ import {
   sendPostBinary,
   sendPut,
   sendPutBinary,
-} from './httpClient'
+} from "./httpClient";
 // @ts-ignore
-import mockProduct1 from './mock-data/mockProduct1.json'
+import mockProduct1 from "./mock-data/mockProduct1.json";
 // @ts-ignore
-import mockProductsLimit3 from './mock-data/mockProductsLimit3.json'
-import type { HttpRequestContext } from './types'
+import mockProductsLimit3 from "./mock-data/mockProductsLimit3.json";
+import type { HttpRequestContext } from "./types";
 
 const TEXT_HEADERS = {
-  'content-type': 'text/plain',
-}
+  "content-type": "text/plain",
+};
 
-const baseUrl = 'https://fakestoreapi.com'
+const baseUrl = "https://fakestoreapi.com";
 const reqContext: HttpRequestContext = {
-  reqId: 'dummyId',
-}
+  reqId: "dummyId",
+};
 
-const UNKNOWN_RESPONSE_SCHEMA = z.unknown()
+const UNKNOWN_RESPONSE_SCHEMA = z.unknown();
 
-describe('httpClient', () => {
-  let mockAgent: MockAgent
-  let client: Client & Interceptable
+describe("httpClient", () => {
+  let mockAgent: MockAgent;
+  let client: Client & Interceptable;
   beforeEach(() => {
-    mockAgent = new MockAgent()
-    mockAgent.disableNetConnect()
-    setGlobalDispatcher(mockAgent)
-    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable
-  })
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable;
+  });
 
-  describe('buildClient', () => {
-    it('creates a client', () => {
-      const client = buildClient(baseUrl)
-      expect(client).toBeInstanceOf(Client)
-    })
-  })
+  describe("buildClient", () => {
+    it("creates a client", () => {
+      const client = buildClient(baseUrl);
+      expect(client).toBeInstanceOf(Client);
+    });
+  });
 
-  describe('GET', () => {
-    it('validates response structure with provided schema, throws an error', async () => {
+  describe("GET", () => {
+    it("validates response structure with provided schema, throws an error", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       await expect(
-        sendGet(client, '/products/1', {
+        sendGet(client, "/products/1", {
           responseSchema: schema,
           reqContext,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
           validateResponse: true,
         }),
-      ).rejects.toThrow(/Expected string, received number/)
-    })
+      ).rejects.toThrow(/Expected string, received number/);
+    });
 
-    it('validates response structure with provided schema, passes validation', async () => {
+    it("validates response structure with provided schema, passes validation", async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -84,384 +84,443 @@ describe('httpClient', () => {
           rate: z.number(),
         }),
         title: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: schema,
-        requestLabel: 'dummy',
+        requestLabel: "dummy",
         validateResponse: true,
-      })
+      });
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
-
-    it('validates response structure with provided schema, skips validation', async () => {
-      const schema = z.object({
-        id: z.string(),
-      })
-
+      expect(result.result.body).toEqual(mockProduct1);
+    });
+    it("validates response structure with provided schema, skips validation", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
-        responseSchema: schema,
-        requestLabel: 'dummy',
+      const result = await sendGet(client, "/products/1", {
+        responseSchema: z.number(),
+        requestLabel: "dummy",
+        validateResponse: true,
+      });
 
+      expect(result.result.body).toEqual(mockProduct1);
+    });
+
+    it("unexpected 204, with validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "GET",
+        })
+        .reply(204);
+
+      await expect(
+        sendGet(client, "/products/1", {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+        }),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204, without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "GET",
+        })
+        .reply(204);
+
+      const result = await sendGet(client, "/products/1", {
+        responseSchema: z.number(),
+        requestLabel: "dummy",
         validateResponse: false,
-      })
+      });
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
 
-    it('returns original payload when breaking during parsing and throw on error is true', async () => {
-      expect.assertions(1)
+    it("expected 204", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
+        .reply(204);
+
+      const result = await sendGet(client, "/products/1", {
+        responseSchema: z.number(),
+        requestLabel: "dummy",
+        isEmptyResponseExpected: true,
+        validateResponse: true,
+      });
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBeNull();
+    });
+
+    it("returns original payload when breaking during parsing and throw on error is true", async () => {
+      expect.assertions(1);
+      client
+        .intercept({
+          path: "/products/1",
+          method: "GET",
+        })
+        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
 
       try {
-        await sendGet(client, '/products/1', {
+        await sendGet(client, "/products/1", {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
           throwOnError: true,
           safeParseJson: true,
-          requestLabel: 'label',
-        })
+          requestLabel: "label",
+        });
       } catch (err) {
         // This is needed, because built-in error assertions do not assert nested fields
         // eslint-disable-next-line vitest/no-conditional-expect
         expect(err).toMatchObject({
-          message: 'Error while parsing HTTP JSON response',
-          errorCode: 'INVALID_HTTP_RESPONSE_JSON',
+          message: "Error while parsing HTTP JSON response",
+          errorCode: "INVALID_HTTP_RESPONSE_JSON",
           details: {
-            rawBody: 'this is not a real json',
-            requestLabel: 'label',
+            rawBody: "this is not a real json",
+            requestLabel: "label",
           },
-        })
+        });
       }
-    })
+    });
 
-    it('does not throw if broken during parsing but throwOnError is false', async () => {
-      expect.assertions(1)
+    it("does not throw if broken during parsing but throwOnError is false", async () => {
+      expect.assertions(1);
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
+        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         throwOnError: false,
         safeParseJson: true,
-        requestLabel: 'label',
-      })
+        requestLabel: "label",
+      });
 
       expect(result.error).toMatchObject({
-        message: 'Error while parsing HTTP JSON response',
-        errorCode: 'INVALID_HTTP_RESPONSE_JSON',
+        message: "Error while parsing HTTP JSON response",
+        errorCode: "INVALID_HTTP_RESPONSE_JSON",
         details: {
-          rawBody: 'this is not a real json',
-          requestLabel: 'label',
+          rawBody: "this is not a real json",
+          requestLabel: "label",
         },
-      })
-    })
+      });
+    });
 
-    it('GET without queryParams', async () => {
+    it("GET without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('GET returning text', async () => {
+    it("GET returning text", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'just text', {
+        .reply(200, "just text", {
           headers: TEXT_HEADERS,
-        })
+        });
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toBe('just text')
-    })
+      expect(result.result.body).toBe("just text");
+    });
 
-    it('GET returning text without content type', async () => {
+    it("GET returning text without content type", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'GET',
+          path: "/products/1",
+          method: "GET",
         })
-        .reply(200, 'just text', {})
+        .reply(200, "just text", {});
 
-      const result = await sendGet(client, '/products/1', {
+      const result = await sendGet(client, "/products/1", {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toBe('just text')
-    })
+      expect(result.result.body).toBe("just text");
+    });
 
-    it('GET with queryParams', async () => {
+    it("GET with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS })
+        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS });
 
-      const result = await sendGet(client, '/products', {
+      const result = await sendGet(client, "/products", {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual(mockProductsLimit3)
-    })
+      expect(result.result.body).toEqual(mockProductsLimit3);
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendGet(client, '/products', {
+        sendGet(client, "/products", {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
+        message: "connection error",
+      });
+    });
 
-    it('Throws an error with a label on internal error', async () => {
-      expect.assertions(2)
+    it("Throws an error with a label on internal error", async () => {
+      expect.assertions(2);
       const query = {
         limit: 3,
-      }
+      };
 
       try {
-        await sendGet(buildClient('http://127.0.0.1:999'), '/dummy', {
-          requestLabel: 'label',
+        await sendGet(buildClient("http://127.0.0.1:999"), "/dummy", {
+          requestLabel: "label",
           throwOnError: true,
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        })
+        });
       } catch (err) {
         if (!isInternalRequestError(err)) {
-          throw new Error('Invalid error type')
+          throw new Error("Invalid error type");
         }
-        expect(err.message).toBe('connect ECONNREFUSED 127.0.0.1:999')
-        expect(err.requestLabel).toBe('label')
+        expect(err.message).toBe("connect ECONNREFUSED 127.0.0.1:999");
+        expect(err.requestLabel).toBe("label");
       }
-    })
+    });
 
-    it('Returns error response', async () => {
-      expect.assertions(1)
+    it("Returns error response", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(400, 'Invalid request')
+        .reply(400, "Invalid request");
 
       await expect(
-        sendGet(client, '/products', {
+        sendGet(client, "/products", {
           query,
-          requestLabel: 'label',
+          requestLabel: "label",
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         }),
       ).rejects.toMatchObject({
-        message: 'Response status code 400',
+        message: "Response status code 400",
         response: {
-          body: 'Invalid request',
+          body: "Invalid request",
           statusCode: 400,
         },
         details: {
-          requestLabel: 'label',
+          requestLabel: "label",
           response: {
-            body: 'Invalid request',
+            body: "Invalid request",
             statusCode: 400,
           },
         },
-      })
-    })
+      });
+    });
 
-    it('Works with retry', async () => {
-      expect.assertions(1)
+    it("Works with retry", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(500, 'Invalid request')
+        .reply(500, "Invalid request");
       client
         .intercept({
-          path: '/products',
-          method: 'GET',
+          path: "/products",
+          method: "GET",
           query,
         })
-        .reply(200, 'OK')
+        .reply(200, "OK");
 
-      const response = await sendGet(client, '/products', {
+      const response = await sendGet(client, "/products", {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
+        requestLabel: "dummy",
         retryConfig: {
           statusCodesToRetry: [500],
           retryOnTimeout: false,
           delayBetweenAttemptsInMsecs: 0,
           maxAttempts: 2,
         },
-      })
+      });
 
-      expect(response.result.body).toBe('OK')
-    })
-  })
+      expect(response.result.body).toBe("OK");
+    });
+  });
 
-  describe('DELETE', () => {
-    it('DELETE without queryParams', async () => {
+  describe("DELETE", () => {
+    it("DELETE without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'DELETE',
+          path: "/products/1",
+          method: "DELETE",
         })
-        .reply(204, undefined)
+        .reply(204, undefined);
 
-      const result = await sendDelete(client, '/products/1', {
+      const result = await sendDelete(client, "/products/1", {
         reqContext,
         responseSchema: z.any(), // TODO
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.statusCode).toBe(204)
-      expect(result.result.body).toBe('')
-    })
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
 
-    it('DELETE with queryParams', async () => {
+    it("DELETE with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'DELETE',
+          path: "/products",
+          method: "DELETE",
           query,
         })
-        .reply(204)
+        .reply(204);
 
-      const result = await sendDelete(client, '/products', {
+      const result = await sendDelete(client, "/products", {
         query,
         responseSchema: z.any(), // TODO
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.statusCode).toBe(204)
-      expect(result.result.body).toBe('')
-    })
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'DELETE',
+          path: "/products",
+          method: "DELETE",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendDelete(client, '/products', {
+        sendDelete(client, "/products", {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('POST', () => {
-    it('validates response structure with provided schema, throws an error', async () => {
+  describe("POST", () => {
+    it("validates response structure with provided schema, throws an error", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       await expect(
         sendPost(
           client,
-          '/products/1',
+          "/products/1",
           {},
           {
             responseSchema: schema,
             validateResponse: true,
-            requestLabel: 'Test request',
+            requestLabel: "Test request",
           },
         ),
       ).rejects.toThrow(`[
@@ -475,10 +534,10 @@ describe('httpClient', () => {
     "message": "Expected string, received number",
     "requestLabel": "Test request"
   }
-]`)
-    })
+]`);
+    });
 
-    it('validates response structure with provided schema, passes validation', async () => {
+    it("validates response structure with provided schema, passes validation", async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -490,175 +549,175 @@ describe('httpClient', () => {
           rate: z.number(),
         }),
         title: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       const result = await sendPost(
         client,
-        '/products/1',
+        "/products/1",
         {},
         {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
           reqContext,
         },
-      )
+      );
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('validates response structure with provided schema, skips validation', async () => {
+    it("validates response structure with provided schema, skips validation", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       const result = await sendPost(
         client,
-        '/products/1',
+        "/products/1",
         {},
         {
           responseSchema: schema,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
           validateResponse: false,
         },
-      )
+      );
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('POST without queryParams', async () => {
+    it("POST without queryParams", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPost(client, '/products', mockProduct1, {
+      const result = await sendPost(client, "/products", mockProduct1, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST without body', async () => {
+    it("POST without body", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPost(client, '/products', undefined, {
+      const result = await sendPost(client, "/products", undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST with queryParams', async () => {
+    it("POST with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPost(client, '/products', mockProduct1, {
+      const result = await sendPost(client, "/products", mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST that returns 400 throws an error', async () => {
+    it("POST that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPost(client, '/products', mockProduct1, {
+        sendPost(client, "/products", mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow('Response status code 400')
-    })
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPost(client, '/products', undefined, {
+        sendPost(client, "/products", undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('POST binary', () => {
-    it('validates response structure with provided schema, throws an error', async () => {
+  describe("POST binary", () => {
+    it("validates response structure with provided schema, throws an error", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       await expect(
-        sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow(/Expected string, received number/)
-    })
+      ).rejects.toThrow(/Expected string, received number/);
+    });
 
-    it('validates response structure with provided schema, passes validation', async () => {
+    it("validates response structure with provided schema, passes validation", async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -670,411 +729,436 @@ describe('httpClient', () => {
           rate: z.number(),
         }),
         title: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
-      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
-        responseSchema: schema,
-        validateResponse: true,
-        requestLabel: 'dummy',
-        reqContext,
-      })
+      const result = await sendPostBinary(
+        client,
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
+        {
+          responseSchema: schema,
+          validateResponse: true,
+          requestLabel: "dummy",
+          reqContext,
+        },
+      );
 
-      expect(result.result.body).toEqual(mockProduct1)
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('validates response structure with provided schema, skips validation', async () => {
+    it("validates response structure with provided schema, skips validation", async () => {
       const schema = z.object({
         id: z.string(),
-      })
+      });
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'POST',
+          path: "/products/1",
+          method: "POST",
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS })
-
-      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
-        responseSchema: schema,
-        requestLabel: 'dummy',
-        validateResponse: false,
-      })
-
-      expect(result.result.body).toEqual(mockProduct1)
-    })
-
-    it('POST without queryParams', async () => {
-      client
-        .intercept({
-          path: '/products',
-          method: 'POST',
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS });
 
       const result = await sendPostBinary(
         client,
-        '/products',
-        Buffer.from(JSON.stringify(mockProduct1)),
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
         {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          responseSchema: schema,
+          requestLabel: "dummy",
+          validateResponse: false,
         },
-      )
+      );
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual(mockProduct1);
+    });
 
-    it('POST with queryParams', async () => {
-      const query = {
-        limit: 3,
-      }
-
+    it("POST without queryParams", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
-          query,
+          path: "/products",
+          method: "POST",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
       const result = await sendPostBinary(
         client,
-        '/products',
+        "/products",
+        Buffer.from(JSON.stringify(mockProduct1)),
+        {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        },
+      );
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("POST with queryParams", async () => {
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products",
+          method: "POST",
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPostBinary(
+        client,
+        "/products",
         Buffer.from(JSON.stringify(mockProduct1)),
         {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         },
-      )
+      );
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('POST that returns 400 throws an error', async () => {
+    it("POST that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
         })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPostBinary(client, '/products', Buffer.from(JSON.stringify(mockProduct1)), {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
-        }),
-      ).rejects.toThrow('Response status code 400')
-    })
+        sendPostBinary(
+          client,
+          "/products",
+          Buffer.from(JSON.stringify(mockProduct1)),
+          {
+            responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+            requestLabel: "dummy",
+          },
+        ),
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'POST',
+          path: "/products",
+          method: "POST",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPostBinary(client, '/products', Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, "/products", Buffer.from(JSON.stringify({})), {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('PUT', () => {
-    it('PUT without queryParams', async () => {
+  describe("PUT", () => {
+    it("PUT without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPut(client, '/products/1', mockProduct1, {
+      const result = await sendPut(client, "/products/1", mockProduct1, {
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT without body', async () => {
+    it("PUT without body", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPut(client, '/products/1', undefined, {
+      const result = await sendPut(client, "/products/1", undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT with queryParams', async () => {
+    it("PUT with queryParams", async () => {
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPut(client, '/products/1', mockProduct1, {
+      const result = await sendPut(client, "/products/1", mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT that returns 400 throws an error', async () => {
+    it("PUT that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPut(client, '/products/1', mockProduct1, {
+        sendPut(client, "/products/1", mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow('Response status code 400')
-    })
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'PUT',
+          path: "/products",
+          method: "PUT",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPut(client, '/products', undefined, {
+        sendPut(client, "/products", undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
+        message: "connection error",
+      });
+    });
+  });
 
-  describe('PUT binary', () => {
-    it('PUT without queryParams', async () => {
+  describe("PUT binary", () => {
+    it("PUT without queryParams", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
+          path: "/products/1",
+          method: "PUT",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
 
-      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
+      const result = await sendPutBinary(
+        client,
+        "/products/1",
+        Buffer.from("text"),
+        {
+          reqContext,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        },
+      );
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PUT with queryParams", async () => {
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPutBinary(
+        client,
+        "/products/1",
+        Buffer.from("text"),
+        {
+          query,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        },
+      );
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PUT that returns 400 throws an error", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+
+      await expect(
+        sendPutBinary(client, "/products/1", Buffer.from("text"), {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        }),
+      ).rejects.toThrow("Response status code 400");
+    });
+
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products",
+          method: "PUT",
+          query,
+        })
+        .replyWithError(new Error("connection error"));
+
+      await expect(
+        sendPutBinary(client, "/products", null, {
+          query,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: "dummy",
+        }),
+      ).rejects.toMatchObject({
+        message: "connection error",
+      });
+    });
+  });
+
+  describe("PATCH", () => {
+    it("PATCH without queryParams", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPatch(client, "/products/1", mockProduct1, {
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: "dummy",
+      });
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PATCH without body", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPatch(client, "/products/1", undefined, {
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: "dummy",
+      });
+
+      expect(result.result.body).toEqual({ id: 21 });
+    });
+
+    it("PATCH with queryParams", async () => {
+      const query = {
+        limit: 3,
+      };
+
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+
+      const result = await sendPatch(client, "/products/1", mockProduct1, {
+        query,
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
+        requestLabel: "dummy",
+      });
 
-      expect(result.result.body).toEqual({ id: 21 })
-    })
+      expect(result.result.body).toEqual({ id: 21 });
+    });
 
-    it('PUT with queryParams', async () => {
-      const query = {
-        limit: 3,
-      }
-
+    it("PATCH that returns 400 throws an error", async () => {
       client
         .intercept({
-          path: '/products/1',
-          method: 'PUT',
-          query,
+          path: "/products/1",
+          method: "PATCH",
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
-        query,
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PUT that returns 400 throws an error', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PUT',
-        })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
 
       await expect(
-        sendPutBinary(client, '/products/1', Buffer.from('text'), {
+        sendPatch(client, "/products/1", mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
-      ).rejects.toThrow('Response status code 400')
-    })
+      ).rejects.toThrow("Response status code 400");
+    });
 
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
+    it("Throws an error on internal error", async () => {
+      expect.assertions(1);
       const query = {
         limit: 3,
-      }
+      };
 
       client
         .intercept({
-          path: '/products',
-          method: 'PUT',
+          path: "/products",
+          method: "PATCH",
           query,
         })
-        .replyWithError(new Error('connection error'))
+        .replyWithError(new Error("connection error"));
 
       await expect(
-        sendPutBinary(client, '/products', null, {
+        sendPatch(client, "/products", undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
+          requestLabel: "dummy",
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
-
-  describe('PATCH', () => {
-    it('PATCH without queryParams', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPatch(client, '/products/1', mockProduct1, {
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PATCH without body', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPatch(client, '/products/1', undefined, {
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PATCH with queryParams', async () => {
-      const query = {
-        limit: 3,
-      }
-
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-          query,
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
-
-      const result = await sendPatch(client, '/products/1', mockProduct1, {
-        query,
-        reqContext,
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: 'dummy',
-      })
-
-      expect(result.result.body).toEqual({ id: 21 })
-    })
-
-    it('PATCH that returns 400 throws an error', async () => {
-      client
-        .intercept({
-          path: '/products/1',
-          method: 'PATCH',
-        })
-        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
-
-      await expect(
-        sendPatch(client, '/products/1', mockProduct1, {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
-        }),
-      ).rejects.toThrow('Response status code 400')
-    })
-
-    it('Throws an error on internal error', async () => {
-      expect.assertions(1)
-      const query = {
-        limit: 3,
-      }
-
-      client
-        .intercept({
-          path: '/products',
-          method: 'PATCH',
-          query,
-        })
-        .replyWithError(new Error('connection error'))
-
-      await expect(
-        sendPatch(client, '/products', undefined, {
-          query,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: 'dummy',
-        }),
-      ).rejects.toMatchObject({
-        message: 'connection error',
-      })
-    })
-  })
-})
+        message: "connection error",
+      });
+    });
+  });
+});

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -19,11 +19,7 @@ import mockProduct1 from "./mock-data/mockProduct1.json";
 // @ts-ignore
 import mockProductsLimit3 from "./mock-data/mockProductsLimit3.json";
 import { HttpRequestContext } from "./types";
-import {
-  JSON_HEADERS,
-  NO_CONTENT_RESPONSE_SCHEMA,
-  UNKNOWN_RESPONSE_SCHEMA,
-} from "./constants";
+import { JSON_HEADERS } from "./constants";
 
 const TEXT_HEADERS = {
   "content-type": "text/plain",
@@ -33,6 +29,8 @@ const baseUrl = "https://fakestoreapi.com";
 const reqContext: HttpRequestContext = {
   reqId: "dummyId",
 };
+
+const UNKNOWN_RESPONSE_SCHEMA = z.unknown();
 
 describe("httpClient", () => {
   let mockAgent: MockAgent;
@@ -385,7 +383,7 @@ describe("httpClient", () => {
 
       const result = await sendDelete(client, "/products/1", {
         reqContext,
-        responseSchema: NO_CONTENT_RESPONSE_SCHEMA,
+        responseSchema: z.any(), // TODO
         requestLabel: "dummy",
       });
 
@@ -408,7 +406,7 @@ describe("httpClient", () => {
 
       const result = await sendDelete(client, "/products", {
         query,
-        responseSchema: NO_CONTENT_RESPONSE_SCHEMA,
+        responseSchema: z.any(), // TODO
         requestLabel: "dummy",
       });
 

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -443,17 +443,17 @@ describe('httpClient', () => {
           path: '/products/1',
           method: 'DELETE',
         })
-        .reply(204)
+        .reply(200)
 
       const result = await sendDelete(client, '/products/1', {
         reqContext,
-        responseSchema: z.number(), // should not check body
+        responseSchema: z.unknown(),
         requestLabel: 'dummy',
         validateResponse: true,
       })
 
-      expect(result.result.statusCode).toBe(204)
-      expect(result.result.body).toBe(null)
+      expect(result.result.statusCode).toBe(200)
+      expect(result.result.body).toBe('')
     })
 
     it('DELETE with queryParams', async () => {
@@ -467,16 +467,15 @@ describe('httpClient', () => {
           method: 'DELETE',
           query,
         })
-        .reply(204)
+        .reply(200)
 
       const result = await sendDelete(client, '/products', {
         query,
-        responseSchema: z.any(),
+        responseSchema: z.unknown(),
         requestLabel: 'dummy',
-        isEmptyResponseExpected: false,
       })
 
-      expect(result.result.statusCode).toBe(204)
+      expect(result.result.statusCode).toBe(200)
       expect(result.result.body).toBe('')
     })
 
@@ -503,6 +502,72 @@ describe('httpClient', () => {
       ).rejects.toMatchObject({
         message: 'connection error',
       })
+    })
+
+    it('unexpected 204, with validation', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'DELETE',
+        })
+        .reply(204)
+
+      await expect(
+        sendDelete(client, '/products/1', {
+          responseSchema: z.number(),
+          requestLabel: 'dummy',
+          validateResponse: true,
+          isEmptyResponseExpected: false,
+        }),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `)
+    })
+
+    it('unexpected 204, without validation', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'DELETE',
+        })
+        .reply(204)
+
+      const result = await sendDelete(client, '/products/1', {
+        responseSchema: z.number(),
+        requestLabel: 'dummy',
+        validateResponse: false,
+        isEmptyResponseExpected: false,
+      })
+
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
+
+    it('expected 204', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'DELETE',
+        })
+        .reply(204)
+
+      const result = await sendDelete(client, '/products/1', {
+        responseSchema: z.number(),
+        requestLabel: 'dummy',
+        validateResponse: true,
+      })
+
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
     })
   })
 
@@ -623,7 +688,6 @@ describe('httpClient', () => {
             responseSchema: z.number(),
             requestLabel: 'dummy',
             validateResponse: true,
-            isEmptyResponseExpected: false,
           },
         ),
       ).rejects.toMatchInlineSnapshot(`
@@ -656,7 +720,6 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: false,
-          isEmptyResponseExpected: false,
         },
       )
 
@@ -680,6 +743,7 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: true,
+          isEmptyResponseExpected: true,
         },
       )
 
@@ -870,7 +934,6 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: true,
-          isEmptyResponseExpected: false,
         }),
       ).rejects.toMatchInlineSnapshot(`
         [ZodError: [
@@ -898,7 +961,6 @@ describe('httpClient', () => {
         responseSchema: z.number(),
         requestLabel: 'dummy',
         validateResponse: false,
-        isEmptyResponseExpected: false,
       })
 
       expect(result.result.statusCode).toBe(204)
@@ -917,6 +979,7 @@ describe('httpClient', () => {
         responseSchema: z.number(),
         requestLabel: 'dummy',
         validateResponse: true,
+        isEmptyResponseExpected: true,
       })
 
       expect(result.result.statusCode).toBe(204)
@@ -1127,7 +1190,6 @@ describe('httpClient', () => {
             responseSchema: z.number(),
             requestLabel: 'dummy',
             validateResponse: true,
-            isEmptyResponseExpected: false,
           },
         ),
       ).rejects.toMatchInlineSnapshot(`
@@ -1160,7 +1222,6 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: false,
-          isEmptyResponseExpected: false,
         },
       )
 
@@ -1184,6 +1245,7 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: true,
+          isEmptyResponseExpected: true,
         },
       )
 
@@ -1286,7 +1348,6 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: true,
-          isEmptyResponseExpected: false,
         }),
       ).rejects.toMatchInlineSnapshot(`
         [ZodError: [
@@ -1314,7 +1375,6 @@ describe('httpClient', () => {
         responseSchema: z.number(),
         requestLabel: 'dummy',
         validateResponse: false,
-        isEmptyResponseExpected: false,
       })
 
       expect(result.result.statusCode).toBe(204)
@@ -1333,6 +1393,7 @@ describe('httpClient', () => {
         responseSchema: z.number(),
         requestLabel: 'dummy',
         validateResponse: true,
+        isEmptyResponseExpected: true,
       })
 
       expect(result.result.statusCode).toBe(204)
@@ -1454,7 +1515,6 @@ describe('httpClient', () => {
             responseSchema: z.number(),
             requestLabel: 'dummy',
             validateResponse: true,
-            isEmptyResponseExpected: false,
           },
         ),
       ).rejects.toMatchInlineSnapshot(`
@@ -1487,7 +1547,6 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: false,
-          isEmptyResponseExpected: false,
         },
       )
 
@@ -1511,6 +1570,7 @@ describe('httpClient', () => {
           responseSchema: z.number(),
           requestLabel: 'dummy',
           validateResponse: true,
+          isEmptyResponseExpected: true,
         },
       )
 

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -438,16 +438,17 @@ describe("httpClient", () => {
           path: "/products/1",
           method: "DELETE",
         })
-        .reply(204, undefined);
+        .reply(204);
 
       const result = await sendDelete(client, "/products/1", {
         reqContext,
-        responseSchema: z.any(), // TODO
+        responseSchema: z.number(), // should not check body
         requestLabel: "dummy",
+        validateResponse: true,
       });
 
       expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
+      expect(result.result.body).toBe(null);
     });
 
     it("DELETE with queryParams", async () => {
@@ -465,8 +466,9 @@ describe("httpClient", () => {
 
       const result = await sendDelete(client, "/products", {
         query,
-        responseSchema: z.any(), // TODO
+        responseSchema: z.any(),
         requestLabel: "dummy",
+        isEmptyResponseExpected: false,
       });
 
       expect(result.result.statusCode).toBe(204);
@@ -597,6 +599,87 @@ describe("httpClient", () => {
       );
 
       expect(result.result.body).toEqual(mockProduct1);
+    });
+
+    it("unexpected 204, with validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "POST",
+        })
+        .reply(204);
+
+      await expect(
+        sendPost(
+          client,
+          "/products/1",
+          {},
+          {
+            responseSchema: z.number(),
+            requestLabel: "dummy",
+            validateResponse: true,
+            isEmptyResponseExpected: false,
+          },
+        ),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204, without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "POST",
+        })
+        .reply(204);
+
+      const result = await sendPost(
+        client,
+        "/products/1",
+        {},
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: false,
+          isEmptyResponseExpected: false,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
+
+    it("expected 204", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "POST",
+        })
+        .reply(204);
+
+      const result = await sendPost(
+        client,
+        "/products/1",
+        {},
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBeNull();
     });
 
     it("POST without queryParams", async () => {
@@ -777,6 +860,82 @@ describe("httpClient", () => {
       );
 
       expect(result.result.body).toEqual(mockProduct1);
+    });
+
+    it("unexpected 204, with validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "POST",
+        })
+        .reply(204);
+
+      await expect(
+        sendPostBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+          isEmptyResponseExpected: false,
+        }),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204, without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "POST",
+        })
+        .reply(204);
+
+      const result = await sendPostBinary(
+        client,
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: false,
+          isEmptyResponseExpected: false,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
+
+    it("expected 204", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "POST",
+        })
+        .reply(204);
+
+      const result = await sendPostBinary(
+        client,
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBeNull();
     });
 
     it("POST without queryParams", async () => {
@@ -970,6 +1129,87 @@ describe("httpClient", () => {
         message: "connection error",
       });
     });
+
+    it("unexpected 204, with validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(204);
+
+      await expect(
+        sendPut(
+          client,
+          "/products/1",
+          {},
+          {
+            responseSchema: z.number(),
+            requestLabel: "dummy",
+            validateResponse: true,
+            isEmptyResponseExpected: false,
+          },
+        ),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204, without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(204);
+
+      const result = await sendPut(
+        client,
+        "/products/1",
+        {},
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: false,
+          isEmptyResponseExpected: false,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
+
+    it("expected 204", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(204);
+
+      const result = await sendPut(
+        client,
+        "/products/1",
+        {},
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBeNull();
+    });
   });
 
   describe("PUT binary", () => {
@@ -1061,6 +1301,82 @@ describe("httpClient", () => {
       ).rejects.toMatchObject({
         message: "connection error",
       });
+    });
+
+    it("unexpected 204, with validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(204);
+
+      await expect(
+        sendPutBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+          isEmptyResponseExpected: false,
+        }),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204, without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(204);
+
+      const result = await sendPutBinary(
+        client,
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: false,
+          isEmptyResponseExpected: false,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
+
+    it("expected 204", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PUT",
+        })
+        .reply(204);
+
+      const result = await sendPutBinary(
+        client,
+        "/products/1",
+        Buffer.from(JSON.stringify({})),
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBeNull();
     });
   });
 
@@ -1159,6 +1475,87 @@ describe("httpClient", () => {
       ).rejects.toMatchObject({
         message: "connection error",
       });
+    });
+
+    it("unexpected 204, with validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(204);
+
+      await expect(
+        sendPatch(
+          client,
+          "/products/1",
+          {},
+          {
+            responseSchema: z.number(),
+            requestLabel: "dummy",
+            validateResponse: true,
+            isEmptyResponseExpected: false,
+          },
+        ),
+      ).rejects.toMatchInlineSnapshot(`
+        [ZodError: [
+          {
+            "code": "invalid_type",
+            "expected": "number",
+            "received": "string",
+            "path": [],
+            "message": "Expected number, received string",
+            "requestLabel": "dummy"
+          }
+        ]]
+      `);
+    });
+
+    it("unexpected 204, without validation", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(204);
+
+      const result = await sendPatch(
+        client,
+        "/products/1",
+        {},
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: false,
+          isEmptyResponseExpected: false,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBe("");
+    });
+
+    it("expected 204", async () => {
+      client
+        .intercept({
+          path: "/products/1",
+          method: "PATCH",
+        })
+        .reply(204);
+
+      const result = await sendPatch(
+        client,
+        "/products/1",
+        {},
+        {
+          responseSchema: z.number(),
+          requestLabel: "dummy",
+          validateResponse: true,
+        },
+      );
+
+      expect(result.result.statusCode).toBe(204);
+      expect(result.result.body).toBeNull();
     });
   });
 });

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -14,7 +14,9 @@ import {
   sendPut,
   sendPutBinary,
 } from "./httpClient";
+// @ts-ignore
 import mockProduct1 from "./mock-data/mockProduct1.json";
+// @ts-ignore
 import mockProductsLimit3 from "./mock-data/mockProductsLimit3.json";
 import { HttpRequestContext } from "./types";
 import {
@@ -122,93 +124,6 @@ describe("httpClient", () => {
       });
 
       expect(result.result.body).toEqual(mockProduct1);
-    });
-
-    it("unexpected 204 response is validated", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "GET",
-        })
-        .reply(204);
-
-      await expect(
-        sendGet(client, "/products/1", {
-          responseSchema: z.object({ id: z.string() }),
-          requestLabel: "dummy",
-          validateResponse: true,
-        }),
-      ).rejects.toMatchInlineSnapshot(`
-        [ZodError: [
-          {
-            "code": "invalid_type",
-            "expected": "object",
-            "received": "string",
-            "path": [],
-            "message": "Expected object, received string",
-            "requestLabel": "dummy"
-          }
-        ]]
-      `);
-    });
-
-    it("unexpected 204 without validation", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "GET",
-        })
-        .reply(204);
-
-      const result = await sendGet(client, "/products/1", {
-        responseSchema: z.number(),
-        requestLabel: "dummy",
-        validateResponse: true,
-        isEmptyResponseExpected: false,
-      });
-
-      const typedResult: RequestResult<number> = result.result;
-
-      await expect(
-        sendGet(client, "/products/1", {
-          responseSchema: z.object({ id: z.string() }),
-          requestLabel: "dummy",
-          validateResponse: true,
-        }),
-      ).rejects.toMatchInlineSnapshot(`
-        [ZodError: [
-          {
-            "code": "invalid_type",
-            "expected": "object",
-            "received": "string",
-            "path": [],
-            "message": "Expected object, received string",
-            "requestLabel": "dummy"
-          }
-        ]]
-      `);
-    });
-
-    it("expected 204 skips validation", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "GET",
-        })
-        .reply(204);
-
-      const result = await sendGet(client, "/products/1", {
-        responseSchema: z.number(),
-        requestLabel: "dummy",
-        validateResponse: true,
-        isEmptyResponseExpected: true,
-      });
-
-      const typedResult = result.result;
-      expect(typedResult).toMatchObject({
-        body: null,
-        statusCode: 204,
-      });
     });
 
     it("returns original payload when breaking during parsing and throw on error is true", async () => {

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -1,9 +1,10 @@
-import type { Interceptable } from "undici";
-import { Client, MockAgent, setGlobalDispatcher } from "undici";
-import { isInternalRequestError, RequestResult } from "undici-retry";
-import { beforeEach, describe, expect, it } from "vitest";
-import { z } from "zod";
+import type { Interceptable } from 'undici'
+import { Client, MockAgent, setGlobalDispatcher } from 'undici'
+import { isInternalRequestError } from 'undici-retry'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
+import { JSON_HEADERS } from './constants'
 import {
   buildClient,
   sendDelete,
@@ -13,66 +14,65 @@ import {
   sendPostBinary,
   sendPut,
   sendPutBinary,
-} from "./httpClient";
+} from './httpClient'
 // @ts-ignore
-import mockProduct1 from "./mock-data/mockProduct1.json";
+import mockProduct1 from './mock-data/mockProduct1.json'
 // @ts-ignore
-import mockProductsLimit3 from "./mock-data/mockProductsLimit3.json";
-import { HttpRequestContext } from "./types";
-import { JSON_HEADERS } from "./constants";
+import mockProductsLimit3 from './mock-data/mockProductsLimit3.json'
+import type { HttpRequestContext } from './types'
 
 const TEXT_HEADERS = {
-  "content-type": "text/plain",
-};
+  'content-type': 'text/plain',
+}
 
-const baseUrl = "https://fakestoreapi.com";
+const baseUrl = 'https://fakestoreapi.com'
 const reqContext: HttpRequestContext = {
-  reqId: "dummyId",
-};
+  reqId: 'dummyId',
+}
 
-const UNKNOWN_RESPONSE_SCHEMA = z.unknown();
+const UNKNOWN_RESPONSE_SCHEMA = z.unknown()
 
-describe("httpClient", () => {
-  let mockAgent: MockAgent;
-  let client: Client & Interceptable;
+describe('httpClient', () => {
+  let mockAgent: MockAgent
+  let client: Client & Interceptable
   beforeEach(() => {
-    mockAgent = new MockAgent();
-    mockAgent.disableNetConnect();
-    setGlobalDispatcher(mockAgent);
-    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable;
-  });
+    mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
+    setGlobalDispatcher(mockAgent)
+    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable
+  })
 
-  describe("buildClient", () => {
-    it("creates a client", () => {
-      const client = buildClient(baseUrl);
-      expect(client).toBeInstanceOf(Client);
-    });
-  });
+  describe('buildClient', () => {
+    it('creates a client', () => {
+      const client = buildClient(baseUrl)
+      expect(client).toBeInstanceOf(Client)
+    })
+  })
 
-  describe("GET", () => {
-    it("validates response structure with provided schema, throws an error", async () => {
+  describe('GET', () => {
+    it('validates response structure with provided schema, throws an error', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       await expect(
-        sendGet(client, "/products/1", {
+        sendGet(client, '/products/1', {
           responseSchema: schema,
           reqContext,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
         }),
-      ).rejects.toThrow(/Expected string, received number/);
-    });
+      ).rejects.toThrow(/Expected string, received number/)
+    })
 
-    it("validates response structure with provided schema, passes validation", async () => {
+    it('validates response structure with provided schema, passes validation', async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -84,384 +84,384 @@ describe("httpClient", () => {
           rate: z.number(),
         }),
         title: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: schema,
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         validateResponse: true,
-      });
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("validates response structure with provided schema, skips validation", async () => {
+    it('validates response structure with provided schema, skips validation', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: schema,
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
 
         validateResponse: false,
-      });
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("returns original payload when breaking during parsing and throw on error is true", async () => {
-      expect.assertions(1);
+    it('returns original payload when breaking during parsing and throw on error is true', async () => {
+      expect.assertions(1)
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
+        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
 
       try {
-        await sendGet(client, "/products/1", {
+        await sendGet(client, '/products/1', {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
           throwOnError: true,
           safeParseJson: true,
-          requestLabel: "label",
-        });
+          requestLabel: 'label',
+        })
       } catch (err) {
         // This is needed, because built-in error assertions do not assert nested fields
         // eslint-disable-next-line vitest/no-conditional-expect
         expect(err).toMatchObject({
-          message: "Error while parsing HTTP JSON response",
-          errorCode: "INVALID_HTTP_RESPONSE_JSON",
+          message: 'Error while parsing HTTP JSON response',
+          errorCode: 'INVALID_HTTP_RESPONSE_JSON',
           details: {
-            rawBody: "this is not a real json",
-            requestLabel: "label",
+            rawBody: 'this is not a real json',
+            requestLabel: 'label',
           },
-        });
+        })
       }
-    });
+    })
 
-    it("does not throw if broken during parsing but throwOnError is false", async () => {
-      expect.assertions(1);
+    it('does not throw if broken during parsing but throwOnError is false', async () => {
+      expect.assertions(1)
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
+        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         throwOnError: false,
         safeParseJson: true,
-        requestLabel: "label",
-      });
+        requestLabel: 'label',
+      })
 
       expect(result.error).toMatchObject({
-        message: "Error while parsing HTTP JSON response",
-        errorCode: "INVALID_HTTP_RESPONSE_JSON",
+        message: 'Error while parsing HTTP JSON response',
+        errorCode: 'INVALID_HTTP_RESPONSE_JSON',
         details: {
-          rawBody: "this is not a real json",
-          requestLabel: "label",
+          rawBody: 'this is not a real json',
+          requestLabel: 'label',
         },
-      });
-    });
+      })
+    })
 
-    it("GET without queryParams", async () => {
+    it('GET without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("GET returning text", async () => {
+    it('GET returning text', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "just text", {
+        .reply(200, 'just text', {
           headers: TEXT_HEADERS,
-        });
+        })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toBe("just text");
-    });
+      expect(result.result.body).toBe('just text')
+    })
 
-    it("GET returning text without content type", async () => {
+    it('GET returning text without content type', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "just text", {});
+        .reply(200, 'just text', {})
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toBe("just text");
-    });
+      expect(result.result.body).toBe('just text')
+    })
 
-    it("GET with queryParams", async () => {
+    it('GET with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS });
+        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products", {
+      const result = await sendGet(client, '/products', {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual(mockProductsLimit3);
-    });
+      expect(result.result.body).toEqual(mockProductsLimit3)
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendGet(client, "/products", {
+        sendGet(client, '/products', {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
+        message: 'connection error',
+      })
+    })
 
-    it("Throws an error with a label on internal error", async () => {
-      expect.assertions(2);
+    it('Throws an error with a label on internal error', async () => {
+      expect.assertions(2)
       const query = {
         limit: 3,
-      };
+      }
 
       try {
-        await sendGet(buildClient("http://127.0.0.1:999"), "/dummy", {
-          requestLabel: "label",
+        await sendGet(buildClient('http://127.0.0.1:999'), '/dummy', {
+          requestLabel: 'label',
           throwOnError: true,
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        });
+        })
       } catch (err) {
         if (!isInternalRequestError(err)) {
-          throw new Error("Invalid error type");
+          throw new Error('Invalid error type')
         }
-        expect(err.message).toBe("connect ECONNREFUSED 127.0.0.1:999");
-        expect(err.requestLabel).toBe("label");
+        expect(err.message).toBe('connect ECONNREFUSED 127.0.0.1:999')
+        expect(err.requestLabel).toBe('label')
       }
-    });
+    })
 
-    it("Returns error response", async () => {
-      expect.assertions(1);
+    it('Returns error response', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(400, "Invalid request");
+        .reply(400, 'Invalid request')
 
       await expect(
-        sendGet(client, "/products", {
+        sendGet(client, '/products', {
           query,
-          requestLabel: "label",
+          requestLabel: 'label',
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         }),
       ).rejects.toMatchObject({
-        message: "Response status code 400",
+        message: 'Response status code 400',
         response: {
-          body: "Invalid request",
+          body: 'Invalid request',
           statusCode: 400,
         },
         details: {
-          requestLabel: "label",
+          requestLabel: 'label',
           response: {
-            body: "Invalid request",
+            body: 'Invalid request',
             statusCode: 400,
           },
         },
-      });
-    });
+      })
+    })
 
-    it("Works with retry", async () => {
-      expect.assertions(1);
+    it('Works with retry', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(500, "Invalid request");
+        .reply(500, 'Invalid request')
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(200, "OK");
+        .reply(200, 'OK')
 
-      const response = await sendGet(client, "/products", {
+      const response = await sendGet(client, '/products', {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         retryConfig: {
           statusCodesToRetry: [500],
           retryOnTimeout: false,
           delayBetweenAttemptsInMsecs: 0,
           maxAttempts: 2,
         },
-      });
+      })
 
-      expect(response.result.body).toBe("OK");
-    });
-  });
+      expect(response.result.body).toBe('OK')
+    })
+  })
 
-  describe("DELETE", () => {
-    it("DELETE without queryParams", async () => {
+  describe('DELETE', () => {
+    it('DELETE without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "DELETE",
+          path: '/products/1',
+          method: 'DELETE',
         })
-        .reply(204, undefined);
+        .reply(204, undefined)
 
-      const result = await sendDelete(client, "/products/1", {
+      const result = await sendDelete(client, '/products/1', {
         reqContext,
         responseSchema: z.any(), // TODO
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("DELETE with queryParams", async () => {
+    it('DELETE with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "DELETE",
+          path: '/products',
+          method: 'DELETE',
           query,
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendDelete(client, "/products", {
+      const result = await sendDelete(client, '/products', {
         query,
         responseSchema: z.any(), // TODO
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "DELETE",
+          path: '/products',
+          method: 'DELETE',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendDelete(client, "/products", {
+        sendDelete(client, '/products', {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("POST", () => {
-    it("validates response structure with provided schema, throws an error", async () => {
+  describe('POST', () => {
+    it('validates response structure with provided schema, throws an error', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       await expect(
         sendPost(
           client,
-          "/products/1",
+          '/products/1',
           {},
           {
             responseSchema: schema,
             validateResponse: true,
-            requestLabel: "Test request",
+            requestLabel: 'Test request',
           },
         ),
       ).rejects.toThrow(`[
@@ -475,10 +475,10 @@ describe("httpClient", () => {
     "message": "Expected string, received number",
     "requestLabel": "Test request"
   }
-]`);
-    });
+]`)
+    })
 
-    it("validates response structure with provided schema, passes validation", async () => {
+    it('validates response structure with provided schema, passes validation', async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -490,175 +490,175 @@ describe("httpClient", () => {
           rate: z.number(),
         }),
         title: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       const result = await sendPost(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           reqContext,
         },
-      );
+      )
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("validates response structure with provided schema, skips validation", async () => {
+    it('validates response structure with provided schema, skips validation', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       const result = await sendPost(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: schema,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: false,
         },
-      );
+      )
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("POST without queryParams", async () => {
+    it('POST without queryParams', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPost(client, "/products", mockProduct1, {
+      const result = await sendPost(client, '/products', mockProduct1, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST without body", async () => {
+    it('POST without body', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPost(client, "/products", undefined, {
+      const result = await sendPost(client, '/products', undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST with queryParams", async () => {
+    it('POST with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPost(client, "/products", mockProduct1, {
+      const result = await sendPost(client, '/products', mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST that returns 400 throws an error", async () => {
+    it('POST that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPost(client, "/products", mockProduct1, {
+        sendPost(client, '/products', mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPost(client, "/products", undefined, {
+        sendPost(client, '/products', undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("POST binary", () => {
-    it("validates response structure with provided schema, throws an error", async () => {
+  describe('POST binary', () => {
+    it('validates response structure with provided schema, throws an error', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       await expect(
-        sendPostBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow(/Expected string, received number/);
-    });
+      ).rejects.toThrow(/Expected string, received number/)
+    })
 
-    it("validates response structure with provided schema, passes validation", async () => {
+    it('validates response structure with provided schema, passes validation', async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -670,436 +670,411 @@ describe("httpClient", () => {
           rate: z.number(),
         }),
         title: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendPostBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: schema,
-          validateResponse: true,
-          requestLabel: "dummy",
-          reqContext,
-        },
-      );
+      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: schema,
+        validateResponse: true,
+        requestLabel: 'dummy',
+        reqContext,
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("validates response structure with provided schema, skips validation", async () => {
+    it('validates response structure with provided schema, skips validation', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendPostBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: schema,
-          requestLabel: "dummy",
-          validateResponse: false,
-        },
-      );
+      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: schema,
+        requestLabel: 'dummy',
+        validateResponse: false,
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("POST without queryParams", async () => {
+    it('POST without queryParams', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
       const result = await sendPostBinary(
         client,
-        "/products",
+        '/products',
         Buffer.from(JSON.stringify(mockProduct1)),
         {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         },
-      );
+      )
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST with queryParams", async () => {
+    it('POST with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
       const result = await sendPostBinary(
         client,
-        "/products",
+        '/products',
         Buffer.from(JSON.stringify(mockProduct1)),
         {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         },
-      );
+      )
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST that returns 400 throws an error", async () => {
+    it('POST that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPostBinary(
-          client,
-          "/products",
-          Buffer.from(JSON.stringify(mockProduct1)),
-          {
-            responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-            requestLabel: "dummy",
-          },
-        ),
-      ).rejects.toThrow("Response status code 400");
-    });
+        sendPostBinary(client, '/products', Buffer.from(JSON.stringify(mockProduct1)), {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: 'dummy',
+        }),
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPostBinary(client, "/products", Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, '/products', Buffer.from(JSON.stringify({})), {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("PUT", () => {
-    it("PUT without queryParams", async () => {
+  describe('PUT', () => {
+    it('PUT without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPut(client, "/products/1", mockProduct1, {
+      const result = await sendPut(client, '/products/1', mockProduct1, {
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT without body", async () => {
+    it('PUT without body', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPut(client, "/products/1", undefined, {
+      const result = await sendPut(client, '/products/1', undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT with queryParams", async () => {
+    it('PUT with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPut(client, "/products/1", mockProduct1, {
+      const result = await sendPut(client, '/products/1', mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT that returns 400 throws an error", async () => {
+    it('PUT that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPut(client, "/products/1", mockProduct1, {
+        sendPut(client, '/products/1', mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "PUT",
+          path: '/products',
+          method: 'PUT',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPut(client, "/products", undefined, {
+        sendPut(client, '/products', undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
-        }),
-      ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
-
-  describe("PUT binary", () => {
-    it("PUT without queryParams", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "PUT",
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
-
-      const result = await sendPutBinary(
-        client,
-        "/products/1",
-        Buffer.from("text"),
-        {
-          reqContext,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
-        },
-      );
-
-      expect(result.result.body).toEqual({ id: 21 });
-    });
-
-    it("PUT with queryParams", async () => {
-      const query = {
-        limit: 3,
-      };
-
-      client
-        .intercept({
-          path: "/products/1",
-          method: "PUT",
-          query,
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
-
-      const result = await sendPutBinary(
-        client,
-        "/products/1",
-        Buffer.from("text"),
-        {
-          query,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
-        },
-      );
-
-      expect(result.result.body).toEqual({ id: 21 });
-    });
-
-    it("PUT that returns 400 throws an error", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "PUT",
-        })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
-
-      await expect(
-        sendPutBinary(client, "/products/1", Buffer.from("text"), {
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
-        }),
-      ).rejects.toThrow("Response status code 400");
-    });
-
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
-      const query = {
-        limit: 3,
-      };
-
-      client
-        .intercept({
-          path: "/products",
-          method: "PUT",
-          query,
-        })
-        .replyWithError(new Error("connection error"));
-
-      await expect(
-        sendPutBinary(client, "/products", null, {
-          query,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("PATCH", () => {
-    it("PATCH without queryParams", async () => {
+  describe('PUT binary', () => {
+    it('PUT without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPatch(client, "/products/1", mockProduct1, {
+      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
+        reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PATCH without body", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "PATCH",
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
-
-      const result = await sendPatch(client, "/products/1", undefined, {
-        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
-
-      expect(result.result.body).toEqual({ id: 21 });
-    });
-
-    it("PATCH with queryParams", async () => {
+    it('PUT with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PUT',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPatch(client, "/products/1", mockProduct1, {
+      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
+        query,
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: 'dummy',
+      })
+
+      expect(result.result.body).toEqual({ id: 21 })
+    })
+
+    it('PUT that returns 400 throws an error', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'PUT',
+        })
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
+
+      await expect(
+        sendPutBinary(client, '/products/1', Buffer.from('text'), {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: 'dummy',
+        }),
+      ).rejects.toThrow('Response status code 400')
+    })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'PUT',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendPutBinary(client, '/products', null, {
+          query,
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: 'dummy',
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
+    })
+  })
+
+  describe('PATCH', () => {
+    it('PATCH without queryParams', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'PATCH',
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+
+      const result = await sendPatch(client, '/products/1', mockProduct1, {
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: 'dummy',
+      })
+
+      expect(result.result.body).toEqual({ id: 21 })
+    })
+
+    it('PATCH without body', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'PATCH',
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+
+      const result = await sendPatch(client, '/products/1', undefined, {
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: 'dummy',
+      })
+
+      expect(result.result.body).toEqual({ id: 21 })
+    })
+
+    it('PATCH with queryParams', async () => {
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'PATCH',
+          query,
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
+
+      const result = await sendPatch(client, '/products/1', mockProduct1, {
         query,
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PATCH that returns 400 throws an error", async () => {
+    it('PATCH that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPatch(client, "/products/1", mockProduct1, {
+        sendPatch(client, '/products/1', mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "PATCH",
+          path: '/products',
+          method: 'PATCH',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPatch(client, "/products", undefined, {
+        sendPatch(client, '/products', undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
-});
+        message: 'connection error',
+      })
+    })
+  })
+})

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -1,10 +1,10 @@
-import type { Interceptable } from "undici";
-import { Client, MockAgent, setGlobalDispatcher } from "undici";
-import { isInternalRequestError } from "undici-retry";
-import { beforeEach, describe, expect, it } from "vitest";
-import { z } from "zod";
+import type { Interceptable } from 'undici'
+import { Client, MockAgent, setGlobalDispatcher } from 'undici'
+import { isInternalRequestError } from 'undici-retry'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
-import { JSON_HEADERS } from "./constants";
+import { JSON_HEADERS } from './constants'
 import {
   buildClient,
   sendDelete,
@@ -14,65 +14,65 @@ import {
   sendPostBinary,
   sendPut,
   sendPutBinary,
-} from "./httpClient";
+} from './httpClient'
 // @ts-ignore
-import mockProduct1 from "./mock-data/mockProduct1.json";
+import mockProduct1 from './mock-data/mockProduct1.json'
 // @ts-ignore
-import mockProductsLimit3 from "./mock-data/mockProductsLimit3.json";
-import type { HttpRequestContext } from "./types";
+import mockProductsLimit3 from './mock-data/mockProductsLimit3.json'
+import type { HttpRequestContext } from './types'
 
 const TEXT_HEADERS = {
-  "content-type": "text/plain",
-};
+  'content-type': 'text/plain',
+}
 
-const baseUrl = "https://fakestoreapi.com";
+const baseUrl = 'https://fakestoreapi.com'
 const reqContext: HttpRequestContext = {
-  reqId: "dummyId",
-};
+  reqId: 'dummyId',
+}
 
-const UNKNOWN_RESPONSE_SCHEMA = z.unknown();
+const UNKNOWN_RESPONSE_SCHEMA = z.unknown()
 
-describe("httpClient", () => {
-  let mockAgent: MockAgent;
-  let client: Client & Interceptable;
+describe('httpClient', () => {
+  let mockAgent: MockAgent
+  let client: Client & Interceptable
   beforeEach(() => {
-    mockAgent = new MockAgent();
-    mockAgent.disableNetConnect();
-    setGlobalDispatcher(mockAgent);
-    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable;
-  });
+    mockAgent = new MockAgent()
+    mockAgent.disableNetConnect()
+    setGlobalDispatcher(mockAgent)
+    client = mockAgent.get(baseUrl) as unknown as Client & Interceptable
+  })
 
-  describe("buildClient", () => {
-    it("creates a client", () => {
-      const client = buildClient(baseUrl);
-      expect(client).toBeInstanceOf(Client);
-    });
-  });
+  describe('buildClient', () => {
+    it('creates a client', () => {
+      const client = buildClient(baseUrl)
+      expect(client).toBeInstanceOf(Client)
+    })
+  })
 
-  describe("GET", () => {
-    it("validates response structure with provided schema, throws an error", async () => {
+  describe('GET', () => {
+    it('validates response structure with provided schema, throws an error', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       await expect(
-        sendGet(client, "/products/1", {
+        sendGet(client, '/products/1', {
           responseSchema: schema,
           reqContext,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
         }),
-      ).rejects.toThrow(/Expected string, received number/);
-    });
+      ).rejects.toThrow(/Expected string, received number/)
+    })
 
-    it("validates response structure with provided schema, passes validation", async () => {
+    it('validates response structure with provided schema, passes validation', async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -84,52 +84,52 @@ describe("httpClient", () => {
           rate: z.number(),
         }),
         title: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: schema,
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         validateResponse: true,
-      });
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
-    it("validates response structure with provided schema, skips validation", async () => {
+      expect(result.result.body).toEqual(mockProduct1)
+    })
+    it('validates response structure with provided schema, skips validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: z.number(),
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         validateResponse: true,
-      });
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("unexpected 204, with validation", async () => {
+    it('unexpected 204, with validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(204);
+        .reply(204)
 
       await expect(
-        sendGet(client, "/products/1", {
+        sendGet(client, '/products/1', {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
         }),
       ).rejects.toMatchInlineSnapshot(`
@@ -143,386 +143,386 @@ describe("httpClient", () => {
             "requestLabel": "dummy"
           }
         ]]
-      `);
-    });
+      `)
+    })
 
-    it("unexpected 204, without validation", async () => {
+    it('unexpected 204, without validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: z.number(),
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         validateResponse: false,
-      });
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("expected 204", async () => {
+    it('expected 204', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: z.number(),
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         isEmptyResponseExpected: true,
         validateResponse: true,
-      });
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBeNull();
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
+    })
 
-    it("returns original payload when breaking during parsing and throw on error is true", async () => {
-      expect.assertions(1);
+    it('returns original payload when breaking during parsing and throw on error is true', async () => {
+      expect.assertions(1)
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
+        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
 
       try {
-        await sendGet(client, "/products/1", {
+        await sendGet(client, '/products/1', {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
           throwOnError: true,
           safeParseJson: true,
-          requestLabel: "label",
-        });
+          requestLabel: 'label',
+        })
       } catch (err) {
         // This is needed, because built-in error assertions do not assert nested fields
         // eslint-disable-next-line vitest/no-conditional-expect
         expect(err).toMatchObject({
-          message: "Error while parsing HTTP JSON response",
-          errorCode: "INVALID_HTTP_RESPONSE_JSON",
+          message: 'Error while parsing HTTP JSON response',
+          errorCode: 'INVALID_HTTP_RESPONSE_JSON',
           details: {
-            rawBody: "this is not a real json",
-            requestLabel: "label",
+            rawBody: 'this is not a real json',
+            requestLabel: 'label',
           },
-        });
+        })
       }
-    });
+    })
 
-    it("does not throw if broken during parsing but throwOnError is false", async () => {
-      expect.assertions(1);
+    it('does not throw if broken during parsing but throwOnError is false', async () => {
+      expect.assertions(1)
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "this is not a real json", { headers: JSON_HEADERS });
+        .reply(200, 'this is not a real json', { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         throwOnError: false,
         safeParseJson: true,
-        requestLabel: "label",
-      });
+        requestLabel: 'label',
+      })
 
       expect(result.error).toMatchObject({
-        message: "Error while parsing HTTP JSON response",
-        errorCode: "INVALID_HTTP_RESPONSE_JSON",
+        message: 'Error while parsing HTTP JSON response',
+        errorCode: 'INVALID_HTTP_RESPONSE_JSON',
         details: {
-          rawBody: "this is not a real json",
-          requestLabel: "label",
+          rawBody: 'this is not a real json',
+          requestLabel: 'label',
         },
-      });
-    });
+      })
+    })
 
-    it("GET without queryParams", async () => {
+    it('GET without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("GET returning text", async () => {
+    it('GET returning text', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "just text", {
+        .reply(200, 'just text', {
           headers: TEXT_HEADERS,
-        });
+        })
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toBe("just text");
-    });
+      expect(result.result.body).toBe('just text')
+    })
 
-    it("GET returning text without content type", async () => {
+    it('GET returning text without content type', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "GET",
+          path: '/products/1',
+          method: 'GET',
         })
-        .reply(200, "just text", {});
+        .reply(200, 'just text', {})
 
-      const result = await sendGet(client, "/products/1", {
+      const result = await sendGet(client, '/products/1', {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toBe("just text");
-    });
+      expect(result.result.body).toBe('just text')
+    })
 
-    it("GET with queryParams", async () => {
+    it('GET with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS });
+        .reply(200, mockProductsLimit3, { headers: JSON_HEADERS })
 
-      const result = await sendGet(client, "/products", {
+      const result = await sendGet(client, '/products', {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual(mockProductsLimit3);
-    });
+      expect(result.result.body).toEqual(mockProductsLimit3)
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendGet(client, "/products", {
+        sendGet(client, '/products', {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
+        message: 'connection error',
+      })
+    })
 
-    it("Throws an error with a label on internal error", async () => {
-      expect.assertions(2);
+    it('Throws an error with a label on internal error', async () => {
+      expect.assertions(2)
       const query = {
         limit: 3,
-      };
+      }
 
       try {
-        await sendGet(buildClient("http://127.0.0.1:999"), "/dummy", {
-          requestLabel: "label",
+        await sendGet(buildClient('http://127.0.0.1:999'), '/dummy', {
+          requestLabel: 'label',
           throwOnError: true,
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        });
+        })
       } catch (err) {
         if (!isInternalRequestError(err)) {
-          throw new Error("Invalid error type");
+          throw new Error('Invalid error type')
         }
-        expect(err.message).toBe("connect ECONNREFUSED 127.0.0.1:999");
-        expect(err.requestLabel).toBe("label");
+        expect(err.message).toBe('connect ECONNREFUSED 127.0.0.1:999')
+        expect(err.requestLabel).toBe('label')
       }
-    });
+    })
 
-    it("Returns error response", async () => {
-      expect.assertions(1);
+    it('Returns error response', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(400, "Invalid request");
+        .reply(400, 'Invalid request')
 
       await expect(
-        sendGet(client, "/products", {
+        sendGet(client, '/products', {
           query,
-          requestLabel: "label",
+          requestLabel: 'label',
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
         }),
       ).rejects.toMatchObject({
-        message: "Response status code 400",
+        message: 'Response status code 400',
         response: {
-          body: "Invalid request",
+          body: 'Invalid request',
           statusCode: 400,
         },
         details: {
-          requestLabel: "label",
+          requestLabel: 'label',
           response: {
-            body: "Invalid request",
+            body: 'Invalid request',
             statusCode: 400,
           },
         },
-      });
-    });
+      })
+    })
 
-    it("Works with retry", async () => {
-      expect.assertions(1);
+    it('Works with retry', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(500, "Invalid request");
+        .reply(500, 'Invalid request')
       client
         .intercept({
-          path: "/products",
-          method: "GET",
+          path: '/products',
+          method: 'GET',
           query,
         })
-        .reply(200, "OK");
+        .reply(200, 'OK')
 
-      const response = await sendGet(client, "/products", {
+      const response = await sendGet(client, '/products', {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         retryConfig: {
           statusCodesToRetry: [500],
           retryOnTimeout: false,
           delayBetweenAttemptsInMsecs: 0,
           maxAttempts: 2,
         },
-      });
+      })
 
-      expect(response.result.body).toBe("OK");
-    });
-  });
+      expect(response.result.body).toBe('OK')
+    })
+  })
 
-  describe("DELETE", () => {
-    it("DELETE without queryParams", async () => {
+  describe('DELETE', () => {
+    it('DELETE without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "DELETE",
+          path: '/products/1',
+          method: 'DELETE',
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendDelete(client, "/products/1", {
+      const result = await sendDelete(client, '/products/1', {
         reqContext,
         responseSchema: z.number(), // should not check body
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         validateResponse: true,
-      });
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe(null);
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe(null)
+    })
 
-    it("DELETE with queryParams", async () => {
+    it('DELETE with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "DELETE",
+          path: '/products',
+          method: 'DELETE',
           query,
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendDelete(client, "/products", {
+      const result = await sendDelete(client, '/products', {
         query,
         responseSchema: z.any(),
-        requestLabel: "dummy",
+        requestLabel: 'dummy',
         isEmptyResponseExpected: false,
-      });
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "DELETE",
+          path: '/products',
+          method: 'DELETE',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendDelete(client, "/products", {
+        sendDelete(client, '/products', {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("POST", () => {
-    it("validates response structure with provided schema, throws an error", async () => {
+  describe('POST', () => {
+    it('validates response structure with provided schema, throws an error', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       await expect(
         sendPost(
           client,
-          "/products/1",
+          '/products/1',
           {},
           {
             responseSchema: schema,
             validateResponse: true,
-            requestLabel: "Test request",
+            requestLabel: 'Test request',
           },
         ),
       ).rejects.toThrow(`[
@@ -536,10 +536,10 @@ describe("httpClient", () => {
     "message": "Expected string, received number",
     "requestLabel": "Test request"
   }
-]`);
-    });
+]`)
+    })
 
-    it("validates response structure with provided schema, passes validation", async () => {
+    it('validates response structure with provided schema, passes validation', async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -551,72 +551,72 @@ describe("httpClient", () => {
           rate: z.number(),
         }),
         title: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       const result = await sendPost(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           reqContext,
         },
-      );
+      )
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("validates response structure with provided schema, skips validation", async () => {
+    it('validates response structure with provided schema, skips validation', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       const result = await sendPost(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: schema,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: false,
         },
-      );
+      )
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("unexpected 204, with validation", async () => {
+    it('unexpected 204, with validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(204);
+        .reply(204)
 
       await expect(
         sendPost(
           client,
-          "/products/1",
+          '/products/1',
           {},
           {
             responseSchema: z.number(),
-            requestLabel: "dummy",
+            requestLabel: 'dummy',
             validateResponse: true,
             isEmptyResponseExpected: false,
           },
@@ -632,175 +632,175 @@ describe("httpClient", () => {
             "requestLabel": "dummy"
           }
         ]]
-      `);
-    });
+      `)
+    })
 
-    it("unexpected 204, without validation", async () => {
+    it('unexpected 204, without validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(204);
+        .reply(204)
 
       const result = await sendPost(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: false,
           isEmptyResponseExpected: false,
         },
-      );
+      )
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("expected 204", async () => {
+    it('expected 204', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(204);
+        .reply(204)
 
       const result = await sendPost(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
         },
-      );
+      )
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBeNull();
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
+    })
 
-    it("POST without queryParams", async () => {
+    it('POST without queryParams', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPost(client, "/products", mockProduct1, {
+      const result = await sendPost(client, '/products', mockProduct1, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST without body", async () => {
+    it('POST without body', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPost(client, "/products", undefined, {
+      const result = await sendPost(client, '/products', undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST with queryParams", async () => {
+    it('POST with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPost(client, "/products", mockProduct1, {
+      const result = await sendPost(client, '/products', mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST that returns 400 throws an error", async () => {
+    it('POST that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPost(client, "/products", mockProduct1, {
+        sendPost(client, '/products', mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPost(client, "/products", undefined, {
+        sendPost(client, '/products', undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("POST binary", () => {
-    it("validates response structure with provided schema, throws an error", async () => {
+  describe('POST binary', () => {
+    it('validates response structure with provided schema, throws an error', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
       await expect(
-        sendPostBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
           responseSchema: schema,
           validateResponse: true,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow(/Expected string, received number/);
-    });
+      ).rejects.toThrow(/Expected string, received number/)
+    })
 
-    it("validates response structure with provided schema, passes validation", async () => {
+    it('validates response structure with provided schema, passes validation', async () => {
       const schema = z.object({
         category: z.string(),
         description: z.string(),
@@ -812,68 +812,58 @@ describe("httpClient", () => {
           rate: z.number(),
         }),
         title: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendPostBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: schema,
-          validateResponse: true,
-          requestLabel: "dummy",
-          reqContext,
-        },
-      );
+      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: schema,
+        validateResponse: true,
+        requestLabel: 'dummy',
+        reqContext,
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("validates response structure with provided schema, skips validation", async () => {
+    it('validates response structure with provided schema, skips validation', async () => {
       const schema = z.object({
         id: z.string(),
-      });
+      })
 
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(200, mockProduct1, { headers: JSON_HEADERS });
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
 
-      const result = await sendPostBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: schema,
-          requestLabel: "dummy",
-          validateResponse: false,
-        },
-      );
+      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: schema,
+        requestLabel: 'dummy',
+        validateResponse: false,
+      })
 
-      expect(result.result.body).toEqual(mockProduct1);
-    });
+      expect(result.result.body).toEqual(mockProduct1)
+    })
 
-    it("unexpected 204, with validation", async () => {
+    it('unexpected 204, with validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(204);
+        .reply(204)
 
       await expect(
-        sendPostBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
           isEmptyResponseExpected: false,
         }),
@@ -888,264 +878,249 @@ describe("httpClient", () => {
             "requestLabel": "dummy"
           }
         ]]
-      `);
-    });
+      `)
+    })
 
-    it("unexpected 204, without validation", async () => {
+    it('unexpected 204, without validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "POST",
+          path: '/products/1',
+          method: 'POST',
         })
-        .reply(204);
+        .reply(204)
+
+      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: z.number(),
+        requestLabel: 'dummy',
+        validateResponse: false,
+        isEmptyResponseExpected: false,
+      })
+
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
+
+    it('expected 204', async () => {
+      client
+        .intercept({
+          path: '/products/1',
+          method: 'POST',
+        })
+        .reply(204)
+
+      const result = await sendPostBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: z.number(),
+        requestLabel: 'dummy',
+        validateResponse: true,
+      })
+
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
+    })
+
+    it('POST without queryParams', async () => {
+      client
+        .intercept({
+          path: '/products',
+          method: 'POST',
+        })
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
       const result = await sendPostBinary(
         client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: z.number(),
-          requestLabel: "dummy",
-          validateResponse: false,
-          isEmptyResponseExpected: false,
-        },
-      );
-
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
-
-    it("expected 204", async () => {
-      client
-        .intercept({
-          path: "/products/1",
-          method: "POST",
-        })
-        .reply(204);
-
-      const result = await sendPostBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: z.number(),
-          requestLabel: "dummy",
-          validateResponse: true,
-        },
-      );
-
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBeNull();
-    });
-
-    it("POST without queryParams", async () => {
-      client
-        .intercept({
-          path: "/products",
-          method: "POST",
-        })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
-
-      const result = await sendPostBinary(
-        client,
-        "/products",
+        '/products',
         Buffer.from(JSON.stringify(mockProduct1)),
         {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         },
-      );
+      )
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST with queryParams", async () => {
+    it('POST with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
       const result = await sendPostBinary(
         client,
-        "/products",
+        '/products',
         Buffer.from(JSON.stringify(mockProduct1)),
         {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         },
-      );
+      )
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("POST that returns 400 throws an error", async () => {
+    it('POST that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPostBinary(
-          client,
-          "/products",
-          Buffer.from(JSON.stringify(mockProduct1)),
-          {
-            responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-            requestLabel: "dummy",
-          },
-        ),
-      ).rejects.toThrow("Response status code 400");
-    });
+        sendPostBinary(client, '/products', Buffer.from(JSON.stringify(mockProduct1)), {
+          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+          requestLabel: 'dummy',
+        }),
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "POST",
+          path: '/products',
+          method: 'POST',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPostBinary(client, "/products", Buffer.from(JSON.stringify({})), {
+        sendPostBinary(client, '/products', Buffer.from(JSON.stringify({})), {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
-  });
+        message: 'connection error',
+      })
+    })
+  })
 
-  describe("PUT", () => {
-    it("PUT without queryParams", async () => {
+  describe('PUT', () => {
+    it('PUT without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPut(client, "/products/1", mockProduct1, {
+      const result = await sendPut(client, '/products/1', mockProduct1, {
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT without body", async () => {
+    it('PUT without body', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPut(client, "/products/1", undefined, {
+      const result = await sendPut(client, '/products/1', undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT with queryParams", async () => {
+    it('PUT with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPut(client, "/products/1", mockProduct1, {
+      const result = await sendPut(client, '/products/1', mockProduct1, {
         query,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT that returns 400 throws an error", async () => {
+    it('PUT that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPut(client, "/products/1", mockProduct1, {
+        sendPut(client, '/products/1', mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "PUT",
+          path: '/products',
+          method: 'PUT',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPut(client, "/products", undefined, {
+        sendPut(client, '/products', undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
+        message: 'connection error',
+      })
+    })
 
-    it("unexpected 204, with validation", async () => {
+    it('unexpected 204, with validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(204);
+        .reply(204)
 
       await expect(
         sendPut(
           client,
-          "/products/1",
+          '/products/1',
           {},
           {
             responseSchema: z.number(),
-            requestLabel: "dummy",
+            requestLabel: 'dummy',
             validateResponse: true,
             isEmptyResponseExpected: false,
           },
@@ -1161,160 +1136,150 @@ describe("httpClient", () => {
             "requestLabel": "dummy"
           }
         ]]
-      `);
-    });
+      `)
+    })
 
-    it("unexpected 204, without validation", async () => {
+    it('unexpected 204, without validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(204);
+        .reply(204)
 
       const result = await sendPut(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: false,
           isEmptyResponseExpected: false,
         },
-      );
+      )
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("expected 204", async () => {
+    it('expected 204', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(204);
+        .reply(204)
 
       const result = await sendPut(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
         },
-      );
+      )
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBeNull();
-    });
-  });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
+    })
+  })
 
-  describe("PUT binary", () => {
-    it("PUT without queryParams", async () => {
+  describe('PUT binary', () => {
+    it('PUT without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPutBinary(
-        client,
-        "/products/1",
-        Buffer.from("text"),
-        {
-          reqContext,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
-        },
-      );
+      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
+        reqContext,
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT with queryParams", async () => {
+    it('PUT with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPutBinary(
-        client,
-        "/products/1",
-        Buffer.from("text"),
-        {
-          query,
-          responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
-        },
-      );
+      const result = await sendPutBinary(client, '/products/1', Buffer.from('text'), {
+        query,
+        responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PUT that returns 400 throws an error", async () => {
+    it('PUT that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPutBinary(client, "/products/1", Buffer.from("text"), {
+        sendPutBinary(client, '/products/1', Buffer.from('text'), {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "PUT",
+          path: '/products',
+          method: 'PUT',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPutBinary(client, "/products", null, {
+        sendPutBinary(client, '/products', null, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
+        message: 'connection error',
+      })
+    })
 
-    it("unexpected 204, with validation", async () => {
+    it('unexpected 204, with validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(204);
+        .reply(204)
 
       await expect(
-        sendPutBinary(client, "/products/1", Buffer.from(JSON.stringify({})), {
+        sendPutBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
           isEmptyResponseExpected: false,
         }),
@@ -1329,170 +1294,160 @@ describe("httpClient", () => {
             "requestLabel": "dummy"
           }
         ]]
-      `);
-    });
+      `)
+    })
 
-    it("unexpected 204, without validation", async () => {
+    it('unexpected 204, without validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendPutBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: z.number(),
-          requestLabel: "dummy",
-          validateResponse: false,
-          isEmptyResponseExpected: false,
-        },
-      );
+      const result = await sendPutBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: z.number(),
+        requestLabel: 'dummy',
+        validateResponse: false,
+        isEmptyResponseExpected: false,
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("expected 204", async () => {
+    it('expected 204', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PUT",
+          path: '/products/1',
+          method: 'PUT',
         })
-        .reply(204);
+        .reply(204)
 
-      const result = await sendPutBinary(
-        client,
-        "/products/1",
-        Buffer.from(JSON.stringify({})),
-        {
-          responseSchema: z.number(),
-          requestLabel: "dummy",
-          validateResponse: true,
-        },
-      );
+      const result = await sendPutBinary(client, '/products/1', Buffer.from(JSON.stringify({})), {
+        responseSchema: z.number(),
+        requestLabel: 'dummy',
+        validateResponse: true,
+      })
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBeNull();
-    });
-  });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
+    })
+  })
 
-  describe("PATCH", () => {
-    it("PATCH without queryParams", async () => {
+  describe('PATCH', () => {
+    it('PATCH without queryParams', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPatch(client, "/products/1", mockProduct1, {
+      const result = await sendPatch(client, '/products/1', mockProduct1, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PATCH without body", async () => {
+    it('PATCH without body', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPatch(client, "/products/1", undefined, {
+      const result = await sendPatch(client, '/products/1', undefined, {
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PATCH with queryParams", async () => {
+    it('PATCH with queryParams', async () => {
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
           query,
         })
-        .reply(200, { id: 21 }, { headers: JSON_HEADERS });
+        .reply(200, { id: 21 }, { headers: JSON_HEADERS })
 
-      const result = await sendPatch(client, "/products/1", mockProduct1, {
+      const result = await sendPatch(client, '/products/1', mockProduct1, {
         query,
         reqContext,
         responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-        requestLabel: "dummy",
-      });
+        requestLabel: 'dummy',
+      })
 
-      expect(result.result.body).toEqual({ id: 21 });
-    });
+      expect(result.result.body).toEqual({ id: 21 })
+    })
 
-    it("PATCH that returns 400 throws an error", async () => {
+    it('PATCH that returns 400 throws an error', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(400, { errorCode: "err" }, { headers: JSON_HEADERS });
+        .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(
-        sendPatch(client, "/products/1", mockProduct1, {
+        sendPatch(client, '/products/1', mockProduct1, {
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
-      ).rejects.toThrow("Response status code 400");
-    });
+      ).rejects.toThrow('Response status code 400')
+    })
 
-    it("Throws an error on internal error", async () => {
-      expect.assertions(1);
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
       const query = {
         limit: 3,
-      };
+      }
 
       client
         .intercept({
-          path: "/products",
-          method: "PATCH",
+          path: '/products',
+          method: 'PATCH',
           query,
         })
-        .replyWithError(new Error("connection error"));
+        .replyWithError(new Error('connection error'))
 
       await expect(
-        sendPatch(client, "/products", undefined, {
+        sendPatch(client, '/products', undefined, {
           query,
           responseSchema: UNKNOWN_RESPONSE_SCHEMA,
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
         }),
       ).rejects.toMatchObject({
-        message: "connection error",
-      });
-    });
+        message: 'connection error',
+      })
+    })
 
-    it("unexpected 204, with validation", async () => {
+    it('unexpected 204, with validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(204);
+        .reply(204)
 
       await expect(
         sendPatch(
           client,
-          "/products/1",
+          '/products/1',
           {},
           {
             responseSchema: z.number(),
-            requestLabel: "dummy",
+            requestLabel: 'dummy',
             validateResponse: true,
             isEmptyResponseExpected: false,
           },
@@ -1508,54 +1463,54 @@ describe("httpClient", () => {
             "requestLabel": "dummy"
           }
         ]]
-      `);
-    });
+      `)
+    })
 
-    it("unexpected 204, without validation", async () => {
+    it('unexpected 204, without validation', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(204);
+        .reply(204)
 
       const result = await sendPatch(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: false,
           isEmptyResponseExpected: false,
         },
-      );
+      )
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBe("");
-    });
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
+    })
 
-    it("expected 204", async () => {
+    it('expected 204', async () => {
       client
         .intercept({
-          path: "/products/1",
-          method: "PATCH",
+          path: '/products/1',
+          method: 'PATCH',
         })
-        .reply(204);
+        .reply(204)
 
       const result = await sendPatch(
         client,
-        "/products/1",
+        '/products/1',
         {},
         {
           responseSchema: z.number(),
-          requestLabel: "dummy",
+          requestLabel: 'dummy',
           validateResponse: true,
         },
-      );
+      )
 
-      expect(result.result.statusCode).toBe(204);
-      expect(result.result.body).toBeNull();
-    });
-  });
-});
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBeNull()
+    })
+  })
+})

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -1,7 +1,6 @@
 import type { Readable } from "node:stream";
 
 import { copyWithoutUndefined } from "@lokalise/node-core";
-import type { DefiniteEither } from "@lokalise/node-core";
 import { Client } from "undici";
 import type { FormData } from "undici";
 import { NO_RETRY_CONFIG, isRequestResult, sendWithRetry } from "undici-retry";
@@ -63,8 +62,6 @@ export async function sendGet<
     resolveRequestConfig(options),
   );
 
-  return {} as any;
-  /*
   return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
@@ -73,14 +70,16 @@ export async function sendGet<
     options.requestLabel,
     options.isEmptyResponseExpected ?? false,
   );
-  */
 }
 
-export async function sendDelete<T>(
+export async function sendDelete<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+>(
   client: Client,
   path: string,
-  options: RequestOptions<T>,
-): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
+  options: RequestOptions<T, IsEmptyResponseExpected>,
+): Promise<RequestResultDefinitiveEither<T, IsEmptyResponseExpected>> {
   const result = await sendWithRetry<T>(
     client,
     {
@@ -104,24 +103,26 @@ export async function sendDelete<T>(
     resolveRetryConfig(options),
     resolveRequestConfig(options),
   );
-  return { result: {} } as any;
-  /*
+
   return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
+    options.isEmptyResponseExpected ?? true,
   );
-     */
 }
 
-export async function sendPost<T>(
+export async function sendPost<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
-  options: RequestOptions<T>,
-): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
+  options: RequestOptions<T, IsEmptyResponseExpected>,
+): Promise<RequestResultDefinitiveEither<T, IsEmptyResponseExpected>> {
   const result = await sendWithRetry<T>(
     client,
     {
@@ -147,24 +148,25 @@ export async function sendPost<T>(
     resolveRequestConfig(options),
   );
 
-  return { result: {} } as any;
-  /*
   return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
+    options.isEmptyResponseExpected ?? true,
   );
-     */
 }
 
-export async function sendPostBinary<T>(
+export async function sendPostBinary<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | FormData | null,
-  options: RequestOptions<T>,
-): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
+  options: RequestOptions<T, IsEmptyResponseExpected>,
+): Promise<RequestResultDefinitiveEither<T, IsEmptyResponseExpected>> {
   const result = await sendWithRetry<T>(
     client,
     {
@@ -189,24 +191,26 @@ export async function sendPostBinary<T>(
     resolveRetryConfig(options),
     resolveRequestConfig(options),
   );
-  return { result: {} } as any;
-  /*
+
   return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
+    options.isEmptyResponseExpected ?? true,
   );
-   */
 }
 
-export async function sendPut<T>(
+export async function sendPut<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
-  options: RequestOptions<T>,
-): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
+  options: RequestOptions<T, IsEmptyResponseExpected>,
+): Promise<RequestResultDefinitiveEither<T, IsEmptyResponseExpected>> {
   const result = await sendWithRetry<T>(
     client,
     {
@@ -231,24 +235,26 @@ export async function sendPut<T>(
     resolveRetryConfig(options),
     resolveRequestConfig(options),
   );
-  return { result: {} } as any;
-  /*
+
   return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
+    options.isEmptyResponseExpected ?? true,
   );
-  */
 }
 
-export async function sendPutBinary<T>(
+export async function sendPutBinary<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | FormData | null,
-  options: RequestOptions<T>,
-): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
+  options: RequestOptions<T, IsEmptyResponseExpected>,
+): Promise<RequestResultDefinitiveEither<T, IsEmptyResponseExpected>> {
   const result = await sendWithRetry<T>(
     client,
     {
@@ -274,23 +280,25 @@ export async function sendPutBinary<T>(
     resolveRequestConfig(options),
   );
 
-  return { result: {} } as any;
-  /*
   return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-  );*/
+    options.isEmptyResponseExpected ?? true,
+  );
 }
 
-export async function sendPatch<T>(
+export async function sendPatch<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
-  options: RequestOptions<T>,
-): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
+  options: RequestOptions<T, IsEmptyResponseExpected>,
+): Promise<RequestResultDefinitiveEither<T, IsEmptyResponseExpected>> {
   const result = await sendWithRetry<T>(
     client,
     {
@@ -315,15 +323,15 @@ export async function sendPatch<T>(
     resolveRetryConfig(options),
     resolveRequestConfig(options),
   );
-  return { result: {} } as any;
 
-  /*return resolveResult(
+  return resolveResult(
     result,
     options.throwOnError ?? DEFAULT_OPTIONS.throwOnError,
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-  );*/
+    options.isEmptyResponseExpected ?? true,
+  );
 }
 
 function resolveRequestConfig(

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -73,7 +73,7 @@ export async function sendGet<
 
 export async function sendDelete<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   client: Client,
   path: string,
@@ -115,7 +115,7 @@ export async function sendDelete<
 
 export async function sendPost<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   client: Client,
   path: string,
@@ -159,7 +159,7 @@ export async function sendPost<
 
 export async function sendPostBinary<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   client: Client,
   path: string,
@@ -203,7 +203,7 @@ export async function sendPostBinary<
 
 export async function sendPut<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   client: Client,
   path: string,
@@ -247,7 +247,7 @@ export async function sendPut<
 
 export async function sendPutBinary<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   client: Client,
   path: string,
@@ -291,7 +291,7 @@ export async function sendPutBinary<
 
 export async function sendPatch<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   client: Client,
   path: string,

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -99,7 +99,7 @@ export async function sendDelete<T, IsEmptyResponseExpected extends boolean = tr
   )
 }
 
-export async function sendPost<T, IsEmptyResponseExpected extends boolean = true>(
+export async function sendPost<T, IsEmptyResponseExpected extends boolean = false>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
@@ -132,11 +132,11 @@ export async function sendPost<T, IsEmptyResponseExpected extends boolean = true
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-    options.isEmptyResponseExpected ?? true,
+    options.isEmptyResponseExpected ?? false,
   )
 }
 
-export async function sendPostBinary<T, IsEmptyResponseExpected extends boolean = true>(
+export async function sendPostBinary<T, IsEmptyResponseExpected extends boolean = false>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | FormData | null,
@@ -169,11 +169,11 @@ export async function sendPostBinary<T, IsEmptyResponseExpected extends boolean 
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-    options.isEmptyResponseExpected ?? true,
+    options.isEmptyResponseExpected ?? false,
   )
 }
 
-export async function sendPut<T, IsEmptyResponseExpected extends boolean = true>(
+export async function sendPut<T, IsEmptyResponseExpected extends boolean = false>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
@@ -206,11 +206,11 @@ export async function sendPut<T, IsEmptyResponseExpected extends boolean = true>
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-    options.isEmptyResponseExpected ?? true,
+    options.isEmptyResponseExpected ?? false,
   )
 }
 
-export async function sendPutBinary<T, IsEmptyResponseExpected extends boolean = true>(
+export async function sendPutBinary<T, IsEmptyResponseExpected extends boolean = false>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | FormData | null,
@@ -243,11 +243,11 @@ export async function sendPutBinary<T, IsEmptyResponseExpected extends boolean =
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-    options.isEmptyResponseExpected ?? true,
+    options.isEmptyResponseExpected ?? false,
   )
 }
 
-export async function sendPatch<T, IsEmptyResponseExpected extends boolean = true>(
+export async function sendPatch<T, IsEmptyResponseExpected extends boolean = false>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
@@ -280,7 +280,7 @@ export async function sendPatch<T, IsEmptyResponseExpected extends boolean = tru
     options.validateResponse ?? DEFAULT_OPTIONS.validateResponse,
     options.responseSchema,
     options.requestLabel,
-    options.isEmptyResponseExpected ?? true,
+    options.isEmptyResponseExpected ?? false,
   )
 }
 

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -11,7 +11,7 @@ import type {
   RequestResult,
   RetryConfig,
 } from "undici-retry";
-import { type ZodError } from "zod";
+import { type ZodError, ZodSchema } from "zod";
 
 import { ResponseStatusError } from "../errors/ResponseStatusError";
 import {
@@ -19,7 +19,6 @@ import {
   RecordObject,
   RequestOptions,
   RequestResultDefinitiveEither,
-  ResponseSchema,
 } from "./types";
 import { DEFAULT_OPTIONS, defaultClientOptions } from "./constants";
 
@@ -358,7 +357,7 @@ function resolveResult<T, IsEmptyResponseExpected extends boolean>(
   >,
   throwOnError: boolean,
   validateResponse: boolean,
-  validationSchema: ResponseSchema,
+  validationSchema: ZodSchema<T>,
   requestLabel: string,
   isEmptyResponseExpected: boolean,
 ): RequestResultDefinitiveEither<T, IsEmptyResponseExpected> {

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -1,38 +1,35 @@
-import type { Readable } from "node:stream";
+import type { Readable } from 'node:stream'
 
-import { copyWithoutUndefined } from "@lokalise/node-core";
-import { Client } from "undici";
-import type { FormData } from "undici";
-import { NO_RETRY_CONFIG, isRequestResult, sendWithRetry } from "undici-retry";
+import { copyWithoutUndefined } from '@lokalise/node-core'
+import { Client } from 'undici'
+import type { FormData } from 'undici'
+import { NO_RETRY_CONFIG, isRequestResult, sendWithRetry } from 'undici-retry'
 import type {
   Either,
   InternalRequestError,
   RequestParams,
   RequestResult,
   RetryConfig,
-} from "undici-retry";
-import type { ZodError, ZodSchema } from "zod";
+} from 'undici-retry'
+import type { ZodError, ZodSchema } from 'zod'
 
-import { ResponseStatusError } from "../errors/ResponseStatusError";
-import { DEFAULT_OPTIONS, defaultClientOptions } from "./constants";
+import { ResponseStatusError } from '../errors/ResponseStatusError'
+import { DEFAULT_OPTIONS, defaultClientOptions } from './constants'
 import type {
   InternalRequestOptions,
   RecordObject,
   RequestOptions,
   RequestResultDefinitiveEither,
-} from "./types";
+} from './types'
 
 export function buildClient(baseUrl: string, clientOptions?: Client.Options) {
   return new Client(baseUrl, {
     ...defaultClientOptions,
     ...clientOptions,
-  });
+  })
 }
 
-export async function sendGet<
-  T,
-  IsEmptyResponseExpected extends boolean = false,
->(
+export async function sendGet<T, IsEmptyResponseExpected extends boolean = false>(
   client: Client,
   path: string,
   options: RequestOptions<T, IsEmptyResponseExpected>,
@@ -42,24 +39,20 @@ export async function sendGet<
     {
       ...DEFAULT_OPTIONS,
       path: path,
-      method: "GET",
+      method: 'GET',
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -68,13 +61,10 @@ export async function sendGet<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? false,
-  );
+  )
 }
 
-export async function sendDelete<
-  T,
-  IsEmptyResponseExpected extends boolean = true,
->(
+export async function sendDelete<T, IsEmptyResponseExpected extends boolean = true>(
   client: Client,
   path: string,
   options: RequestOptions<T, IsEmptyResponseExpected>,
@@ -84,24 +74,20 @@ export async function sendDelete<
     {
       ...DEFAULT_OPTIONS,
       path,
-      method: "DELETE",
+      method: 'DELETE',
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -110,13 +96,10 @@ export async function sendDelete<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? true,
-  );
+  )
 }
 
-export async function sendPost<
-  T,
-  IsEmptyResponseExpected extends boolean = true,
->(
+export async function sendPost<T, IsEmptyResponseExpected extends boolean = true>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
@@ -127,25 +110,21 @@ export async function sendPost<
     {
       ...DEFAULT_OPTIONS,
       path: path,
-      method: "POST",
+      method: 'POST',
       body: body ? JSON.stringify(body) : undefined,
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -154,13 +133,10 @@ export async function sendPost<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? true,
-  );
+  )
 }
 
-export async function sendPostBinary<
-  T,
-  IsEmptyResponseExpected extends boolean = true,
->(
+export async function sendPostBinary<T, IsEmptyResponseExpected extends boolean = true>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | FormData | null,
@@ -171,25 +147,21 @@ export async function sendPostBinary<
     {
       ...DEFAULT_OPTIONS,
       path: path,
-      method: "POST",
+      method: 'POST',
       body,
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -198,13 +170,10 @@ export async function sendPostBinary<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? true,
-  );
+  )
 }
 
-export async function sendPut<
-  T,
-  IsEmptyResponseExpected extends boolean = true,
->(
+export async function sendPut<T, IsEmptyResponseExpected extends boolean = true>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
@@ -215,25 +184,21 @@ export async function sendPut<
     {
       ...DEFAULT_OPTIONS,
       path: path,
-      method: "PUT",
+      method: 'PUT',
       body: body ? JSON.stringify(body) : undefined,
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -242,13 +207,10 @@ export async function sendPut<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? true,
-  );
+  )
 }
 
-export async function sendPutBinary<
-  T,
-  IsEmptyResponseExpected extends boolean = true,
->(
+export async function sendPutBinary<T, IsEmptyResponseExpected extends boolean = true>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | FormData | null,
@@ -259,25 +221,21 @@ export async function sendPutBinary<
     {
       ...DEFAULT_OPTIONS,
       path: path,
-      method: "PUT",
+      method: 'PUT',
       body,
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -286,13 +244,10 @@ export async function sendPutBinary<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? true,
-  );
+  )
 }
 
-export async function sendPatch<
-  T,
-  IsEmptyResponseExpected extends boolean = true,
->(
+export async function sendPatch<T, IsEmptyResponseExpected extends boolean = true>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
@@ -303,25 +258,21 @@ export async function sendPatch<
     {
       ...DEFAULT_OPTIONS,
       path: path,
-      method: "PATCH",
+      method: 'PATCH',
       body: body ? JSON.stringify(body) : undefined,
       query: options.query,
       headers: copyWithoutUndefined({
-        "x-request-id": options.reqContext?.reqId,
+        'x-request-id': options.reqContext?.reqId,
         ...options.headers,
       }),
       reset: options.disableKeepAlive ?? false,
-      bodyTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
-      headersTimeout: Object.hasOwn(options, "timeout")
-        ? options.timeout
-        : DEFAULT_OPTIONS.timeout,
+      bodyTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
+      headersTimeout: Object.hasOwn(options, 'timeout') ? options.timeout : DEFAULT_OPTIONS.timeout,
       throwOnError: false,
     },
     resolveRetryConfig(options),
     resolveRequestConfig(options),
-  );
+  )
 
   return resolveResult(
     result,
@@ -330,31 +281,24 @@ export async function sendPatch<
     options.responseSchema,
     options.requestLabel,
     options.isEmptyResponseExpected ?? true,
-  );
+  )
 }
 
-function resolveRequestConfig(
-  options: InternalRequestOptions<unknown>,
-): RequestParams {
+function resolveRequestConfig(options: InternalRequestOptions<unknown>): RequestParams {
   return {
     safeParseJson: options.safeParseJson ?? false,
     blobBody: options.blobResponseBody ?? false,
     throwOnInternalError: false,
     requestLabel: options.requestLabel,
-  };
+  }
 }
 
-function resolveRetryConfig(
-  options: InternalRequestOptions<unknown>,
-): RetryConfig {
-  return options.retryConfig ?? NO_RETRY_CONFIG;
+function resolveRetryConfig(options: InternalRequestOptions<unknown>): RetryConfig {
+  return options.retryConfig ?? NO_RETRY_CONFIG
 }
 
 function resolveResult<T, IsEmptyResponseExpected extends boolean>(
-  requestResult: Either<
-    RequestResult<unknown> | InternalRequestError,
-    RequestResult<T>
-  >,
+  requestResult: Either<RequestResult<unknown> | InternalRequestError, RequestResult<T>>,
   throwOnError: boolean,
   validateResponse: boolean,
   validationSchema: ZodSchema<T>,
@@ -365,7 +309,7 @@ function resolveResult<T, IsEmptyResponseExpected extends boolean>(
   if (requestResult.error && throwOnError) {
     throw isRequestResult(requestResult.error)
       ? new ResponseStatusError(requestResult.error, requestLabel)
-      : requestResult.error;
+      : requestResult.error
   }
 
   if (requestResult.result) {
@@ -375,13 +319,10 @@ function resolveResult<T, IsEmptyResponseExpected extends boolean>(
       validationSchema,
       requestLabel,
       isEmptyResponseExpected,
-    );
+    )
   }
 
-  return requestResult as RequestResultDefinitiveEither<
-    T,
-    IsEmptyResponseExpected
-  >;
+  return requestResult as RequestResultDefinitiveEither<T, IsEmptyResponseExpected>
 }
 
 function handleRequestResultSuccess<T>(
@@ -393,25 +334,25 @@ function handleRequestResultSuccess<T>(
 ) {
   if (result.statusCode === 204 && isEmptyResponseExpected) {
     // @ts-ignore
-    result.body = null;
-    return result;
+    result.body = null
+    return result
   }
 
   if (validateResponse) {
     try {
-      result.body = validationSchema.parse(result.body);
+      result.body = validationSchema.parse(result.body)
     } catch (err: unknown) {
       for (const issue of (err as ZodError).issues) {
         // @ts-ignore
-        issue.requestLabel = requestLabel;
+        issue.requestLabel = requestLabel
       }
       // @ts-ignore
-      err.requestLabel = requestLabel;
-      throw err;
+      err.requestLabel = requestLabel
+      throw err
     }
   }
 
-  return result;
+  return result
 }
 
 export const httpClient = {
@@ -420,4 +361,4 @@ export const httpClient = {
   put: sendPut,
   patch: sendPatch,
   del: sendDelete,
-};
+}

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -1,39 +1,39 @@
-import type { Client } from "undici";
-import type { RequestResult, RetryConfig } from "undici-retry";
-import type { DefiniteEither } from "@lokalise/node-core";
-import { ZodSchema } from "zod";
+import type { DefiniteEither } from '@lokalise/node-core'
+import type { Client } from 'undici'
+import type { RequestResult, RetryConfig } from 'undici-retry'
+import type { ZodSchema } from 'zod'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RecordObject = Record<string, any>;
+export type RecordObject = Record<string, any>
 
 export type HttpRequestContext = {
-  reqId: string;
-};
+  reqId: string
+}
 
 export type InternalRequestOptions<T> = {
-  headers?: RecordObject;
-  query?: RecordObject;
-  timeout?: number | null;
-  throwOnError?: boolean;
-  reqContext?: HttpRequestContext;
+  headers?: RecordObject
+  query?: RecordObject
+  timeout?: number | null
+  throwOnError?: boolean
+  reqContext?: HttpRequestContext
 
-  safeParseJson?: boolean;
-  blobResponseBody?: boolean;
-  requestLabel: string;
+  safeParseJson?: boolean
+  blobResponseBody?: boolean
+  requestLabel: string
 
-  disableKeepAlive?: boolean;
-  retryConfig?: RetryConfig;
-  clientOptions?: Client.Options;
-  responseSchema: ZodSchema<T>;
-  validateResponse?: boolean;
-};
+  disableKeepAlive?: boolean
+  retryConfig?: RetryConfig
+  clientOptions?: Client.Options
+  responseSchema: ZodSchema<T>
+  validateResponse?: boolean
+}
 
 export type RequestOptions<
   T,
   IsEmptyResponseExpected extends boolean,
 > = InternalRequestOptions<T> & {
-  isEmptyResponseExpected?: IsEmptyResponseExpected;
-};
+  isEmptyResponseExpected?: IsEmptyResponseExpected
+}
 
 export type RequestResultDefinitiveEither<
   T,
@@ -41,4 +41,4 @@ export type RequestResultDefinitiveEither<
 > = DefiniteEither<
   RequestResult<unknown>,
   RequestResult<IsEmptyResponseExpected extends true ? T | null : T>
->;
+>

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -10,12 +10,6 @@ export type HttpRequestContext = {
   reqId: string;
 };
 
-// TODO: remove
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ResponseSchema<Output = any> = {
-  parse(data: unknown): Output;
-};
-
 export type InternalRequestOptions<T> = {
   headers?: RecordObject;
   query?: RecordObject;

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -46,7 +46,5 @@ export type RequestResultDefinitiveEither<
   IsEmptyResponseExpected extends boolean,
 > = DefiniteEither<
   RequestResult<unknown>,
-  IsEmptyResponseExpected extends true
-    ? RequestResult<T | null>
-    : RequestResult<T>
+  RequestResult<IsEmptyResponseExpected extends true ? T | null : T>
 >;

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -1,44 +1,46 @@
-import type { DefiniteEither } from '@lokalise/node-core'
-import type { Client } from 'undici'
-import type { RequestResult, RetryConfig } from 'undici-retry'
-import type { ZodSchema } from 'zod'
+import type { DefiniteEither } from "@lokalise/node-core";
+import type { Client } from "undici";
+import type { RequestResult, RetryConfig } from "undici-retry";
+import type { ZodSchema } from "zod";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RecordObject = Record<string, any>
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export type RecordObject = Record<string, any>;
 
 export type HttpRequestContext = {
-  reqId: string
-}
+  reqId: string;
+};
 
 export type InternalRequestOptions<T> = {
-  headers?: RecordObject
-  query?: RecordObject
-  timeout?: number | null
-  throwOnError?: boolean
-  reqContext?: HttpRequestContext
+  headers?: RecordObject;
+  query?: RecordObject;
+  timeout?: number | null;
+  throwOnError?: boolean;
+  reqContext?: HttpRequestContext;
 
-  safeParseJson?: boolean
-  blobResponseBody?: boolean
-  requestLabel: string
+  safeParseJson?: boolean;
+  blobResponseBody?: boolean;
+  requestLabel: string;
 
-  disableKeepAlive?: boolean
-  retryConfig?: RetryConfig
-  clientOptions?: Client.Options
-  responseSchema: ZodSchema<T>
-  validateResponse?: boolean
-}
+  disableKeepAlive?: boolean;
+  retryConfig?: RetryConfig;
+  clientOptions?: Client.Options;
+  responseSchema: ZodSchema<T>;
+  validateResponse?: boolean;
+};
 
 export type RequestOptions<
   T,
   IsEmptyResponseExpected extends boolean,
 > = InternalRequestOptions<T> & {
-  isEmptyResponseExpected?: IsEmptyResponseExpected
-}
+  isEmptyResponseExpected?: IsEmptyResponseExpected;
+};
 
 export type RequestResultDefinitiveEither<
   T,
   IsEmptyResponseExpected extends boolean,
 > = DefiniteEither<
   RequestResult<unknown>,
-  RequestResult<IsEmptyResponseExpected extends true ? T | null : T>
->
+  IsEmptyResponseExpected extends true
+    ? RequestResult<T | null>
+    : RequestResult<T>
+>;

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -1,46 +1,44 @@
-import type { DefiniteEither } from "@lokalise/node-core";
-import type { Client } from "undici";
-import type { RequestResult, RetryConfig } from "undici-retry";
-import type { ZodSchema } from "zod";
+import type { DefiniteEither } from '@lokalise/node-core'
+import type { Client } from 'undici'
+import type { RequestResult, RetryConfig } from 'undici-retry'
+import type { ZodSchema } from 'zod'
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-export type RecordObject = Record<string, any>;
+export type RecordObject = Record<string, any>
 
 export type HttpRequestContext = {
-  reqId: string;
-};
+  reqId: string
+}
 
 export type InternalRequestOptions<T> = {
-  headers?: RecordObject;
-  query?: RecordObject;
-  timeout?: number | null;
-  throwOnError?: boolean;
-  reqContext?: HttpRequestContext;
+  headers?: RecordObject
+  query?: RecordObject
+  timeout?: number | null
+  throwOnError?: boolean
+  reqContext?: HttpRequestContext
 
-  safeParseJson?: boolean;
-  blobResponseBody?: boolean;
-  requestLabel: string;
+  safeParseJson?: boolean
+  blobResponseBody?: boolean
+  requestLabel: string
 
-  disableKeepAlive?: boolean;
-  retryConfig?: RetryConfig;
-  clientOptions?: Client.Options;
-  responseSchema: ZodSchema<T>;
-  validateResponse?: boolean;
-};
+  disableKeepAlive?: boolean
+  retryConfig?: RetryConfig
+  clientOptions?: Client.Options
+  responseSchema: ZodSchema<T>
+  validateResponse?: boolean
+}
 
 export type RequestOptions<
   T,
   IsEmptyResponseExpected extends boolean,
 > = InternalRequestOptions<T> & {
-  isEmptyResponseExpected?: IsEmptyResponseExpected;
-};
+  isEmptyResponseExpected?: IsEmptyResponseExpected
+}
 
 export type RequestResultDefinitiveEither<
   T,
   IsEmptyResponseExpected extends boolean,
 > = DefiniteEither<
   RequestResult<unknown>,
-  IsEmptyResponseExpected extends true
-    ? RequestResult<T | null>
-    : RequestResult<T>
->;
+  IsEmptyResponseExpected extends true ? RequestResult<T | null> : RequestResult<T>
+>

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -1,5 +1,7 @@
 import type { Client } from "undici";
-import type { RetryConfig } from "undici-retry";
+import type { RequestResult, RetryConfig } from "undici-retry";
+import type { DefiniteEither } from "@lokalise/node-core";
+import { ZodSchema } from "zod";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type RecordObject = Record<string, any>;
@@ -8,6 +10,7 @@ export type HttpRequestContext = {
   reqId: string;
 };
 
+// TODO: remove
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ResponseSchema<Output = any> = {
   parse(data: unknown): Output;
@@ -27,20 +30,23 @@ export type InternalRequestOptions<T> = {
   disableKeepAlive?: boolean;
   retryConfig?: RetryConfig;
   clientOptions?: Client.Options;
-  responseSchema: ResponseSchema<T>;
+  responseSchema: ZodSchema<T>;
   validateResponse?: boolean;
 };
 
 export type RequestOptions<
   T,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean,
 > = InternalRequestOptions<T> & {
   isEmptyResponseExpected?: IsEmptyResponseExpected;
 };
 
-// TODO: I think it is not used, remove on next major update
-export type Response<T> = {
-  body: T;
-  headers: RecordObject;
-  statusCode: number;
-};
+export type RequestResultDefinitiveEither<
+  T,
+  IsEmptyResponseExpected extends boolean,
+> = DefiniteEither<
+  RequestResult<unknown>,
+  IsEmptyResponseExpected extends true
+    ? RequestResult<T | null>
+    : RequestResult<T>
+>;

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -1,0 +1,46 @@
+import type { Client } from "undici";
+import type { RetryConfig } from "undici-retry";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RecordObject = Record<string, any>;
+
+export type HttpRequestContext = {
+  reqId: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ResponseSchema<Output = any> = {
+  parse(data: unknown): Output;
+};
+
+export type InternalRequestOptions<T> = {
+  headers?: RecordObject;
+  query?: RecordObject;
+  timeout?: number | null;
+  throwOnError?: boolean;
+  reqContext?: HttpRequestContext;
+
+  safeParseJson?: boolean;
+  blobResponseBody?: boolean;
+  requestLabel: string;
+
+  disableKeepAlive?: boolean;
+  retryConfig?: RetryConfig;
+  clientOptions?: Client.Options;
+  responseSchema: ResponseSchema<T>;
+  validateResponse?: boolean;
+};
+
+export type RequestOptions<
+  T,
+  IsEmptyResponseExpected extends boolean = false,
+> = InternalRequestOptions<T> & {
+  isEmptyResponseExpected?: IsEmptyResponseExpected;
+};
+
+// TODO: I think it is not used, remove on next major update
+export type Response<T> = {
+  body: T;
+  headers: RecordObject;
+  statusCode: number;
+};


### PR DESCRIPTION
## Changes

adding support for `204`, same as we did for FE client

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
