### PR TITLE
chore: add sharable tsconfig package

### DIFF
--- a/.github/workflows/release.tsconfig.yml
+++ b/.github/workflows/release.tsconfig.yml
@@ -1,0 +1,18 @@
+name: Package release to NPM -> tsconfig
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - 'packages/dev/tsconfig/**'
+
+jobs:
+  call-build-flow:
+    uses: lokalise/shared-ts-libs/.github/workflows/release.package.yml@main
+    with:
+      working_directory: 'packages/dev/tsconfig'
+      package_name: '@lokalise/tsconfig'
+    secrets:
+      npm_token: ${{ secrets.NPM_TOKEN }}

--- a/packages/app/non-translatable-markup/package.json
+++ b/packages/app/non-translatable-markup/package.json
@@ -30,6 +30,7 @@
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@lokalise/biome-config": "^1.5.0",
+        "@lokalise/tsconfig": "*",
         "@vitest/coverage-v8": "^3.0.7",
         "rimraf": "^6.0.1",
         "typescript": "5.8.2",

--- a/packages/app/non-translatable-markup/tsconfig.build.json
+++ b/packages/app/non-translatable-markup/tsconfig.build.json
@@ -1,11 +1,5 @@
 {
-    "compilerOptions": {
-        "noEmit": false,
-        "outDir": "dist",
-        "sourceMap": true,
-        "declaration": true
-    },
-    "extends": ["./tsconfig.json"],
+    "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"],
     "include": ["src/**/*"],
     "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/packages/app/non-translatable-markup/tsconfig.json
+++ b/packages/app/non-translatable-markup/tsconfig.json
@@ -1,21 +1,4 @@
 {
-    "compilerOptions": {
-        "module": "Node16",
-        "target": "ES2022",
-        "lib": ["ES2022"],
-        "types": ["node", "vitest/globals"],
-        "noEmit": true,
-        "strict": true,
-        "noImplicitOverride": true,
-        "noUncheckedIndexedAccess": true,
-        "noUncheckedSideEffectImports": true,
-        "erasableSyntaxOnly": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "verbatimModuleSyntax": true,
-        "moduleDetection": "force",
-        "resolveJsonModule": true
-    },
-    "include": ["src/**/*", "vitest.config.ts"],
-    "exclude": []
+    "extends": "@lokalise/tsconfig/tsc",
+    "include": ["src/**/*", "vitest.config.ts"]
 }

