### PR TITLE
Trying to fix node import for BE

### DIFF
--- a/packages/app/universal-ts-utils/package.json
+++ b/packages/app/universal-ts-utils/package.json
@@ -37,5 +37,11 @@
         "@vitest/coverage-v8": "^2.0.4",
         "typescript": "^5.6.2",
         "vitest": "^2.0.4"
+    },
+    "exports": {
+        "./node": {
+            "import": "./dist/node.js",
+            "types": "./dist/node.d.ts"
+        }
     }
 }


### PR DESCRIPTION
## Changes

Objective was to, on BE, be able to use `import {...} from '@lokalise/universal-ts-utils/node'` but it does not work as /dist is still needed (`@lokalise/universal-ts-utils/dist/node`).

With this PR I am trying to fix it, but I am not sure if it will work as desired or not, so please feel free to let me know if you disagree with the change or know how to achieve it 🙏 

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
