### PR TITLE
fix: move vite/vitest dependencies to peerDependencies

### DIFF
--- a/packages/dev/package-vite-config/package.json
+++ b/packages/dev/package-vite-config/package.json
@@ -30,9 +30,9 @@
         "package-version": "echo $npm_package_version",
         "postversion": "biome check --write package.json"
     },
-    "dependencies": {
-        "vite": "5.4.2",
-        "vite-plugin-dts": "4.2.1",
+    "peerDependencies": {
+        "vite": "^5.4.2",
+        "vite-plugin-dts": "^4.2.1",
         "vitest": "^2.0.3"
     },
     "devDependencies": {


### PR DESCRIPTION
## Changes

Moved the vite/vitest dependencies to `peerDependencies`. This will allow better de-duplication in the consuming packages. Also made the versions to be range rather being pinned to specific version.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
