### PR TITLE
Trying to fix imports on universal-ts-utils

### DIFF
--- a/packages/app/universal-ts-utils/biome.json
+++ b/packages/app/universal-ts-utils/biome.json
@@ -2,6 +2,7 @@
     "$schema": "../../../node_modules/@biomejs/biome/configuration_schema.json",
     "extends": [
         "../../../node_modules/@lokalise/biome-config/configs/biome-base.jsonc",
-        "../../../node_modules/@lokalise/biome-config/configs/biome-package.jsonc"
+        "../../../node_modules/@lokalise/biome-config/configs/biome-package.jsonc",
+        "../../../node_modules/@lokalise/biome-config/configs/biome-esm.jsonc"
     ]
 }

--- a/packages/app/universal-ts-utils/src/internal/compare.spec.ts
+++ b/packages/app/universal-ts-utils/src/internal/compare.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { compare } from './compare'
+import { compare } from './compare.js'
 
 describe('compare', () => {
   it('should correctly compare two strings', () => {

--- a/packages/app/universal-ts-utils/src/public/array/areStringArraysEqual.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/areStringArraysEqual.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { areStringArraysEqual } from './areStringArraysEqual'
+import { areStringArraysEqual } from './areStringArraysEqual.js'
 
 describe('areStringArraysEqual', () => {
   it('returns true for identical arrays', () => {

--- a/packages/app/universal-ts-utils/src/public/array/callChunked.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/callChunked.spec.ts
@@ -1,5 +1,5 @@
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
-import { callChunked } from './callChunked'
+import { callChunked } from './callChunked.js'
 
 describe('callChunked', () => {
   let mockedMethod: Mock

--- a/packages/app/universal-ts-utils/src/public/array/chunk.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/chunk.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { chunk } from './chunk'
+import { chunk } from './chunk.js'
 
 describe('arrayUtils', () => {
   describe('chunk', () => {

--- a/packages/app/universal-ts-utils/src/public/array/isNonEmptyArray.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/isNonEmptyArray.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isNonEmptyArray } from './isNonEmptyArray'
+import { isNonEmptyArray } from './isNonEmptyArray.js'
 
 describe('arrayUtils', () => {
   describe('isNonEmptyArray', () => {

--- a/packages/app/universal-ts-utils/src/public/array/removeFalsy.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/removeFalsy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { removeFalsy } from './removeFalsy'
+import { removeFalsy } from './removeFalsy.js'
 
 describe('arrayUtils', () => {
   describe('removeFalsy', () => {

--- a/packages/app/universal-ts-utils/src/public/array/removeNullish.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/removeNullish.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { removeNullish } from './removeNullish'
+import { removeNullish } from './removeNullish.js'
 
 describe('arrayUtils', () => {
   describe('removeNullish', () => {

--- a/packages/app/universal-ts-utils/src/public/array/sort.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/sort.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sort } from './sort'
+import { sort } from './sort.js'
 
 describe('sort', () => {
   it('is able to handle empty arrays', () => {

--- a/packages/app/universal-ts-utils/src/public/array/sort.ts
+++ b/packages/app/universal-ts-utils/src/public/array/sort.ts
@@ -1,4 +1,4 @@
-import { compare } from '../../internal/compare'
+import { compare } from '../../internal/compare.js'
 
 /**
  * Sorts an array of strings or numbers in either ascending or descending order.

--- a/packages/app/universal-ts-utils/src/public/array/sortByField.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/sortByField.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sortByField } from './sortByField'
+import { sortByField } from './sortByField.js'
 
 describe('sortByField', () => {
   it('should handle an empty array without throwing errors', () => {

--- a/packages/app/universal-ts-utils/src/public/array/sortByField.ts
+++ b/packages/app/universal-ts-utils/src/public/array/sortByField.ts
@@ -1,5 +1,5 @@
-import { compare } from '../../internal/compare'
-import type { KeysMatching } from '../../internal/types'
+import { compare } from '../../internal/compare.js'
+import type { KeysMatching } from '../../internal/types.js'
 
 /**
  * Sorts an array of objects based on a specified string field and order.

--- a/packages/app/universal-ts-utils/src/public/array/unique.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/array/unique.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { unique } from './unique'
+import { unique } from './unique.js'
 
 describe('unique', () => {
   it('returns a new array of mixed primitive value without duplicates', () => {

--- a/packages/app/universal-ts-utils/src/public/object/areDeepEqual.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/object/areDeepEqual.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { areDeepEqual } from './areDeepEqual'
+import { areDeepEqual } from './areDeepEqual.js'
 
 describe('areDeepEqual', () => {
   describe('comparing primitives', () => {

--- a/packages/app/universal-ts-utils/src/public/object/groupBy.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/object/groupBy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { groupBy } from './groupBy'
+import { groupBy } from './groupBy.js'
 
 describe('groupBy', () => {
   it('Empty array', () => {

--- a/packages/app/universal-ts-utils/src/public/object/groupBy.ts
+++ b/packages/app/universal-ts-utils/src/public/object/groupBy.ts
@@ -1,4 +1,4 @@
-import type { KeysMatching, RecordKeyType } from '../../internal/types'
+import type { KeysMatching, RecordKeyType } from '../../internal/types.js'
 
 /**
  * @param array The array of objects to be grouped.

--- a/packages/app/universal-ts-utils/src/public/object/groupByUnique.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/object/groupByUnique.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { groupByUnique } from './groupByUnique'
+import { groupByUnique } from './groupByUnique.js'
 
 describe('groupByUnique', () => {
   it('Empty array', () => {

--- a/packages/app/universal-ts-utils/src/public/object/groupByUnique.ts
+++ b/packages/app/universal-ts-utils/src/public/object/groupByUnique.ts
@@ -1,4 +1,4 @@
-import type { KeysMatching, RecordKeyType } from '../../internal/types'
+import type { KeysMatching, RecordKeyType } from '../../internal/types.js'
 
 /**
  * @param array The array of objects to be grouped.


### PR DESCRIPTION
## Changes

Trying to fix:
```
Error: Cannot find module '.../node_modules/@lokalise/universal-ts-utils/dist/internal/compare' imported from .../node_modules/@lokalise/universal-ts-utils/dist/public/array/sort.js
```

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
