### PR TITLE
chore: enable ts extension usage

### DIFF
--- a/packages/dev/tsconfig/configs/base.json
+++ b/packages/dev/tsconfig/configs/base.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "lib": ["ES2022"],
     "target": "ES2022",
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -8,12 +9,12 @@
     "moduleDetection": "force",
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "strict": true,
     "erasableSyntaxOnly": true,
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,
-    "noUncheckedSideEffectImports": true,
-    "lib": ["ES2022"]
+    "noUncheckedSideEffectImports": true
   },
   "include": [],
   "exclude": []

--- a/packages/dev/tsconfig/configs/build-app.json
+++ b/packages/dev/tsconfig/configs/build-app.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "noEmit": false,
+    "rewriteRelativeImportExtensions": true,
     "outDir": "${configDir}/dist",
     "sourceMap": true
   }


### PR DESCRIPTION
## Changes

This PR enables `.ts` extension usage that will be rewritten into `.js` during the build process.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
