### PR TITLE
Pin Node version to a fixed one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.5.1]
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/dev/package-vite-config/package.json
+++ b/packages/dev/package-vite-config/package.json
@@ -3,11 +3,7 @@
   "version": "3.0.0",
   "type": "module",
   "license": "Apache-2.0",
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "dist"
-  ],
+  "files": ["README.md", "LICENSE.md", "dist"],
   "homepage": "https://github.com/lokalise/shared-ts-libs",
   "repository": {
     "type": "git",
@@ -21,9 +17,7 @@
   },
   "typesVersions": {
     "*": {
-      "package": [
-        "dist/package.config.d.ts"
-      ]
+      "package": ["dist/package.config.d.ts"]
     }
   },
   "scripts": {


### PR DESCRIPTION
## Changes

See https://nodejs.org/en/blog/release/v22.5.1

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
