### PR TITLE
Type inference improvement

### DIFF
--- a/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
+++ b/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
@@ -34,7 +34,7 @@ export type CommonRouteDefinition<
   requestPathParamsSchema?: PathParamsSchema
   requestQuerySchema?: RequestQuerySchema
   requestHeaderSchema?: RequestHeaderSchema
-  pathResolver: RoutePathResolver<InferSchemaInput<PathParamsSchema>>
+  pathResolver: RoutePathResolver<InferSchemaOutput<PathParamsSchema>>
   responseSchemasByStatusCode?: Partial<Record<HttpStatusCode, z.Schema>>
   description?: string
   metadata?: CommonRouteDefinitionMetadata

--- a/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
+++ b/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
@@ -3,8 +3,14 @@ import type { HttpStatusCode } from './HttpStatusCodes.js'
 
 const EMPTY_PARAMS = {}
 
-export type InferSchemaOutput<T extends ZodSchema | undefined> = T extends ZodSchema<infer U>
-  ? U
+export type InferSchemaInput<T extends ZodSchema | undefined> = T extends ZodSchema
+  ? z.input<T>
+  : T extends undefined
+    ? undefined
+    : never
+
+export type InferSchemaOutput<T extends ZodSchema | undefined> = T extends ZodSchema
+  ? z.infer<T>
   : T extends undefined
     ? undefined
     : never
@@ -28,7 +34,7 @@ export type CommonRouteDefinition<
   requestPathParamsSchema?: PathParamsSchema
   requestQuerySchema?: RequestQuerySchema
   requestHeaderSchema?: RequestHeaderSchema
-  pathResolver: RoutePathResolver<InferSchemaOutput<PathParamsSchema>>
+  pathResolver: RoutePathResolver<InferSchemaInput<PathParamsSchema>>
   responseSchemasByStatusCode?: Partial<Record<HttpStatusCode, z.Schema>>
   description?: string
   metadata?: CommonRouteDefinitionMetadata


### PR DESCRIPTION
## Changes

This change allows to properly infer response type in case preprocessing on response is used. To achieve that we need to use different type inference for input and output values

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
