### PR TITLE
bg processor shared spy instance

### DIFF
--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
@@ -573,8 +573,8 @@ describe('QueueManager', () => {
         redisConfig,
         isTest: false,
       })
-      expect(() => queueManager.getSpy('queue1')).toThrowError(
-        'spy was not instantiated, it is only available on test mode. Please use `config.isTest` to enable it.',
+      expect(() => queueManager.getSpy('queue1')).toThrowErrorMatchingInlineSnapshot(
+        "[Error: queue1 spy was not instantiated, it is only available on test mode. Please use 'config.isTest` to enable it on QueueManager]",
       )
     })
 

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
@@ -574,7 +574,7 @@ describe('QueueManager', () => {
         isTest: false,
       })
       expect(() => queueManager.getSpy('queue1')).toThrowErrorMatchingInlineSnapshot(
-        "[Error: queue1 spy was not instantiated, it is only available on test mode. Please use 'config.isTest` to enable it on QueueManager]",
+        '[Error: queue1 spy was not instantiated, it is only available on test mode. Please use `config.isTest` to enable it on QueueManager]',
       )
     })
 

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
@@ -585,13 +585,13 @@ describe('QueueManager', () => {
       const schema1 = supportedQueues[0].jobPayloadSchema
       type schemaType1 = z.infer<typeof schema1>
       expectTypeOf<returnType1>().toEqualTypeOf<
-        BackgroundJobProcessorSpyInterface<schemaType1, undefined>
+        BackgroundJobProcessorSpyInterface<schemaType1, unknown>
       >()
 
       const schema2 = supportedQueues[1].jobPayloadSchema
       type schemaType2 = z.infer<typeof schema2>
       expectTypeOf<returnType2>().toEqualTypeOf<
-        BackgroundJobProcessorSpyInterface<schemaType2, undefined>
+        BackgroundJobProcessorSpyInterface<schemaType2, unknown>
       >()
     })
   })

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -41,7 +41,8 @@ export class QueueManager<
     QueueConfiguration<QueueOptionsType>['queueId'],
     BackgroundJobProcessorSpy<
       JobPayloadForQueue<Queues, QueueConfiguration<QueueOptionsType>['queueId']>,
-      undefined
+      // biome-ignore lint/suspicious/noExplicitAny: At this point we don't know the return type of the spy
+      any
     >
   > = {}
 
@@ -264,12 +265,12 @@ export class QueueManager<
     }
   }
 
