### PR TITLE
fix: add vitest globals to biome base config

### DIFF
--- a/packages/dev/biome-config/configs/biome-base.jsonc
+++ b/packages/dev/biome-config/configs/biome-base.jsonc
@@ -14,7 +14,6 @@
     }
   },
   "javascript": {
-    "globals": ["vitest"],
     "formatter": {
       "enabled": true,
       "indentWidth": 2,

--- a/packages/dev/biome-config/configs/biome-base.jsonc
+++ b/packages/dev/biome-config/configs/biome-base.jsonc
@@ -69,6 +69,19 @@
   "overrides": [
     {
       "include": ["./**/*.spec.ts", "./**/*.test.ts", "./**/*.test.tsx", "./test/**/*"],
+      "javascript": {
+        // Allow Vitest globals in test files
+        "globals": [
+          "describe",
+          "it",
+          "expect",
+          "beforeEach",
+          "afterEach",
+          "beforeAll",
+          "afterAll",
+          "vi"
+        ]
+      },
       "linter": {
         "rules": {
           "style": {


### PR DESCRIPTION
The "vitest" string did not work as expected. The variables have to be all listed in there.