### PR TITLE
Fix Redis check

### DIFF
--- a/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.ts
@@ -64,7 +64,7 @@ export abstract class AbstractPeriodicJob {
     this.errorReporter = errorReporter
     this.scheduler = scheduler
 
-    if (!redis && options.singleConsumerMode) {
+    if (!redis && options.singleConsumerMode && options.singleConsumerMode.enabled) {
       throw new InternalError({
         message: 'Redis instance must be provided in a single consumer mode',
         errorCode: 'MISSING_SINGLE_CONSUMER_MODE_DEPENDENCY',


### PR DESCRIPTION
## Changes

Disabled single consumer mode shouldn't require redis either.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
