### PR TITLE
Make abstract periodic job configuration more flexible

### DIFF
--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -35,7 +35,7 @@
         "@lokalise/node-core": "^13.1.0",
         "pino": "^9.5.0",
         "redis-semaphore": "^5.6.1",
-        "ts-deepmerge": "^7.0.1"
+        "ts-deepmerge": "^7.0.2"
     },
     "peerDependencies": {
         "bullmq": "^5.28.2",
@@ -45,10 +45,10 @@
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@lokalise/biome-config": "^1.5.0",
-        "@types/node": "^22.7.6",
+        "@types/node": "^22.10.1",
         "@lokalise/package-vite-config": "latest",
         "@vitest/coverage-v8": "^2.1.5",
-        "bullmq": "^5.28.2",
+        "bullmq": "^5.31.2",
         "ioredis": "^5.4.1",
         "rimraf": "^6.0.1",
         "toad-scheduler": "^3.0.1",

--- a/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.spec.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.spec.ts
@@ -25,6 +25,27 @@ describe('AbstractPeriodicJob', () => {
     await redis.quit()
   })
 
+  it('should throw an error when single producer mode is enabled without redis instance', () => {
+    expect(
+      () =>
+        new FakePeriodicJob(
+          () => Promise.resolve(),
+          {
+            scheduler,
+          },
+          {
+            schedule: {
+              intervalInMs: 1000,
+            },
+            singleConsumerMode: {
+              enabled: true,
+              exclusiveLockSuffix: 'suff',
+            },
+          },
+        ),
+    ).toThrow(/Redis instance must be provided/)
+  })
+
   it('should run processing multiple times', async () => {
     const executionIds: string[] = []
     const processMock = (executionContext: JobExecutionContext) => {
@@ -33,7 +54,6 @@ describe('AbstractPeriodicJob', () => {
     }
     const job = new FakePeriodicJob(processMock, {
       scheduler,
-      redis,
     })
     job.register()
 
@@ -56,7 +76,6 @@ describe('AbstractPeriodicJob', () => {
       processMock,
       {
         scheduler,
-        redis,
       },
       {
         schedule: {

--- a/packages/app/background-jobs-common/src/periodic-jobs/periodicJobTypes.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/periodicJobTypes.ts
@@ -72,10 +72,10 @@ export type LockConfiguration = {
 }
 
 export type PeriodicJobDependencies = {
-  redis: Redis
-  logger: CommonLogger
-  transactionObservabilityManager: TransactionObservabilityManager
-  errorReporter: ErrorReporter
+  redis?: Redis
+  logger?: CommonLogger
+  transactionObservabilityManager?: TransactionObservabilityManager
+  errorReporter?: ErrorReporter
   scheduler: ToadScheduler
 }
 


### PR DESCRIPTION
## Changes

Periodic jobs work without all the dependencies that are currently mandatory, so we can relax the requirements a bit

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
