### PR TITLE
improve exports config for universal ts utils

### DIFF
--- a/packages/app/universal-ts-utils/README.md
+++ b/packages/app/universal-ts-utils/README.md
@@ -23,7 +23,7 @@ entry point.
 
 **Frontend:**
 ```typescript
-import { chunk } from '@lokalise/universal-ts-utils/array/chunk.js';
+import { chunk } from '@lokalise/universal-ts-utils/array/chunk';
 ```
 
 **Backend:**

--- a/packages/app/universal-ts-utils/package.json
+++ b/packages/app/universal-ts-utils/package.json
@@ -39,15 +39,8 @@
         "vitest": "^2.1.3"
     },
     "exports": {
-        "./node": {
-            "types": "./dist/node.d.ts",
-            "import": "./dist/node.js"
-        },
-        "./*": {
-            "types": "./dist/public/*.d.ts",
-            "import": "./dist/public/*",
-            "require": "./dist/public/*"
-        },
+        "./node": "./dist/node.js",
+        "./*": "./dist/public/*.js",
         "./package.json": "./package.json"
     }
 }


### PR DESCRIPTION
## Changes

This PR improves the exports config in universal-ts-utils package.json.
After the changes, adding explicit extensions when importing an util will be forbidden, and the import will be automatically resolved to the js file.
Thanks to this change IDE will no longer list .dts or source map files in imports autocomplete
![image](https://github.com/user-attachments/assets/38610732-ad50-448d-99bf-9fbc18c9e741)

This is a MAJOR change, as every `*.js` import will have to be replaced with an extensionless one
```
import { mapNonEmptyArray } from '@lokalise/universal-ts-utils/array/mapNonEmptyArray.js'
into
import { mapNonEmptyArray } from '@lokalise/universal-ts-utils/array/mapNonEmptyArray'
```

For more info, please take a look into: https://hirok.io/posts/package-json-exports#subpaths-resolution-advanced

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
