### PR TITLE
Fastify api contracts type improvements

### DIFF
--- a/packages/app/fastify-api-contracts/package.json
+++ b/packages/app/fastify-api-contracts/package.json
@@ -28,7 +28,7 @@
     "dependencies": {},
     "peerDependencies": {
         "@lokalise/node-core": ">=13.5.0",
-        "@lokalise/universal-ts-utils": ">=4.2.0",
+        "@lokalise/universal-ts-utils": ">=4.2.1",
         "fastify": ">=5.0.0",
         "zod": "^3.24.2"
     },
@@ -36,7 +36,7 @@
         "@biomejs/biome": "^1.9.4",
         "@lokalise/biome-config": "^1.5.0",
         "@lokalise/package-vite-config": "latest",
-        "@lokalise/universal-ts-utils": "^4.2.0",
+        "@lokalise/universal-ts-utils": "^4.2.1",
         "@vitest/coverage-v8": "^2.1.3",
         "fastify-type-provider-zod": "^4.0.2",
         "rimraf": "^6.0.1",

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -35,6 +35,12 @@ const PATH_PARAMS_SCHEMA = z.object({
 const HEADERS_SCHEMA = z.object({
   authorization: z.string(),
 })
+const arrayPreprocessor = (value: unknown) => (Array.isArray(value) ? value : [value])
+
+const REQUEST_QUERY_SCHEMA = z.object({
+  testIds: z.preprocess(arrayPreprocessor, z.array(z.string())).optional(),
+  limit: z.coerce.number().gt(0).default(10),
+})
 
 async function initApp(route: RouteOptions) {
   const app = fastify({
@@ -56,6 +62,7 @@ describe('fastifyApiContracts', () => {
       const contract = buildGetRoute({
         successResponseBodySchema: BODY_SCHEMA,
         requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestQuerySchema: REQUEST_QUERY_SCHEMA,
         pathResolver: (pathParams) => `/users/${pathParams.userId}`,
       })
 
@@ -65,44 +72,54 @@ describe('fastifyApiContracts', () => {
   })
   describe('buildFastifyNoPayloadRoute', () => {
     it('uses API spec to build valid GET route in fastify app', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
       const contract = buildGetRoute({
         successResponseBodySchema: BODY_SCHEMA,
         requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestQuerySchema: REQUEST_QUERY_SCHEMA,
         pathResolver: (pathParams) => `/users/${pathParams.userId}`,
       })
 
       const route = buildFastifyNoPayloadRoute(contract, (req) => {
         expect(req.params.userId).toEqual('1')
+        // satisfies checks if type is inferred properly in route
+        expect(req.query.testIds satisfies string[] | undefined).toBeUndefined()
         return Promise.resolve()
       })
 
       const app = await initApp(route)
       const response = await injectGet(app, contract, {
         pathParams: { userId: '1' },
+        queryParams: { limit: 10 },
       })
 
       expect(response.statusCode).toBe(200)
     })
 
     it('uses API spec to build valid GET route with header factory in fastify app', async () => {
-      expect.assertions(2)
+      expect.assertions(3)
       const contract = buildGetRoute({
         successResponseBodySchema: BODY_SCHEMA,
         requestPathParamsSchema: PATH_PARAMS_SCHEMA,
         requestHeaderSchema: HEADERS_SCHEMA,
+        requestQuerySchema: REQUEST_QUERY_SCHEMA,
         pathResolver: (pathParams) => `/users/${pathParams.userId}`,
       })
 
-      const route = buildFastifyNoPayloadRoute(contract, (req) => {
+      const handler = buildFastifyNoPayloadRouteHandler(contract, (req) => {
         expect(req.params.userId).toEqual('1')
+        // satisfies checks if type is inferred properly in handler
+        expect(req.query.testIds satisfies string[] | undefined).toEqual(['test-id'])
         return Promise.resolve()
       })
+
+      const route = buildFastifyNoPayloadRoute(contract, handler)
 
       const app = await initApp(route)
       const response = await injectGet(app, contract, {
         headers: () => Promise.resolve({ authorization: 'dummy' }),
         pathParams: { userId: '1' },
+        queryParams: { testIds: ['test-id'] },
       })
 
       expect(response.statusCode).toBe(200)
@@ -204,12 +221,14 @@ describe('fastifyApiContracts', () => {
         pathResolver: (pathParams) => `/users/${pathParams.userId}`,
       })
 
-      const route = buildFastifyPayloadRoute(contract, (req) => {
+      const handler = buildFastifyPayloadRouteHandler(contract, (req) => {
         expect(req.params.userId).toEqual('1')
         expect(req.body.id).toEqual('2')
         expect(req.headers.authorization).toEqual('dummy')
         return Promise.resolve()
       })
+
+      const route = buildFastifyPayloadRoute(contract, handler)
 
       const app = await initApp(route)
       const response = await injectPost(app, contract, {

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -5,7 +5,7 @@ import {
   type PayloadRouteDefinition,
   mapRouteToPath,
 } from '@lokalise/universal-ts-utils/node'
-import { z } from 'zod'
+import type { z } from 'zod'
 import type {
   ApiContractMetadataToRouteMapper,
   ExtendedFastifySchema,

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -8,7 +8,7 @@ import {
 } from '@lokalise/universal-ts-utils/node'
 import type { FastifyReply, FastifyRequest, RouteOptions } from 'fastify'
 import type { FastifySchema } from 'fastify/types/schema'
-import type { ZodSchema } from 'zod'
+import type { z } from 'zod'
 
 /**
  * Default fastify fields + fastify-swagger fields
@@ -59,41 +59,44 @@ export type FastifyNoPayloadHandlerFn<ReplyType, ParamsType, QueryType, HeadersT
   reply: FastifyReply<{ Body: ReplyType }>,
 ) => Promise<void>
 
+type OptionalZodSchema = z.Schema | undefined
+type InferredOptionalSchema<Schema> = Schema extends z.Schema ? z.infer<Schema> : never
+
 /**
  * Infers handler request type automatically from the contract for GET or DELETE methods
  */
 export function buildFastifyNoPayloadRouteHandler<
-  ResponseBodySchema,
-  PathParams,
-  RequestQuerySchema,
-  RequestHeaderSchema,
+  ResponseBodySchema extends OptionalZodSchema = undefined,
+  PathParams extends OptionalZodSchema = undefined,
+  RequestQuerySchema extends OptionalZodSchema = undefined,
+  RequestHeaderSchema extends OptionalZodSchema = undefined,
 >(
   _apiContract:
     | GetRouteDefinition<
+        InferredOptionalSchema<PathParams>,
+        ResponseBodySchema,
         PathParams,
-        ZodSchema<ResponseBodySchema>,
-        ZodSchema<PathParams>,
-        ZodSchema<RequestQuerySchema>,
-        ZodSchema<RequestHeaderSchema>
+        RequestQuerySchema,
+        RequestHeaderSchema
       >
     | DeleteRouteDefinition<
+        InferredOptionalSchema<PathParams>,
+        ResponseBodySchema,
         PathParams,
-        ZodSchema<ResponseBodySchema>,
-        ZodSchema<PathParams>,
-        ZodSchema<RequestQuerySchema>,
-        ZodSchema<RequestHeaderSchema>
+        RequestQuerySchema,
+        RequestHeaderSchema
       >,
   handler: FastifyNoPayloadHandlerFn<
-    ResponseBodySchema,
-    PathParams,
-    RequestQuerySchema,
-    RequestHeaderSchema
+    InferredOptionalSchema<ResponseBodySchema>,
+    InferredOptionalSchema<PathParams>,
+    InferredOptionalSchema<RequestQuerySchema>,
+    InferredOptionalSchema<RequestHeaderSchema>
   >,
 ): FastifyNoPayloadHandlerFn<
-  ResponseBodySchema,
-  PathParams,
-  RequestQuerySchema,
-  RequestHeaderSchema
+  InferredOptionalSchema<ResponseBodySchema>,
+  InferredOptionalSchema<PathParams>,
+  InferredOptionalSchema<RequestQuerySchema>,
+  InferredOptionalSchema<RequestHeaderSchema>
 > {
   return handler
 }
@@ -102,35 +105,35 @@ export function buildFastifyNoPayloadRouteHandler<
  * Build full fastify route definition for GET or DELETE methods
  */
 export function buildFastifyNoPayloadRoute<
-  ResponseBodySchema,
-  PathParams,
-  RequestQuerySchema,
-  RequestHeaderSchema,
+  ResponseBodySchema extends OptionalZodSchema = undefined,
+  PathParams extends OptionalZodSchema = undefined,
+  RequestQuerySchema extends OptionalZodSchema = undefined,
+  RequestHeaderSchema extends OptionalZodSchema = undefined,
 >(
   apiContract:
     | GetRouteDefinition<
+        InferredOptionalSchema<PathParams>,
+        ResponseBodySchema,
         PathParams,
-        ZodSchema<ResponseBodySchema>,
-        ZodSchema<PathParams>,
-        ZodSchema<RequestQuerySchema>,
-        ZodSchema<RequestHeaderSchema>,
+        RequestQuerySchema,
+        RequestHeaderSchema,
         boolean,
         boolean
       >
     | DeleteRouteDefinition<
+        InferredOptionalSchema<PathParams>,
+        ResponseBodySchema,
         PathParams,
-        ZodSchema<ResponseBodySchema>,
-        ZodSchema<PathParams>,
-        ZodSchema<RequestQuerySchema>,
-        ZodSchema<RequestHeaderSchema>,
+        RequestQuerySchema,
+        RequestHeaderSchema,
         boolean,
         boolean
       >,
   handler: FastifyNoPayloadHandlerFn<
-    ResponseBodySchema,
-    PathParams,
-    RequestQuerySchema,
-    RequestHeaderSchema
+    InferredOptionalSchema<ResponseBodySchema>,
+    InferredOptionalSchema<PathParams>,
+    InferredOptionalSchema<RequestQuerySchema>,
+    InferredOptionalSchema<RequestHeaderSchema>
   >,
 ): RouteType {
   return {
@@ -151,33 +154,33 @@ export function buildFastifyNoPayloadRoute<
  * Infers handler request type automatically from the contract for POST, PUT and PATCH methods
  */
 export function buildFastifyPayloadRouteHandler<
-  RequestBodySchema,
-  ResponseBodySchema,
-  PathParams,
-  RequestQuerySchema,
-  RequestHeaderSchema,
+  RequestBodySchema extends OptionalZodSchema = undefined,
+  ResponseBodySchema extends OptionalZodSchema = undefined,
+  PathParams extends OptionalZodSchema = undefined,
+  RequestQuerySchema extends OptionalZodSchema = undefined,
+  RequestHeaderSchema extends OptionalZodSchema = undefined,
 >(
   _apiContract: PayloadRouteDefinition<
-    PathParams,
-    ZodSchema<RequestBodySchema>,
-    ZodSchema<ResponseBodySchema>,
-    ZodSchema<PathParams>,
-    ZodSchema<RequestQuerySchema>,
-    ZodSchema<RequestHeaderSchema>
-  >,
-  handler: FastifyPayloadHandlerFn<
-    ResponseBodySchema,
+    InferredOptionalSchema<PathParams>,
     RequestBodySchema,
+    ResponseBodySchema,
     PathParams,
     RequestQuerySchema,
     RequestHeaderSchema
   >,
+  handler: FastifyPayloadHandlerFn<
+    InferredOptionalSchema<ResponseBodySchema>,
+    InferredOptionalSchema<RequestBodySchema>,
+    InferredOptionalSchema<PathParams>,
+    InferredOptionalSchema<RequestQuerySchema>,
+    InferredOptionalSchema<RequestHeaderSchema>
+  >,
 ): FastifyPayloadHandlerFn<
-  ResponseBodySchema,
-  RequestBodySchema,
-  PathParams,
-  RequestQuerySchema,
-  RequestHeaderSchema
+  InferredOptionalSchema<ResponseBodySchema>,
+  InferredOptionalSchema<RequestBodySchema>,
+  InferredOptionalSchema<PathParams>,
+  InferredOptionalSchema<RequestQuerySchema>,
+  InferredOptionalSchema<RequestHeaderSchema>
 > {
   return handler
 }
@@ -186,26 +189,26 @@ export function buildFastifyPayloadRouteHandler<
  * Build full fastify route definition for POST, PUT and PATCH methods
  */
 export function buildFastifyPayloadRoute<
-  RequestBodySchema,
-  ResponseBodySchema,
-  PathParams,
-  RequestQuerySchema,
-  RequestHeaderSchema,
+  RequestBodySchema extends OptionalZodSchema = undefined,
+  ResponseBodySchema extends OptionalZodSchema = undefined,
+  PathParams extends OptionalZodSchema = undefined,
+  RequestQuerySchema extends OptionalZodSchema = undefined,
+  RequestHeaderSchema extends OptionalZodSchema = undefined,
 >(
   apiContract: PayloadRouteDefinition<
-    PathParams,
-    ZodSchema<RequestBodySchema>,
-    ZodSchema<ResponseBodySchema>,
-    ZodSchema<PathParams>,
-    ZodSchema<RequestQuerySchema>,
-    ZodSchema<RequestHeaderSchema>
-  >,
-  handler: FastifyPayloadHandlerFn<
-    ResponseBodySchema,
+    InferredOptionalSchema<PathParams>,
     RequestBodySchema,
+    ResponseBodySchema,
     PathParams,
     RequestQuerySchema,
     RequestHeaderSchema
+  >,
+  handler: FastifyPayloadHandlerFn<
+    InferredOptionalSchema<ResponseBodySchema>,
+    InferredOptionalSchema<RequestBodySchema>,
+    InferredOptionalSchema<PathParams>,
+    InferredOptionalSchema<RequestQuerySchema>,
+    InferredOptionalSchema<RequestHeaderSchema>
   >,
 ): RouteType {
   return {

--- a/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
@@ -1,4 +1,7 @@
-import type { InferSchemaOutput } from '@lokalise/universal-ts-utils/api-contracts/apiContracts'
+import type {
+  InferSchemaInput,
+  InferSchemaOutput,
+} from '@lokalise/universal-ts-utils/api-contracts/apiContracts'
 import type {
   DeleteRouteDefinition,
   GetRouteDefinition,
@@ -59,8 +62,8 @@ export async function injectGet<
   >,
   params: RouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
-    InferSchemaOutput<RequestQuerySchema>,
-    InferSchemaOutput<RequestHeaderSchema>
+    InferSchemaInput<RequestQuerySchema>,
+    InferSchemaInput<RequestHeaderSchema>
   >,
 ) {
   const resolvedHeaders =
@@ -97,8 +100,8 @@ export async function injectDelete<
   >,
   params: RouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
-    InferSchemaOutput<RequestQuerySchema>,
-    InferSchemaOutput<RequestHeaderSchema>
+    InferSchemaInput<RequestQuerySchema>,
+    InferSchemaInput<RequestHeaderSchema>
   >,
 ) {
   const resolvedHeaders =
@@ -135,9 +138,9 @@ export async function injectPost<
   >,
   params: PayloadRouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
-    InferSchemaOutput<RequestBodySchema>,
-    InferSchemaOutput<RequestQuerySchema>,
-    InferSchemaOutput<RequestHeaderSchema>
+    InferSchemaInput<RequestBodySchema>,
+    InferSchemaInput<RequestQuerySchema>,
+    InferSchemaInput<RequestHeaderSchema>
   >,
 ) {
   const resolvedHeaders =
@@ -176,9 +179,9 @@ export async function injectPut<
   >,
   params: PayloadRouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
-    InferSchemaOutput<RequestBodySchema>,
-    InferSchemaOutput<RequestQuerySchema>,
-    InferSchemaOutput<RequestHeaderSchema>
+    InferSchemaInput<RequestBodySchema>,
+    InferSchemaInput<RequestQuerySchema>,
+    InferSchemaInput<RequestHeaderSchema>
   >,
 ) {
   const resolvedHeaders =
@@ -217,9 +220,9 @@ export async function injectPatch<
   >,
   params: PayloadRouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
-    InferSchemaOutput<RequestBodySchema>,
-    InferSchemaOutput<RequestQuerySchema>,
-    InferSchemaOutput<RequestHeaderSchema>
+    InferSchemaInput<RequestBodySchema>,
+    InferSchemaInput<RequestQuerySchema>,
+    InferSchemaInput<RequestHeaderSchema>
   >,
 ) {
   const resolvedHeaders =


### PR DESCRIPTION
## Changes

With previous approach, preprocessed schema properties were not inferred properly, and resolved to unknown. This PR solves it by using schemas as generics params and explicit `z.infer<>` for types

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
