### PR TITLE
Improve support for 202

### DIFF
--- a/packages/app/frontend-http-client/src/client.spec.ts
+++ b/packages/app/frontend-http-client/src/client.spec.ts
@@ -267,7 +267,7 @@ describe('frontend-http-client', () => {
       })
     })
 
-    it('returns no content response', async () => {
+    it('returns no content response for 204', async () => {
       const client = wretch(mockServer.url)
 
       await mockServer.forPost('/').thenReply(204)
@@ -275,6 +275,19 @@ describe('frontend-http-client', () => {
       const responseBody = await sendPost(client, {
         path: '/',
         responseBodySchema: z.any(),
+      })
+      expect(responseBody).toBe(null)
+    })
+
+    it('returns no content response for 202', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forPost('/').thenReply(202)
+
+      const responseBody = await sendPost(client, {
+        path: '/',
+        responseBodySchema: z.any(),
+        isEmptyResponseExpected: true,
       })
       expect(responseBody).toBe(null)
     })
@@ -551,7 +564,7 @@ describe('frontend-http-client', () => {
       })
     })
 
-    it('returns no content response', async () => {
+    it('returns no content response for 204', async () => {
       const client = wretch(mockServer.url)
 
       await mockServer.forPut('/').thenReply(204)
@@ -559,6 +572,19 @@ describe('frontend-http-client', () => {
       const responseBody = await sendPut(client, {
         path: '/',
         responseBodySchema: z.any(),
+      })
+      expect(responseBody).toBe(null)
+    })
+
+    it('returns no content response for 202', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forPut('/').thenReply(202)
+
+      const responseBody = await sendPut(client, {
+        path: '/',
+        responseBodySchema: z.any(),
+        isEmptyResponseExpected: true,
       })
       expect(responseBody).toBe(null)
     })
@@ -785,7 +811,7 @@ describe('frontend-http-client', () => {
       })
     })
 
-    it('returns no content response', async () => {
+    it('returns no content response for 204', async () => {
       const client = wretch(mockServer.url)
 
       await mockServer.forPatch('/').thenReply(204)
@@ -793,6 +819,19 @@ describe('frontend-http-client', () => {
       const responseBody = await sendPatch(client, {
         path: '/',
         responseBodySchema: z.any(),
+      })
+      expect(responseBody).toBe(null)
+    })
+
+    it('returns no content response for 202', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forPatch('/').thenReply(202)
+
+      const responseBody = await sendPatch(client, {
+        path: '/',
+        responseBodySchema: z.any(),
+        isEmptyResponseExpected: true,
       })
       expect(responseBody).toBe(null)
     })
@@ -1019,7 +1058,7 @@ describe('frontend-http-client', () => {
       })
     })
 
-    it('returns no content response', async () => {
+    it('returns no content response for 204', async () => {
       const client = wretch(mockServer.url)
 
       await mockServer.forGet('/').thenReply(204)
@@ -1031,6 +1070,22 @@ describe('frontend-http-client', () => {
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         '[Error: Request to / has returned an unexpected empty response.]',
+      )
+    })
+
+    it('returns unexpected no content response for 202', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forGet('/').thenReply(202)
+
+      await expect(
+        sendGet(client, {
+          path: '/',
+          responseBodySchema: z.any(),
+          isEmptyResponseExpected: false,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '[Error: Request to / has returned an unexpected non-JSON response.]',
       )
     })
 

--- a/packages/app/frontend-http-client/src/client.ts
+++ b/packages/app/frontend-http-client/src/client.ts
@@ -68,6 +68,7 @@ function sendResourceChange<
         response,
         params.path,
         params.responseBodySchema,
+        params.isEmptyResponseExpected,
       )
 
       if (bodyParseResult.error === 'NOT_JSON') {
@@ -138,6 +139,7 @@ export function sendGet<
       response,
       params.path,
       params.responseBodySchema,
+      params.isEmptyResponseExpected,
     )
 
     if (bodyParseResult.error === 'NOT_JSON') {
@@ -272,6 +274,7 @@ export function sendDelete<
       response,
       params.path,
       params.responseBodySchema ?? UNKNOWN_SCHEMA,
+      params.isEmptyResponseExpected,
     )
 
     if (bodyParseResult.error === 'NOT_JSON') {


### PR DESCRIPTION
## Changes

Previously it would throw a non-JSON error if empty response was provided

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