--- a/packages/app/non-translatable-markup/vitest.config.ts
+++ b/packages/app/non-translatable-markup/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config'
 // biome-ignore lint/style/noDefaultExport: vite expects default export
 export default defineConfig({
   test: {
-    globals: true,
     poolOptions: {
       threads: {
         singleThread: true,

--- a/packages/dev/tsconfig/LICENSE.md
+++ b/packages/dev/tsconfig/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2025 Lokalise, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/dev/tsconfig/README.md
+++ b/packages/dev/tsconfig/README.md
@@ -1,0 +1,139 @@
+# @lokalise/tsconfig
+
+Shared TypeScript configuration for Lokalise projects.
+
+## Getting Started
+
+### Requirements:
+- TypeScript `^5.8.0`
+- ESM codebase
+
+### Installation:
+```bash
+npm install --save-dev @lokalise/tsconfig
+```
+
+TypeScript configuration depends on whether you're using `tsc` to build your code or a `bundler` (Vite, esbuild, SWC, etc.).
+
+## **Using a Bundler**
+
+Create a `tsconfig.json` for type-checking:
+
+```jsonc
+{
+  "extends": "@lokalise/tsconfig/bundler",
+  "extends": "@lokalise/tsconfig/bundler-dom", // When your code runs in the DOM
+  // Whitelist files that should be used for type-checking:
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
+}
+```
+**Note:** Choose only one `"extends"` option for `tsconfig.json`.
+
+## **Using `tsc` (TypeScript Compiler)**
+
+Create a `tsconfig.json` for type-checking:
+
+```jsonc
+{
+  "extends": "@lokalise/tsconfig/tsc",
+  "extends": "@lokalise/tsconfig/tsc-dom", // When your code runs in the DOM
+  // Whitelist files that should be used for type-checking:
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
+}
+```
+**Note:** Choose only one `"extends"` option for `tsconfig.json`.
+
+Create a `tsconfig.build.json` for building the code:
+
+```jsonc
+{
+  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-app"], // For an app
+  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"], // For a publishable library
+  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-private-lib"], // For a private monorepo library
+  "include": ["src/**/*"], // Include only necessary files
+  "exclude": ["src/**/*.test.ts"] // Exclude unneeded files from the build output
+}
+```
+
+**Note:** Choose only one `"extends"` option for `tsconfig.build.json`.
+
+## **Additional Configuration Options**
+
+### **JSX Support**
+If your app uses JSX, specify it in `tsconfig.json`:
+
+```json
+{
+  "extends": "@lokalise/tsconfig/bundler-dom",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}
+```
+
+### **Adding Global Types**
+To include additional type definitions:
+
+```json
+{
+  "extends": "@lokalise/tsconfig/tsc",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}
+```
+
+## **Options That Can Be Disabled for Migration**
+
+### **`erasableSyntaxOnly`**
+
+[erasableSyntaxOnly](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
+marks the following syntax as errors:
+- `enum` declarations
+- `namespace` and `module` with runtime code
+- Parameter properties in classes
+- Non-ECMAScript `import =` and `export =` assignments
+
+To disable:
+```json
+{
+  "extends": "@lokalise/tsconfig/tsc",
+  "compilerOptions": {
+    "erasableSyntaxOnly": false
+  }
+}
+```
+
+### **`noUncheckedIndexedAccess`**
+[noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess)
+ensures that accessing arrays or objects without checking if a value exists first results in a TypeScript error, preventing potential runtime crashes.
+
+**Example for accessing the array:**
+```typescript
+const arr: string[] = [];
+
+console.log(arr[0].trim());
+// With `"noUncheckedIndexedAccess": true` → TypeScript error: "Object is possibly `undefined`"
+// With `"noUncheckedIndexedAccess": false` → No error, but at runtime, this will throw:
+// "TypeError: Cannot read properties of undefined (reading 'trim')"
+```
+
+**Example for accessing the object:**
+```typescript
+const obj: Record<string, string> = {};
+
+console.log(obj.some.trim());
+// With `"noUncheckedIndexedAccess": true` → TypeScript error: "`obj.some` is possibly `undefined`"
+// With `"noUncheckedIndexedAccess": false` → No error, but at runtime, this will throw:
+// "TypeError: Cannot read properties of undefined (reading 'trim')"
+```
+
+To disable:
+```json
+{
+  "extends": "@lokalise/tsconfig/tsc",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": false
+  }
+}
+```

--- a/packages/dev/tsconfig/README.md
+++ b/packages/dev/tsconfig/README.md
@@ -13,55 +13,81 @@ Shared TypeScript configuration for Lokalise projects.
 npm install --save-dev @lokalise/tsconfig
 ```
 
-TypeScript configuration depends on whether you're using `tsc` to build your code or a `bundler` (Vite, esbuild, SWC, etc.).
+TypeScript configuration depends on whether you're using a `bundler` (Vite, esbuild, SWC, etc.) or `tsc` to build your code:
+- `Bundlers` are commonly used for frontend applications, where they also bundle and optimize code for faster loading.
+- `tsc` is typically used for backend applications and libraries, where you directly compile TypeScript into JavaScript.
 
 ## **Using a Bundler**
 
-Create a `tsconfig.json` for type-checking:
-
-```jsonc
+Create a `tsconfig.json` that whitelists the files for type-checking:
+```json
 {
   "extends": "@lokalise/tsconfig/bundler",
-  "extends": "@lokalise/tsconfig/bundler-dom", // When your code runs in the DOM
-  // Whitelist files that should be used for type-checking:
   "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
 }
 ```
-**Note:** Choose only one `"extends"` option for `tsconfig.json`.
+
+For frontend applications running in the DOM:
+```json
+{
+  "extends": "@lokalise/tsconfig/bundler-dom",
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
+}
+```
 
 ## **Using `tsc` (TypeScript Compiler)**
 
-Create a `tsconfig.json` for type-checking:
-
-```jsonc
+Create a `tsconfig.json` that whitelists the files for type-checking:
+```json
 {
   "extends": "@lokalise/tsconfig/tsc",
-  "extends": "@lokalise/tsconfig/tsc-dom", // When your code runs in the DOM
-  // Whitelist files that should be used for type-checking:
   "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
 }
 ```
-**Note:** Choose only one `"extends"` option for `tsconfig.json`.
 
-Create a `tsconfig.build.json` for building the code:
-
-```jsonc
+For frontend applications running in the DOM:
+```json
 {
-  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-app"], // For an app
-  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"], // For a publishable library
-  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-private-lib"], // For a private monorepo library
-  "include": ["src/**/*"], // Include only necessary files
-  "exclude": ["src/**/*.test.ts"] // Exclude unneeded files from the build output
+  "extends": "@lokalise/tsconfig/tsc-dom",
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
 }
 ```
 
-**Note:** Choose only one `"extends"` option for `tsconfig.build.json`.
+Create a `tsconfig.build.json` for building the code, ensuring that only
+the necessary files are included, and unnecessary ones are excluded.
+
+For building an application or a service:
+```json
+{
+  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-app"],
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}
+```
+
+For building a publishable library:
+```json
+{
+  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"],
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}
+```
+
+For building a private monorepo library:
+```json
+{
+  "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-private-lib"],
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}
+```
 
 ## **Additional Configuration Options**
 
 ### **JSX Support**
-If your app uses JSX, specify it in `tsconfig.json`:
 
+If your app uses JSX, add `jsx` option in `tsconfig.json`:
 ```json
 {
   "extends": "@lokalise/tsconfig/bundler-dom",
@@ -72,8 +98,8 @@ If your app uses JSX, specify it in `tsconfig.json`:
 ```
 
 ### **Adding Global Types**
-To include additional type definitions:
 
+To include additional type definitions, add `types` option in `tsconfig.json`:
 ```json
 {
   "extends": "@lokalise/tsconfig/tsc",
@@ -83,12 +109,11 @@ To include additional type definitions:
 }
 ```
 
-## **Options That Can Be Disabled for Migration**
+## **Options That Can Be Disabled To Ease Adoption**
 
-### **`erasableSyntaxOnly`**
+### [erasableSyntaxOnly](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
 
-[erasableSyntaxOnly](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
-marks the following syntax as errors:
+It marks the following syntax as errors:
 - `enum` declarations
 - `namespace` and `module` with runtime code
 - Parameter properties in classes
@@ -104,29 +129,30 @@ To disable:
 }
 ```
 
-### **`noUncheckedIndexedAccess`**
-[noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess)
-ensures that accessing arrays or objects without checking if a value exists first results in a TypeScript error, preventing potential runtime crashes.
+### [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess)
+
+It ensures that accessing arrays or objects without checking if a value exists
+results in a TypeScript error, preventing potential runtime crashes.
 
 **Example for accessing the array:**
 ```typescript
 const arr: string[] = [];
 
 console.log(arr[0].trim());
-// With `"noUncheckedIndexedAccess": true` → TypeScript error: "Object is possibly `undefined`"
-// With `"noUncheckedIndexedAccess": false` → No error, but at runtime, this will throw:
-// "TypeError: Cannot read properties of undefined (reading 'trim')"
 ```
+- With `"noUncheckedIndexedAccess": true` → TypeScript error: "Object is possibly `undefined`"
+- With `"noUncheckedIndexedAccess": false` → No error, but at runtime, this will throw:
+`"TypeError: Cannot read properties of undefined (reading 'trim')"`
 
 **Example for accessing the object:**
 ```typescript
 const obj: Record<string, string> = {};
 
 console.log(obj.some.trim());
-// With `"noUncheckedIndexedAccess": true` → TypeScript error: "`obj.some` is possibly `undefined`"
-// With `"noUncheckedIndexedAccess": false` → No error, but at runtime, this will throw:
-// "TypeError: Cannot read properties of undefined (reading 'trim')"
 ```
+- With `"noUncheckedIndexedAccess": true` → TypeScript error: "`obj.some` is possibly `undefined`"
+- With `"noUncheckedIndexedAccess": false` → No error, but at runtime, this will throw:
+`"TypeError: Cannot read properties of undefined (reading 'trim')"`
 
 To disable:
 ```json

--- a/packages/dev/tsconfig/configs/base.json
+++ b/packages/dev/tsconfig/configs/base.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "noUncheckedSideEffectImports": true,
+    "lib": ["ES2022"]
+  },
+  "include": [],
+  "exclude": []
+}

--- a/packages/dev/tsconfig/configs/build-app.json
+++ b/packages/dev/tsconfig/configs/build-app.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "${configDir}/dist",
+    "sourceMap": true
+  }
+}

--- a/packages/dev/tsconfig/configs/build-private-lib.json
+++ b/packages/dev/tsconfig/configs/build-private-lib.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./build-public-lib.json",
+  "compilerOptions": {
+    "declarationMap": true
+  }
+}

--- a/packages/dev/tsconfig/configs/build-public-lib.json
+++ b/packages/dev/tsconfig/configs/build-public-lib.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./build-app.json",
+  "compilerOptions": {
+    "declaration": true
+  }
+}

