### PR TITLE
Trim text util

### DIFF
--- a/packages/app/universal-ts-utils/src/node.ts
+++ b/packages/app/universal-ts-utils/src/node.ts
@@ -23,6 +23,9 @@ export * from './public/object/isEmpty.js'
 export * from './public/object/pick.js'
 export * from './public/object/transformToKebabCase.js'
 
+// string
+export * from './public/string/trimText.js'
+
 // type
 export * from './public/type/hasMessage.js'
 export * from './public/type/isError.js'

--- a/packages/app/universal-ts-utils/src/public/string/trimText.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/string/trimText.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { trimText } from './trimText.js'
+
+describe('trimText', () => {
+  it('handles empty string', () => {
+    const result = trimText('')
+    expect(result).toEqual({ value: '' })
+  })
+
+  it.each([
+    ['text', { value: 'text' }],
+    [' text ', { value: 'text', prefix: ' ', suffix: ' ' }],
+    ['     text     ', { value: 'text', prefix: '     ', suffix: '     ' }],
+    ['\ttext\t', { value: 'text', prefix: '\t', suffix: '\t' }],
+    [' \t  \t text\t  \t', { value: 'text', prefix: ' \t  \t ', suffix: '\t  \t' }],
+    ['\ntext\n', { value: 'text', prefix: '\n', suffix: '\n' }],
+    [' \n  \n text\n   \n ', { value: 'text', prefix: ' \n  \n ', suffix: '\n   \n ' }],
+    ['&nbsp;text&nbsp;', { value: 'text', prefix: '&nbsp;', suffix: '&nbsp;' }],
+    ['\r\ntext\r\n', { value: 'text', prefix: '\r\n', suffix: '\r\n' }],
+    [
+      '  \t \n &nbsp; \r\n \ttext\t \n &nbsp; \r\n \t ',
+      {
+        value: 'text',
+        prefix: '  \t \n &nbsp; \r\n \t',
+        suffix: '\t \n &nbsp; \r\n \t ',
+      },
+    ],
+  ])('trim text and return prefix and suffix', (text, expected) => {
+    const result = trimText(text)
+    expect(result).toEqual(expected)
+  })
+
+  it.each([
+    ['hello world', { value: 'hello world' }],
+    [' hello world ', { value: 'hello world', prefix: ' ', suffix: ' ' }],
+    [' hello\tworld ', { value: 'hello\tworld', prefix: ' ', suffix: ' ' }],
+    [' hello\nworld ', { value: 'hello\nworld', prefix: ' ', suffix: ' ' }],
+    [' hello\r\nworld ', { value: 'hello\r\nworld', prefix: ' ', suffix: ' ' }],
+    [' hello&nbsp;world ', { value: 'hello&nbsp;world', prefix: ' ', suffix: ' ' }],
+    [
+      ' hello  \t \n &nbsp; \r\n \t world ',
+      { value: 'hello  \t \n &nbsp; \r\n \t world', prefix: ' ', suffix: ' ' },
+    ],
+  ])('should not touch text itself', (text, expected) => {
+    const result = trimText(text)
+    expect(result).toEqual(expected)
+  })
+})

--- a/packages/app/universal-ts-utils/src/public/string/trimText.ts
+++ b/packages/app/universal-ts-utils/src/public/string/trimText.ts
@@ -24,7 +24,7 @@ const leadingRegex = /^(?:[\s\u00A0]|&nbsp;)+/
  */
 const trailingRegex = /(?:[\s\u00A0]|&nbsp;)+$/
 
