### PR TITLE
Restrict BullMQ to the latest compatible version

### DIFF
--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -38,7 +38,7 @@
         "ts-deepmerge": "^7.0.1"
     },
     "peerDependencies": {
-        "bullmq": "^5.19.0",
+        "bullmq": "<=5.26.0",
         "ioredis": "^5.4.1",
         "toad-scheduler": "^3.0.1"
     },
@@ -48,7 +48,7 @@
         "@types/node": "^22.7.6",
         "@lokalise/package-vite-config": "latest",
         "@vitest/coverage-v8": "^2.1.3",
-        "bullmq": "^5.21.1",
+        "bullmq": "<=5.26.0",
         "ioredis": "^5.4.1",
         "rimraf": "^6.0.1",
         "toad-scheduler": "^3.0.1",


### PR DESCRIPTION
## Changes
Restricts BullMQ to the latest compatible version to address breaking changes due to incompatible generic types.


## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
