### PR TITLE
Unified start() method signature to match existing approaches

### DIFF
--- a/packages/app/background-jobs-common/README.md
+++ b/packages/app/background-jobs-common/README.md
@@ -70,6 +70,7 @@ const jobId = await queueManager.schedule('queue1', {
   metadata: { correlationId: randomUUID() },
 })
 ```
+There's also a way to start only specific queues by using the `startSpecifiedQueues` method and providing the array of queue names as an argument.
 
 ### Common jobs
 
@@ -80,8 +81,7 @@ logger calls, so you only need to add your domain logic.
 By default, the worker is automatically started when you instantiate the processor. There is a default configuration which
 you can override by passing `workerOptions` params to the constructor.
 
-Similarly, queues are automatically started when you instantiate a queue manager providing a list of queues and a queue
-registry.
+Similarly, queues are automatically started when you instantiate a queue manager providing a list of queues.
 
 Use `dispose()` to correctly stop processing any new messages and wait for the current ones to finish.
 

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
@@ -90,7 +90,7 @@ describe('QueueManager', () => {
       const queueManager = new FakeQueueManager([supportedQueues[0]], {
         redisConfig,
       })
-      await queueManager.start(['queue1'])
+      await queueManager.startSpecifiedQueues(['queue1'])
 
       expect(queueManager.getQueue('queue1')).toBeDefined()
       // @ts-expect-error - queue2 is not a valid queue id
@@ -110,7 +110,7 @@ describe('QueueManager', () => {
       expect(() => queueManager.getQueue('queue3')).toThrowError(
         /queue .* was not instantiated yet, please run "start\(\)"/,
       )
-      await queueManager.start(['queue3'])
+      await queueManager.startSpecifiedQueues(['queue3'])
       // @ts-expect-error - queue3 is not a valid queue id
       expect(() => queueManager.getQueue('queue3')).toThrowError(
         /queue .* was not instantiated yet, please run "start\(\)"/,

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -85,7 +85,15 @@ export class QueueManager<
     return this._queues[queueId]
   }
 
-  public async start(queueIdsToStart?: string[]): Promise<void> {
+  public async start(): Promise<void> {
+    if (this.isStarted) return // if it is already started -> skip
+
+    if (!this.startPromise) this.startPromise = this.internalStart()
+    await this.startPromise
+    this.startPromise = undefined
+  }
+
+  public async startSpecifiedQueues(queueIdsToStart?: string[]): Promise<void> {
     if (this.isStarted) return // if it is already started -> skip
 
     if (!this.startPromise) this.startPromise = this.internalStart(queueIdsToStart)
@@ -101,7 +109,7 @@ export class QueueManager<
     }
 
     if (!this.isStarted || !this._queues[queueId]) {
-      return this.start([queueId])
+      return this.startSpecifiedQueues([queueId])
     }
 
     return Promise.resolve()


### PR DESCRIPTION
## Changes

We've changed the signature of start() method of QueueManager by adding an optional list of queues to start. Because of that, when you awilix-manager tries to initialise QueueManager and passes Dependencies as a default first argument, everything breaks. So we need a method without arguments for default initialization.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [ ] I've updated the tests, or no changes were necessary