--- a/packages/dev/tsconfig/configs/bundler-dom.json
+++ b/packages/dev/tsconfig/configs/bundler-dom.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./bundler.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  }
+}

--- a/packages/dev/tsconfig/configs/bundler.json
+++ b/packages/dev/tsconfig/configs/bundler.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "module": "preserve"
+  }
+}

--- a/packages/dev/tsconfig/configs/tsc-dom.json
+++ b/packages/dev/tsconfig/configs/tsc-dom.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsc.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  }
+}

--- a/packages/dev/tsconfig/configs/tsc.json
+++ b/packages/dev/tsconfig/configs/tsc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "module": "Node16"
+  }
+}

--- a/packages/dev/tsconfig/package.json
+++ b/packages/dev/tsconfig/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@lokalise/tsconfig",
+    "version": "1.0.0",
+    "license": "Apache-2.0",
+    "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/lokalise/shared-ts-libs.git"
+    },
+    "homepage": "https://github.com/lokalise/shared-ts-libs",
+    "files": ["configs"],
+    "exports": {
+        "./bundler": "./configs/bundler.json",
+        "./bundler-dom": "./configs/bundler-dom.json",
+        "./tsc": "./configs/tsc.json",
+        "./tsc-dom": "./configs/tsc-dom.json",
+        "./build-app": "./configs/build-app.json",
+        "./build-public-lib": "./configs/build-public-lib.json",
+        "./build-private-lib": "./configs/build-private-lib.json"
+    },
+    "scripts": {
+        "package-version": "echo $npm_package_version"
+    }
+}

--- a/packages/dev/tsconfig/package.json
+++ b/packages/dev/tsconfig/package.json
@@ -8,6 +8,9 @@
         "url": "git://github.com/lokalise/shared-ts-libs.git"
     },
     "homepage": "https://github.com/lokalise/shared-ts-libs",
+    "publishConfig": {
+        "access": "public"
+    },
     "files": ["configs"],
     "exports": {
         "./bundler": "./configs/bundler.json",


### PR DESCRIPTION
## Changes

This PR adds a sharable tsconfig package. As an example, this package is used for `non-translatable-markup`.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
