### PR TITLE
Added support for isNonJSONResponseExpected and isEmptyResponseExpected in fastify api contracts

### DIFF
--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -345,5 +345,37 @@ describe('fastifyApiContracts', () => {
 
       expect(response.statusCode).toBe(200)
     })
+
+    it('supports isNonJSONResponseExpected and isEmptyResponseExpected parameters', async () => {
+      expect.assertions(4)
+      const contract = buildPayloadRoute({
+        method: 'post',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        successResponseBodySchema: z.undefined(),
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestHeaderSchema: HEADERS_SCHEMA,
+        isEmptyResponseExpected: true,
+        isNonJSONResponseExpected: true,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const handler = buildFastifyPayloadRouteHandler(contract, (req) => {
+        expect(req.params.userId).toEqual('1')
+        expect(req.body.id).toEqual('2')
+        expect(req.headers.authorization).toEqual('dummy')
+        return Promise.resolve()
+      })
+
+      const route = buildFastifyPayloadRoute(contract, handler)
+
+      const app = await initApp(route)
+      const response = await injectPost(app, contract, {
+        headers: () => Promise.resolve({ authorization: 'dummy' }),
+        pathParams: { userId: '1' },
+        body: { id: '2' },
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
   })
 })

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -116,6 +116,8 @@ export function buildFastifyPayloadRouteHandler<
   PathParams extends OptionalZodSchema = undefined,
   RequestQuerySchema extends OptionalZodSchema = undefined,
   RequestHeaderSchema extends OptionalZodSchema = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   _apiContract: PayloadRouteDefinition<
     InferredOptionalSchema<PathParams>,
@@ -123,7 +125,9 @@ export function buildFastifyPayloadRouteHandler<
     ResponseBodySchema,
     PathParams,
     RequestQuerySchema,
-    RequestHeaderSchema
+    RequestHeaderSchema,
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   handler: FastifyPayloadHandlerFn<
     InferredOptionalSchema<ResponseBodySchema>,
@@ -151,6 +155,8 @@ export function buildFastifyPayloadRoute<
   PathParams extends OptionalZodSchema = undefined,
   RequestQuerySchema extends OptionalZodSchema = undefined,
   RequestHeaderSchema extends OptionalZodSchema = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   apiContract: PayloadRouteDefinition<
     InferredOptionalSchema<PathParams>,
@@ -158,7 +164,9 @@ export function buildFastifyPayloadRoute<
     ResponseBodySchema,
     PathParams,
     RequestQuerySchema,
-    RequestHeaderSchema
+    RequestHeaderSchema,
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   handler: FastifyPayloadHandlerFn<
     InferredOptionalSchema<ResponseBodySchema>,

--- a/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
@@ -90,7 +90,7 @@ export async function injectDelete<
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
 >(
   app: FastifyInstance,
   apiContract: DeleteRouteDefinition<

--- a/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
@@ -49,6 +49,8 @@ export async function injectGet<
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   app: FastifyInstance,
   apiContract: GetRouteDefinition<
@@ -57,8 +59,8 @@ export async function injectGet<
     PathParamsSchema,
     RequestQuerySchema,
     RequestHeaderSchema,
-    boolean,
-    boolean
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   params: RouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
@@ -87,6 +89,8 @@ export async function injectDelete<
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   app: FastifyInstance,
   apiContract: DeleteRouteDefinition<
@@ -95,8 +99,8 @@ export async function injectDelete<
     PathParamsSchema,
     RequestQuerySchema,
     RequestHeaderSchema,
-    boolean,
-    boolean
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   params: RouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
@@ -126,6 +130,8 @@ export async function injectPost<
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   app: FastifyInstance,
   apiContract: PayloadRouteDefinition<
@@ -134,7 +140,9 @@ export async function injectPost<
     ResponseBodySchema,
     PathParamsSchema,
     RequestQuerySchema,
-    RequestHeaderSchema
+    RequestHeaderSchema,
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   params: PayloadRouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
@@ -167,6 +175,8 @@ export async function injectPut<
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   app: FastifyInstance,
   apiContract: PayloadRouteDefinition<
@@ -175,7 +185,9 @@ export async function injectPut<
     ResponseBodySchema,
     PathParamsSchema,
     RequestQuerySchema,
-    RequestHeaderSchema
+    RequestHeaderSchema,
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   params: PayloadRouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,
@@ -208,6 +220,8 @@ export async function injectPatch<
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
 >(
   app: FastifyInstance,
   apiContract: PayloadRouteDefinition<
@@ -216,7 +230,9 @@ export async function injectPatch<
     ResponseBodySchema,
     PathParamsSchema,
     RequestQuerySchema,
-    RequestHeaderSchema
+    RequestHeaderSchema,
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected
   >,
   params: PayloadRouteRequestParams<
     InferSchemaOutput<PathParamsSchema>,

--- a/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
+++ b/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
@@ -201,7 +201,7 @@ export function buildDeleteRoute<
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
-  IsEmptyResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = true,
   PathParams = PathParamsSchema extends z.Schema<infer T> ? T : never,
 >(
   params: Omit<


### PR DESCRIPTION
## Changes

Without types propagation, it wasn't possible to generate handler for contract that uses `isNonJSONResponseExpected` or `isEmptyResponseExpected`

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