-  public getSpy<QueueId extends SupportedQueueIds<Queues>>(
+  public getSpy<QueueId extends SupportedQueueIds<Queues>, JobReturn = unknown>(
     queueId: QueueId,
-  ): BackgroundJobProcessorSpyInterface<JobPayloadForQueue<Queues, QueueId>, undefined> {
+  ): BackgroundJobProcessorSpyInterface<JobPayloadForQueue<Queues, QueueId>, JobReturn> {
     if (!this.spies[queueId])
       throw new Error(
-        `${queueId} spy was not instantiated, it is only available on test mode. Please use \`config.isTest\` to enable it.`,
+        `${queueId} spy was not instantiated, it is only available on test mode. Please use \`config.isTest\` to enable it on QueueManager instantiation`,
       )
 
     return this.spies[queueId]

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -270,7 +270,7 @@ export class QueueManager<
   ): BackgroundJobProcessorSpyInterface<JobPayloadForQueue<Queues, QueueId>, JobReturn> {
     if (!this.spies[queueId])
       throw new Error(
-        `${queueId} spy was not instantiated, it is only available on test mode. Please use \`config.isTest\` to enable it on QueueManager instantiation`,
+        `${queueId} spy was not instantiated, it is only available on test mode. Please use \`config.isTest\` to enable it on QueueManager`,
       )
 
     return this.spies[queueId]

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -31,11 +31,11 @@ export class QueueManager<
   QueueOptionsType extends QueueOptions = QueueOptions,
   JobOptionsType extends JobsOptions = JobsOptions,
 > {
+  public readonly config: QueueManagerConfig
+
   protected readonly queueRegistry: QueueRegistry<Queues, QueueOptionsType, JobOptionsType>
 
   private readonly factory: BullmqQueueFactory<QueueType, QueueOptionsType>
-  private config: QueueManagerConfig
-
   private readonly _queues: Record<QueueConfiguration<QueueOptionsType>['queueId'], QueueType> = {}
   private readonly spies: Record<
     QueueConfiguration<QueueOptionsType>['queueId'],

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.barrier.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.barrier.spec.ts
@@ -45,7 +45,6 @@ describe('AbstractBackgroundJobProcessor Barrier', () => {
     const processor = new TestBarrierBackgroundJobProcessorNew<SupportedQueues, 'queue', JobReturn>(
       deps,
       'queue',
-      factory.getRedisConfig(),
       () => {
         counter++
         return Promise.resolve({
@@ -73,7 +72,6 @@ describe('AbstractBackgroundJobProcessor Barrier', () => {
     const processor = new TestBarrierBackgroundJobProcessorNew<SupportedQueues, 'queue', JobReturn>(
       deps,
       'queue',
-      factory.getRedisConfig(),
       () => {
         counter++
 

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.error.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.error.spec.ts
@@ -35,12 +35,7 @@ describe('AbstractBackgroundJobProcessorNew - error', () => {
 
     await factory.clearRedis()
 
-    const redisConfig = factory.getRedisConfig()
-    processor = new TestFailingBackgroundJobProcessorNew<SupportedQueues, 'queue'>(
-      deps,
-      'queue',
-      redisConfig,
-    )
+    processor = new TestFailingBackgroundJobProcessorNew<SupportedQueues, 'queue'>(deps, 'queue')
     await processor.start()
   })
 

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.repeatable.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.repeatable.spec.ts
@@ -34,12 +34,7 @@ describe('AbstractBackgroundJobProcessorNew - repeatable', () => {
 
     await factory.clearRedis()
 
-    const redisConfig = factory.getRedisConfig()
-    processor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(
-      deps,
-      'queue',
-      redisConfig,
-    )
+    processor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(deps, 'queue')
     await processor.start()
   })
 

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.stalled.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.stalled.spec.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { TestDependencyFactory } from '../../../test/TestDependencyFactory'
 import { TestStalledBackgroundJobProcessorNew } from '../../../test/processors/TestStalledBackgroundJobProcessorNew'
-import { FakeQueueManager } from '../managers/FakeQueueManager'
+import type { FakeQueueManager } from '../managers/FakeQueueManager'
 import type { QueueConfiguration } from '../managers/types'
 import type { BackgroundJobProcessorDependenciesNew } from './types'
 
@@ -31,23 +31,19 @@ describe('AbstractBackgroundJobProcessorNew - stalled', () => {
 
   beforeEach(async () => {
     factory = new TestDependencyFactory()
-    deps = factory.createNew(supportedQueues)
+    deps = factory.createNew(supportedQueues, true)
 
     await factory.clearRedis()
 
-    const redisConfig = factory.getRedisConfig()
-    stalledProcessor = new TestStalledBackgroundJobProcessorNew(deps, 'queue', redisConfig)
+    queueManager = deps.queueManager
+
+    stalledProcessor = new TestStalledBackgroundJobProcessorNew(deps, 'queue')
     await stalledProcessor.start()
-    queueManager = new FakeQueueManager(supportedQueues, {
-      redisConfig,
-      isTest: false,
-    })
     await queueManager.start()
   })
 
   afterEach(async () => {
     await stalledProcessor.dispose()
-    await queueManager.dispose()
     await factory.dispose()
   })
 

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.start.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.start.spec.ts
@@ -1,5 +1,4 @@
 import { generateMonotonicUuid } from '@lokalise/id-utils'
-import type { RedisConfig } from '@lokalise/node-core'
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import { TestDependencyFactory } from '../../../test/TestDependencyFactory'
@@ -26,12 +25,10 @@ describe('AbstractBackgroundJobProcessorNew - start', () => {
   let factory: TestDependencyFactory
   let deps: BackgroundJobProcessorDependenciesNew<SupportedQueues, 'queue'>
   let queueManager: FakeQueueManager<SupportedQueues>
-  let redisConfig: RedisConfig
 
   beforeEach(async () => {
     factory = new TestDependencyFactory()
     deps = factory.createNew(supportedQueues)
-    redisConfig = factory.getRedisConfig()
     queueManager = deps.queueManager
 
     await factory.clearRedis()
@@ -42,30 +39,18 @@ describe('AbstractBackgroundJobProcessorNew - start', () => {
   })
 
   it('throws an error if queue id is not unique', async () => {
-    const job1 = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(
-      deps,
-      'queue',
-      redisConfig,
-    )
+    const job1 = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(deps, 'queue')
 
     await job1.start()
     await expect(
-      new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(
-        deps,
-        'queue',
-        redisConfig,
-      ).start(),
+      new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(deps, 'queue').start(),
     ).rejects.toMatchInlineSnapshot('[Error: Processor for queue id "queue" is not unique.]')
 
     await job1.dispose()
   })
 
   it('Multiple start calls (sequential or concurrent) not produce errors', async () => {
-    const processor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(
-      deps,
-      'queue',
-      redisConfig,
-    )
+    const processor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(deps, 'queue')
 
     // sequential start calls
     await expect(processor.start()).resolves.not.toThrowError()
@@ -79,11 +64,7 @@ describe('AbstractBackgroundJobProcessorNew - start', () => {
 
   it('restart processor after dispose', async () => {
     await queueManager.start()
-    const processor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(
-      deps,
-      'queue',
-      redisConfig,
-    )
+    const processor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue'>(deps, 'queue')
     await processor.start()
     await processor.dispose()
 
@@ -107,7 +88,6 @@ describe('AbstractBackgroundJobProcessorNew - start', () => {
     const processor = new TestOverrideProcessBackgroundProcessor<SupportedQueues, 'queue'>(
       deps,
       'queue',
-      redisConfig,
     )
     await processor.start()
 

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.success.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.success.spec.ts
@@ -48,17 +48,11 @@ describe('AbstractBackgroundJobProcessorNew - success', () => {
 
     await factory.clearRedis()
 
-    const redisConfig = factory.getRedisConfig()
-    simpleProcessor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue1'>(
-      deps,
-      'queue1',
-      redisConfig,
-    )
+    simpleProcessor = new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue1'>(deps, 'queue1')
     await simpleProcessor.start()
     processorWithSuccessHook = new TestSuccessBackgroundJobProcessorNew<SupportedQueues, 'queue2'>(
       deps,
       'queue2',
-      redisConfig,
     )
     await processorWithSuccessHook.start()
   })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/FakeBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/FakeBackgroundJobProcessorNew.ts
@@ -1,4 +1,3 @@
-import type { RedisConfig } from '@lokalise/node-core'
 import type { Job } from 'bullmq'
 import { CommonBullmqFactoryNew } from '../factories/CommonBullmqFactoryNew'
 import type { QueueConfiguration, SupportedQueueIds } from '../managers/types'
@@ -15,8 +14,6 @@ export class FakeBackgroundJobProcessorNew<
       'workerFactory' | 'transactionObservabilityManager'
     >,
     queueId: QueueId,
-    redisConfig: RedisConfig,
-    isTest = true,
   ) {
     super(
       {
@@ -35,9 +32,7 @@ export class FakeBackgroundJobProcessorNew<
       {
         queueId,
         ownerName: 'testOwner',
-        isTest,
         workerOptions: { concurrency: 1 },
-        redisConfig,
       },
     )
   }

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/types.ts
@@ -29,11 +29,9 @@ export type BackgroundJobProcessorConfigNew<
   >,
 > = {
   queueId: QueueId
-  isTest: boolean
   // Name of a webservice or a module running the bg job. Used for logging/observability
   ownerName: string
   workerOptions: Omit<Partial<WorkerOptionsType>, 'connection' | 'prefix' | 'autorun'>
-  redisConfig: RedisConfig
   barrier?: BarrierCallback<
     JobPayloadForQueue<Queues, QueueId>,
     ExecutionContext,

--- a/packages/app/background-jobs-common/test/TestDependencyFactory.ts
+++ b/packages/app/background-jobs-common/test/TestDependencyFactory.ts
@@ -50,11 +50,13 @@ export class TestDependencyFactory {
 
   createNew<Queues extends QueueConfiguration[]>(
     queues: Queues,
+    isTest = true,
+    lazyInitEnabled = true,
   ): BackgroundJobProcessorDependenciesNew<Queues, SupportedQueueIds<Queues>> {
     this.queueManager = new FakeQueueManager(queues, {
-      isTest: true,
+      isTest,
       redisConfig: this.getRedisConfig(),
-      lazyInitEnabled: true,
+      lazyInitEnabled,
     })
     return {
       workerFactory: new CommonBullmqFactoryNew(),

--- a/packages/app/background-jobs-common/test/processors/TestBarrierBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/test/processors/TestBarrierBackgroundJobProcessorNew.ts
@@ -1,4 +1,3 @@
-import type { RedisConfig } from '@lokalise/node-core'
 import {
   AbstractBackgroundJobProcessorNew,
   type BackgroundJobProcessorDependenciesNew,
@@ -16,15 +15,12 @@ export class TestBarrierBackgroundJobProcessorNew<
   constructor(
     dependencies: BackgroundJobProcessorDependenciesNew<Q, T, JobReturn>,
     queueId: T,
-    redisConfig: RedisConfig,
     barrier: BarrierCallback<JobPayloadForQueue<Q, T>>,
   ) {
     super(dependencies, {
       queueId,
       ownerName: 'test',
-      isTest: true,
       workerOptions: { concurrency: 1 },
-      redisConfig: redisConfig,
       barrier,
     })
   }

--- a/packages/app/background-jobs-common/test/processors/TestFailingBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/test/processors/TestFailingBackgroundJobProcessorNew.ts
@@ -1,8 +1,5 @@
 import type { Job } from 'bullmq'
-
-import type { RedisConfig } from '@lokalise/node-core'
 import {
-  type BackgroundJobProcessorDependenciesNew,
   type BaseJobPayload,
   FakeBackgroundJobProcessorNew,
   type QueueConfiguration,
@@ -17,14 +14,6 @@ export class TestFailingBackgroundJobProcessorNew<
   private _errorsOnProcess: Error[] = []
   private _errorsToThrowOnProcess: Error[] = []
   private _errorToThrowOnFailed: Error | undefined
-
-  constructor(
-    dependencies: BackgroundJobProcessorDependenciesNew<Q, T>,
-    queueName: T,
-    redisConfig: RedisConfig,
-  ) {
-    super(dependencies, queueName, redisConfig, true)
-  }
 
   protected override async process(job: Job<unknown>): Promise<void> {
     await super.process(job)

--- a/packages/app/background-jobs-common/test/processors/TestOverrideProcessBackgroundProcessor.ts
+++ b/packages/app/background-jobs-common/test/processors/TestOverrideProcessBackgroundProcessor.ts
@@ -1,4 +1,3 @@
-import type { RedisConfig } from '@lokalise/node-core'
 import type { Job } from 'bullmq'
 import {
   AbstractBackgroundJobProcessorNew,
@@ -18,17 +17,11 @@ export class TestOverrideProcessBackgroundProcessor<
 > extends AbstractBackgroundJobProcessorNew<Q, T> {
   private _processOverride?: ProcessOverride<Q, T>
 
-  constructor(
-    dependencies: BackgroundJobProcessorDependenciesNew<Q, T>,
-    queueId: T,
-    redisConfig: RedisConfig,
-  ) {
+  constructor(dependencies: BackgroundJobProcessorDependenciesNew<Q, T>, queueId: T) {
     super(dependencies, {
       queueId,
       ownerName: 'test',
-      isTest: true,
       workerOptions: { concurrency: 1 },
-      redisConfig: redisConfig,
     })
   }
 

--- a/packages/app/background-jobs-common/test/processors/TestReturnValueBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/test/processors/TestReturnValueBackgroundJobProcessorNew.ts
@@ -1,4 +1,3 @@
-import type { RedisConfig } from '@lokalise/node-core'
 import {
   AbstractBackgroundJobProcessorNew,
   type BackgroundJobProcessorDependenciesNew,
@@ -16,15 +15,12 @@ export class TestReturnValueBackgroundJobProcessorNew<
   constructor(
     dependencies: BackgroundJobProcessorDependenciesNew<Q, T, JobReturn>,
     queueId: T,
-    redisConfig: RedisConfig,
     returnValue: JobReturn,
   ) {
     super(dependencies, {
       queueId,
       ownerName: 'test',
-      isTest: true,
       workerOptions: { concurrency: 1 },
-      redisConfig: redisConfig,
     })
     this.returnValue = returnValue
   }

--- a/packages/app/background-jobs-common/test/processors/TestStalledBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/test/processors/TestStalledBackgroundJobProcessorNew.ts
@@ -1,6 +1,4 @@
 import type { Job } from 'bullmq'
-
-import type { RedisConfig } from '@lokalise/node-core'
 import {
   AbstractBackgroundJobProcessorNew,
   type BackgroundJobProcessorDependenciesNew,
@@ -19,20 +17,14 @@ export class TestStalledBackgroundJobProcessorNew<
 > extends AbstractBackgroundJobProcessorNew<Q, T> {
   private _onFailedErrors: OnFailedError[] = []
 
-  constructor(
-    dependencies: BackgroundJobProcessorDependenciesNew<Q, T>,
-    queueId: T,
-    redisConfig: RedisConfig,
-  ) {
+  constructor(dependencies: BackgroundJobProcessorDependenciesNew<Q, T>, queueId: T) {
     super(dependencies, {
       queueId,
       ownerName: 'test',
-      isTest: false, // We don't want to override job options for this processor
       workerOptions: {
         lockDuration: 1,
         stalledInterval: 1,
       },
-      redisConfig: redisConfig,
     })
   }
 

--- a/packages/app/background-jobs-common/test/processors/TestSuccessBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/test/processors/TestSuccessBackgroundJobProcessorNew.ts
@@ -1,16 +1,10 @@
 import type { Job } from 'bullmq'
-
-import type { RedisConfig } from '@lokalise/node-core'
 import {
   type BaseJobPayload,
   FakeBackgroundJobProcessorNew,
   type SupportedQueueIds,
 } from '../../src'
-import type {
-  BackgroundJobProcessorDependenciesNew,
-  QueueConfiguration,
-  RequestContext,
-} from '../../src'
+import type { QueueConfiguration, RequestContext } from '../../src'
 
 export class TestSuccessBackgroundJobProcessorNew<
   Q extends QueueConfiguration[],
@@ -19,14 +13,6 @@ export class TestSuccessBackgroundJobProcessorNew<
   private onSuccessCounter = 0
   private onSuccessCall!: (job: Job<BaseJobPayload>) => void
   private _jobDataResult!: unknown
-
-  constructor(
-    dependencies: BackgroundJobProcessorDependenciesNew<Q, T>,
-    queueId: T,
-    redisConfig: RedisConfig,
-  ) {
-    super(dependencies, queueId, redisConfig, true)
-  }
 
   protected override process(): Promise<void> {
     return Promise.resolve()


### PR DESCRIPTION
## Changes

With this PR, we are sharing the spy instance between the processor and queue manager, which helps to have better visibility on the real state of the job.

Also, we are removing `isTest` and `redisConfig` from the processor config, it will now be taken from the queue manager. This helps to simplify config and avoid configuration issues (eg, having queue and processor with different redis instances)

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
