### PR TITLE
Use separate checks for separate healthchecks

### DIFF
--- a/packages/app/healthcheck-utils/package.json
+++ b/packages/app/healthcheck-utils/package.json
@@ -2,11 +2,7 @@
   "name": "@lokalise/healthcheck-utils",
   "version": "1.2.0",
   "license": "Apache-2.0",
-  "files": [
-    "dist/**",
-    "LICENSE.md",
-    "README.md"
-  ],
+  "files": ["dist/**", "LICENSE.md", "README.md"],
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/app/healthcheck-utils/src/HealthcheckRefreshJob.spec.ts
+++ b/packages/app/healthcheck-utils/src/HealthcheckRefreshJob.spec.ts
@@ -92,7 +92,7 @@ describe('HealthcheckRefreshJob', () => {
   let job: HealthcheckRefreshJob
   beforeAll(() => {
     redis = new Redis(getTestRedisConfig())
-    store = new HealthcheckResultsStore({ healthcheckNumber: 1 })
+    store = new HealthcheckResultsStore({ maxHealthcheckNumber: 1 })
   })
   beforeEach(() => {
     store.resetHealthcheckStores()

--- a/packages/app/healthcheck-utils/src/HealthcheckRefreshJob.spec.ts
+++ b/packages/app/healthcheck-utils/src/HealthcheckRefreshJob.spec.ts
@@ -17,7 +17,7 @@ import {
   type HealthcheckDependencies,
 } from './healthchecks.js'
 
-type SupportedHealthchecks = 'test'
+type SupportedHealthchecks = 'test' | 'test2'
 
 class TestHealthcheck extends AbstractHealthcheck<SupportedHealthchecks> implements Healthcheck {
   private readonly throwError: boolean
@@ -33,6 +33,29 @@ class TestHealthcheck extends AbstractHealthcheck<SupportedHealthchecks> impleme
 
   getId(): SupportedHealthchecks {
     return 'test'
+  }
+
+  check(): Promise<Either<Error, number>> {
+    return this.throwError
+      ? Promise.resolve({ error: new Error('error') })
+      : Promise.resolve({ result: 5 })
+  }
+}
+
+class TestHealthcheck2 extends AbstractHealthcheck<SupportedHealthchecks> implements Healthcheck {
+  private readonly throwError: boolean
+
+  constructor(
+    dependencies: HealthcheckDependencies<SupportedHealthchecks>,
+    areMetricsEnabled: boolean,
+    throwError = false,
+  ) {
+    super(dependencies, areMetricsEnabled)
+    this.throwError = throwError
+  }
+
+  getId(): SupportedHealthchecks {
+    return 'test2'
   }
 
   check(): Promise<Either<Error, number>> {
@@ -84,6 +107,14 @@ describe('HealthcheckRefreshJob', () => {
   it('updates successful redis healthcheck', async () => {
     const healthchecks = [
       new TestHealthcheck(
+        {
+          healthcheckStore: store,
+        },
+        true,
+        false,
+      ),
+
+      new TestHealthcheck2(
         {
           healthcheckStore: store,
         },

--- a/packages/app/healthcheck-utils/src/HealthcheckResultsStore.spec.ts
+++ b/packages/app/healthcheck-utils/src/HealthcheckResultsStore.spec.ts
@@ -5,7 +5,7 @@ import {
 } from './HealthcheckResultsStore'
 
 const testParams: HealthcheckResultsStoreParams = {
-  healthcheckNumber: 2,
+  maxHealthcheckNumber: 2,
   healthCheckResultTtlInMsecs: 5000,
   stalenessThresholdInMsecs: 1000,
 }

--- a/packages/app/healthcheck-utils/src/HealthcheckResultsStore.ts
+++ b/packages/app/healthcheck-utils/src/HealthcheckResultsStore.ts
@@ -8,7 +8,7 @@ export type HealthcheckEntry = {
 }
 
 export type HealthcheckResultsStoreParams = {
-  healthcheckNumber: number // maximum amount of healthchecks that the system can have
+  maxHealthcheckNumber: number // maximum amount of healthchecks that the system can have
   stalenessThresholdInMsecs?: number
   healthCheckResultTtlInMsecs?: number
 }
@@ -24,7 +24,7 @@ export class HealthcheckResultsStore<SupportedHealthchecks extends string> {
     this.stalenessThresholdInMsecs =
       params.stalenessThresholdInMsecs ?? DEFAULT_STALENESS_THRESHOLD_IN_MSECS
     this.store = new FifoMap<HealthcheckEntry>(
-      params.healthcheckNumber,
+      params.maxHealthcheckNumber,
       params.healthCheckResultTtlInMsecs ?? DEFAULT_HEALTHCHECK_TTL_IN_MSECS,
     )
   }

--- a/packages/app/healthcheck-utils/src/HealthcheckResultsStore.ts
+++ b/packages/app/healthcheck-utils/src/HealthcheckResultsStore.ts
@@ -8,7 +8,7 @@ export type HealthcheckEntry = {
 }
 
 export type HealthcheckResultsStoreParams = {
-  healthcheckNumber: number // how many healthchecks does the system have
+  healthcheckNumber: number // maximum amount of healthchecks that the system can have
   stalenessThresholdInMsecs?: number
   healthCheckResultTtlInMsecs?: number
 }

--- a/packages/app/healthcheck-utils/src/healthchecks.ts
+++ b/packages/app/healthcheck-utils/src/healthchecks.ts
@@ -15,7 +15,7 @@ export type HealthcheckDependencies<SupportedHealthchecks extends string> = {
   healthcheckStore: HealthcheckResultsStore<SupportedHealthchecks>
 }
 
-let metricsRegistered = false
+const metricsRegistered = new Map<string, boolean>()
 
 export abstract class AbstractHealthcheck<SupportedHealthchecks extends string>
   implements Healthcheck
@@ -42,11 +42,11 @@ export abstract class AbstractHealthcheck<SupportedHealthchecks extends string>
   }
 
   instantiateMetrics(): void {
-    if (!this.areMetricsEnabled || metricsRegistered) {
+    const id = this.getId()
+    if (!this.areMetricsEnabled || metricsRegistered.get(id)) {
       return
     }
     const store = this.store
-    const id = this.getId()
     new Gauge({
       name: `${id}_availability`,
       help: `Whether ${id} was available at the time`,
@@ -64,7 +64,7 @@ export abstract class AbstractHealthcheck<SupportedHealthchecks extends string>
       },
     })
 
-    metricsRegistered = true
+    metricsRegistered.set(id, true)
   }
 
   async execute(): Promise<void> {


### PR DESCRIPTION
## Changes

Previously it will only register Gauges for the very first healthcheck.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
