### PR TITLE
Vault env var sync indicates that 403 might be due to invalid path.

### DIFF
--- a/packages/app/script-utils/src/vault/vault.ts
+++ b/packages/app/script-utils/src/vault/vault.ts
@@ -100,7 +100,9 @@ export const vaultGetVars = (service: string): Record<string, string> => {
     return responseJson.data.data
   } catch (e: unknown) {
     if (isExecError(e)) {
-      globalLogger.error(`Vault ${service} error downloading env vars -> ${e.stderr.toString()}`)
+      globalLogger.error(
+        `Vault ${service} error downloading env vars -> ${e.stderr.toString()}. Make sure you're using correct path to secrets. Vault reports 403 if the path is incorrect.`,
+      )
     }
     return {}
   }


### PR DESCRIPTION
## Changes

Minor change, explained in error log that 403 might be reported due to invalid secrets path.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
