### PR TITLE
Fix typo in README

### DIFF
--- a/packages/dev/biome-config/README.md
+++ b/packages/dev/biome-config/README.md
@@ -19,7 +19,7 @@ Packages:
 ```json
 {
     "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-    "extends": ["./node_modules/@lokalise/biome-config/configs/biome-base.jsonc", "./node_modules/@lokalise/biome-config/configs/biome-packages.jsonc"]
+    "extends": ["./node_modules/@lokalise/biome-config/configs/biome-base.jsonc", "./node_modules/@lokalise/biome-config/configs/biome-package.jsonc"]
 }
 ```
 


### PR DESCRIPTION
## Changes

The README references `biome-packages.jsonc` but it's actually `biome-package.jsonc`

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
