### PR TITLE
Introduce traversePaginatedSourceByHasMore()

### DIFF
--- a/packages/app/api-common/src/paginationUtils.ts
+++ b/packages/app/api-common/src/paginationUtils.ts
@@ -201,3 +201,22 @@ export async function getPaginatedEntriesByHasMore<T extends Record<string, unkn
 
   return resultArray
 }
+
+export async function traversePaginatedSourceByHasMore<
+  T extends Record<string, unknown>,
+>(
+  pagination: OptionalPaginationParams,
+  apiCall: (params: OptionalPaginationParams) => Promise<PaginatedResponse<T>>,
+  processPage: (pageData: PaginatedResponse<T>['data']) => Promise<void>,
+): Promise<void> {
+  let hasMore: boolean | undefined
+  let currentCursor: string | undefined = pagination.after
+
+  do {
+    const pageResult = await apiCall({ ...pagination, after: currentCursor })
+    hasMore = pageResult.meta.hasMore
+    currentCursor = pageResult.meta.cursor
+
+    await processPage(pageResult.data)
+  } while (hasMore)
+}


### PR DESCRIPTION
## Changes

Allow traversing a paginable resource with constant memory usage.

## Checklist

- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
