### PR TITLE
MET-188 Add support for repeatable jobs

### DIFF
--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -571,17 +571,24 @@ describe('AbstractBackgroundJobProcessor', () => {
       )
 
       await expect(
-        processor.scheduleBulk([{
-          id: 'test_id',
-          value: 'test',
-          metadata: { correlationId: 'correlation_id' },
-        }], {
-          repeat: {
-            every: 10,
-            limit: 5,
-          }
-        }),
-      ).rejects.toThrow(/scheduleBulk does not support repeatOptions. Please use schedule method instead/)
+        processor.scheduleBulk(
+          [
+            {
+              id: 'test_id',
+              value: 'test',
+              metadata: { correlationId: 'correlation_id' },
+            },
+          ],
+          {
+            repeat: {
+              every: 10,
+              limit: 5,
+            },
+          },
+        ),
+      ).rejects.toThrow(
+        /scheduleBulk does not support repeatOptions. Please use schedule method instead/,
+      )
       await processor.dispose()
     })
 
@@ -592,17 +599,20 @@ describe('AbstractBackgroundJobProcessor', () => {
         mocks.getRedisConfig(),
       )
 
-      const scheduledJobId = await processor.schedule({
-        id: 'test_id',
-        value: 'test',
-        metadata: { correlationId: 'correlation_id' },
-      }, {
-        repeat: {
-          every: 10,
-          immediately: true,
-          limit: 5,
-        }
-      })
+      const scheduledJobId = await processor.schedule(
+        {
+          id: 'test_id',
+          value: 'test',
+          metadata: { correlationId: 'correlation_id' },
+        },
+        {
+          repeat: {
+            every: 10,
+            immediately: true,
+            limit: 5,
+          },
+        },
+      )
 
       await processor.spy.waitForJobWithId(scheduledJobId, 'completed')
       // @ts-expect-error executing protected method for testing

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -563,35 +563,6 @@ describe('AbstractBackgroundJobProcessor', () => {
       await redis?.del(QUEUE_IDS_KEY)
     })
 
-    it('throws an error if attempt to use scheduleBulk with repeatable jobs', async () => {
-      const processor = new FakeBackgroundJobProcessor<JobData>(
-        deps,
-        'queue1',
-        mocks.getRedisConfig(),
-      )
-
-      await expect(
-        processor.scheduleBulk(
-          [
-            {
-              id: 'test_id',
-              value: 'test',
-              metadata: { correlationId: 'correlation_id' },
-            },
-          ],
-          {
-            repeat: {
-              every: 10,
-              limit: 5,
-            },
-          },
-        ),
-      ).rejects.toThrow(
-        /scheduleBulk does not support repeatOptions. Please use schedule method instead/,
-      )
-      await processor.dispose()
-    })
-
     it('schedules repeatable job', async () => {
       const processor = new FakeBackgroundJobProcessor<JobData>(
         deps,

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -237,11 +237,25 @@ export abstract class AbstractBackgroundJobProcessor<
   }
 
   public async schedule(jobData: JobPayload, options?: JobOptionsType): Promise<string> {
-    const jobIds = await this.scheduleBulk([jobData], options)
-    return jobIds[0]
+    await this.startIfNotStarted()
+
+    const job = await this._queue?.add(this.config.queueId, jobData, prepareJobOptions(this.config.isTest, options))
+    if (!job?.id) {
+      throw new Error('Scheduled job ID is undefined')
+    }
+
+    if (this._spy) {
+      this._spy.addJob(job, 'scheduled')
+    }
+
+    return job.id
   }
 
   public async scheduleBulk(jobData: JobPayload[], options?: JobOptionsType): Promise<string[]> {
+    if (options?.repeat) {
+      throw new Error('scheduleBulk does not support repeatOptions. Please use schedule method instead')
+    }
+
     await this.startIfNotStarted()
 
     const jobs =
@@ -262,9 +276,7 @@ export abstract class AbstractBackgroundJobProcessor<
     }
 
     if (this._spy) {
-      for (const job of jobs) {
-        this._spy.addJob(job, 'scheduled')
-      }
+      this._spy.addJobs(jobs, 'scheduled')
     }
 
     return jobIds as string[]

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -239,7 +239,11 @@ export abstract class AbstractBackgroundJobProcessor<
   public async schedule(jobData: JobPayload, options?: JobOptionsType): Promise<string> {
     await this.startIfNotStarted()
 
-    const job = await this._queue?.add(this.config.queueId, jobData, prepareJobOptions(this.config.isTest, options))
+    const job = await this._queue?.add(
+      this.config.queueId,
+      jobData,
+      prepareJobOptions(this.config.isTest, options),
+    )
     if (!job?.id) {
       throw new Error('Scheduled job ID is undefined')
     }
@@ -253,7 +257,9 @@ export abstract class AbstractBackgroundJobProcessor<
 
   public async scheduleBulk(jobData: JobPayload[], options?: JobOptionsType): Promise<string[]> {
     if (options?.repeat) {
-      throw new Error('scheduleBulk does not support repeatOptions. Please use schedule method instead')
+      throw new Error(
+        'scheduleBulk does not support repeatOptions. Please use schedule method instead',
+      )
     }
 
     await this.startIfNotStarted()

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -255,13 +255,10 @@ export abstract class AbstractBackgroundJobProcessor<
     return job.id
   }
 
-  public async scheduleBulk(jobData: JobPayload[], options?: JobOptionsType): Promise<string[]> {
-    if (options?.repeat) {
-      throw new Error(
-        'scheduleBulk does not support repeatOptions. Please use schedule method instead',
-      )
-    }
-
+  public async scheduleBulk(
+    jobData: JobPayload[],
+    options?: Omit<JobOptionsType, 'repeat'>,
+  ): Promise<string[]> {
     await this.startIfNotStarted()
 
     const jobs =

--- a/packages/app/background-jobs-common/src/background-job-processor/spy/BackgroundJobProcessorSpy.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/spy/BackgroundJobProcessorSpy.ts
@@ -112,4 +112,10 @@ export class BackgroundJobProcessorSpy<JobData extends object, JobReturn>
       this.promises.splice(index, 1)
     }
   }
+
+  addJobs(jobs: SafeJob<JobData>[], state: JobSpyState): void {
+    for (const job of jobs) {
+      this.addJob(job, state)
+    }
+  }
 }

--- a/packages/app/background-jobs-common/src/background-job-processor/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/types.ts
@@ -31,7 +31,7 @@ export type SafeQueue<
     jobs: {
       name: NameType
       data: DataType
-      opts?: JobsOptionsType
+      opts?: Omit<JobsOptionsType, 'repeat'>
     }[],
   ): Promise<SafeJob<DataType, ResultType, NameType>[]>
 }


### PR DESCRIPTION
## Changes

[Repeatable jobs](https://docs.bullmq.io/guide/jobs/repeatable) can be scheduled by passing the repeat settings. However, these settings are only accepted when using the [add()](https://github.com/taskforcesh/bullmq/blob/c60e6a3f45606c623ef6a2b16415d67eac9b0269/src/classes/queue.ts#L218) method and are ignored when using [addBulk()](https://github.com/taskforcesh/bullmq/blob/c60e6a3f45606c623ef6a2b16415d67eac9b0269/src/classes/queue.ts#L264) where [they are omitted](https://github.com/taskforcesh/bullmq/blob/c60e6a3f45606c623ef6a2b16415d67eac9b0269/src/interfaces/minimal-job.ts#L5). This PR uses `add()` instead of reusing `scheduleBulk()` in the `schedule()` method so that repeatable jobs can be scheduled and prevents this from happening in the future shall they introduce additional properties that are only processed in `add()`.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