-const extractFirstOccurrence = (text: string, regex: RegExp): string | undefined => {
+const extractOccurrence = (text: string, regex: RegExp): string | undefined => {
   const match = text.match(regex)
   return match ? match[0] : undefined
 }
@@ -48,6 +48,6 @@ export type TrimmedText = {
  */
 export const trimText = (text: string): TrimmedText => ({
   value: text.replace(leadingRegex, '').replace(trailingRegex, ''),
-  prefix: extractFirstOccurrence(text, leadingRegex),
-  suffix: extractFirstOccurrence(text, trailingRegex),
+  prefix: extractOccurrence(text, leadingRegex),
+  suffix: extractOccurrence(text, trailingRegex),
 })

--- a/packages/app/universal-ts-utils/src/public/string/trimText.ts
+++ b/packages/app/universal-ts-utils/src/public/string/trimText.ts
@@ -1,0 +1,25 @@
+/**
+ * TODO: explain
+ */
+const leadingRegex = /^(?:[\s\u00A0]|&nbsp;)+/
+/**
+ *  TODO: explain
+ */
+const trailingRegex = /(?:[\s\u00A0]|&nbsp;)+$/
+
+const extractFirstOccurrence = (text: string, regex: RegExp): string | undefined => {
+  const match = text.match(regex)
+  return match ? match[0] : undefined
+}
+
+export type TrimmedText = {
+  value: string
+  prefix?: string
+  suffix?: string
+}
+
+export const trimText = (text: string): TrimmedText => ({
+  value: text.replace(leadingRegex, '').replace(trailingRegex, ''),
+  prefix: extractFirstOccurrence(text, leadingRegex),
+  suffix: extractFirstOccurrence(text, trailingRegex),
+})

--- a/packages/app/universal-ts-utils/src/public/string/trimText.ts
+++ b/packages/app/universal-ts-utils/src/public/string/trimText.ts
@@ -1,9 +1,26 @@
 /**
- * TODO: explain
+ * Explanation of the pattern:
+ * `^`          -> asserts the position at the start of the string
+ * `(?: ... )`  -> non-capturing group, does not save the matched substring for back-references
+ *    `[\s\u00A0]`  -> matches:
+ *      `\s`          -> any whitespace character (spaces, tabs, line breaks)
+ *      `\u00A0`      -> the non-breaking space character (equivalent to `&nbsp;`)
+ *      `|`           -> OR operator allows for matching either the left or right pattern
+ *      `&nbsp;`      -> matches the literal string `&nbsp;` (HTML entity for non-breaking space)
+ * `+`          -> matches one or more occurrences of the preceding pattern
  */
 const leadingRegex = /^(?:[\s\u00A0]|&nbsp;)+/
+
 /**
- *  TODO: explain
+ * Explanation of the pattern:
+ * `(?: ... )`  -> non-capturing group, same function as in leadingRegex
+ *    `[\s\u00A0]` -> matches:
+ *        `\s`      -> any whitespace character
+ *        `\u00A0`  -> the non-breaking space character
+ *        `|`       -> OR operator to allow matching `&nbsp;`
+ *        `&nbsp;`  -> matches the literal string `&nbsp;`
+ * `+`          -> matches one or more occurrences
+ * `$`          -> asserts the position at the end of the string
  */
 const trailingRegex = /(?:[\s\u00A0]|&nbsp;)+$/
 
@@ -18,6 +35,17 @@ export type TrimmedText = {
   suffix?: string
 }
 
+/**
+ * Trims whitespace and `&nbsp;` characters from the beginning and end of a given string.
+ * Extracts and provides the removed part as `prefix` and `suffix` properties.
+ *
+ * @param {string} text - The input string from which to trim leading and trailing whitespace
+ * and `&nbsp;` characters.
+ * @returns {TrimmedText} An object containing:
+ *   - `value`: the trimmed string with leading and trailing whitespace and `&nbsp;` removed.
+ *   - `prefix`: the leading whitespace and `&nbsp;` characters that were removed, if any.
+ *   - `suffix`: the trailing whitespace and `&nbsp;` characters that were removed, if any.
+ */
 export const trimText = (text: string): TrimmedText => ({
   value: text.replace(leadingRegex, '').replace(trailingRegex, ''),
   prefix: extractFirstOccurrence(text, leadingRegex),


### PR DESCRIPTION
## Changes

Adding utility to trim a text but contemplating HTML space and in addition can return the trimmed part in case it is needed

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
