### PR TITLE
fix: allow test folder to be nested

### DIFF
--- a/packages/app/backend-http-client/package.json
+++ b/packages/app/backend-http-client/package.json
@@ -11,11 +11,7 @@
     "url": "git://github.com/lokalise/backend-http-client.git"
   },
   "license": "Apache-2.0",
-  "files": [
-    "dist/**",
-    "LICENSE.md",
-    "README.md"
-  ],
+  "files": ["dist/**", "LICENSE.md", "README.md"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "commonjs",

--- a/packages/dev/biome-config/configs/biome-base.jsonc
+++ b/packages/dev/biome-config/configs/biome-base.jsonc
@@ -67,7 +67,7 @@
   },
   "overrides": [
     {
-      "include": ["./**/*.spec.ts", "./**/*.test.ts", "./**/*.test.tsx", "./test/**/*"],
+      "include": ["./**/*.spec.ts", "./**/*.test.ts", "./**/*.test.tsx", "**/test/**/*"],
       "javascript": {
         // Allow Vitest globals in test files
         "globals": [


### PR DESCRIPTION
This change allows for `test` folder to be nested.

In FE, we have usually test folder nested within `src/test/whatever-file.ts`. 