### PR TITLE
Avoiding error if schedule bulk is called with an empty array

### DIFF
--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -257,6 +257,10 @@ describe('AbstractBackgroundJobProcessor', () => {
       expect(secondJob.data.value).toBe('second')
     })
 
+    it('should not fail if scheduleBulk is called with an empty array', async () => {
+      await expect(processor.scheduleBulk([])).resolves.toHaveLength(0)
+    })
+
     it('should trigger onSuccess hook', async () => {
       // Given
       const jobData = {

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -12,9 +12,9 @@ import {
 import type { JobState } from 'bullmq/dist/esm/types/job-type'
 import pino, { stdSerializers } from 'pino'
 import { merge } from 'ts-deepmerge'
-
 import { DEFAULT_QUEUE_OPTIONS, DEFAULT_WORKER_OPTIONS } from '../constants'
 import type { AbstractBullmqFactory } from '../factories/AbstractBullmqFactory'
+import { BackgroundJobProcessorMonitor } from '../monitoring/BackgroundJobProcessorMonitor'
 import { BackgroundJobProcessorSpy } from '../spy/BackgroundJobProcessorSpy'
 import type { BackgroundJobProcessorSpyInterface } from '../spy/types'
 import type { BaseJobPayload, BullmqProcessor, RequestContext, SafeJob } from '../types'
@@ -26,8 +26,6 @@ import {
   resolveJobId,
   sanitizeRedisConfig,
 } from '../utils'
-
-import { BackgroundJobProcessorMonitor } from '../monitoring/BackgroundJobProcessorMonitor'
 import type {
   BackgroundJobProcessorConfig,
   BackgroundJobProcessorDependencies,
@@ -265,6 +263,8 @@ export abstract class AbstractBackgroundJobProcessor<
     jobData: JobPayload[],
     options?: Omit<JobOptionsType, 'repeat'>,
   ): Promise<string[]> {
+    if (jobData.length === 0) return []
+
     await this.startIfNotStarted()
 
     const jobs =


### PR DESCRIPTION
## Changes

Avoiding `Some scheduled job IDs are undefined` error if the jobs to schedule is an empty array

## Checklist

- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [ ] I've updated the documentation, or no changes were necessary
- [ ] I've updated the tests, or no changes were necessary
