### PR TITLE
fix(frontend-http-client): build with turborepo

### DIFF
--- a/packages/app/frontend-http-client/package.json
+++ b/packages/app/frontend-http-client/package.json
@@ -32,27 +32,27 @@
         "access": "public"
     },
     "scripts": {
-        "build:dev": "tsc",
-        "build:release": "tsup",
+        "build": "tsup",
         "clean": "rimraf dist",
         "lint": "biome check . && tsc --noEmit",
         "lint:fix": "biome check --write",
         "package-version": "echo $npm_package_version",
         "test": "vitest run --coverage",
-        "prepublishOnly": "npm run clean && npm run build:release",
+        "prepublishOnly": "npm run clean && npm run build",
         "postversion": "biome check --write package.json"
     },
     "dependencies": {
         "fast-querystring": "^1.1.2"
     },
     "peerDependencies": {
-        "@lokalise/universal-ts-utils": ">=4.2.2",
+        "@lokalise/universal-ts-utils": "^4.2.2",
         "wretch": "^2.8.0",
         "zod": "^3.22.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^1.8.3",
         "@lokalise/biome-config": "^1.0.0",
+        "@lokalise/universal-ts-utils": "^4.2.2",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.5",
         "jest-fail-on-console": "^3.1.2",


### PR DESCRIPTION
## Changes

This PR renames build script so that it can be used with turborepo.
Also, it adds universal-ts-utils to devDeps, so turbo can build it before building fe-http-client.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
