### PR TITLE
AP-6426 added `sendPostWithProgress()` util function

### DIFF
--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -95,6 +95,25 @@ const responseBody2 = await sendByGetRoute(client, someGetRouteDefinition, {
 })
 ```
 
+### Tracking request progress
+Tracking requests progress is especially useful while uploading files. 
+
+> **Important note**: `wretch` does not support request progress tracking, so we rely on XMLHttpRequest. That's why the interface of the method below is slightly different from the others 
+
+Usage example:
+
+```ts
+ const response = await sendPostWithProgress({
+    path: '/',
+    data: new FormData(), 
+    headers: { Authorization: 'Bearer ...' }, 
+    responseBodySchema: z.object(),
+    onProgress: (progress) => {
+        console.log(`Loaded ${progress.loaded} of ${progress.total}`)
+    }
+})
+```
+
 ## Credits
 
 This library is brought to you by a joint effort of Lokalise engineers:

--- a/packages/app/frontend-http-client/package.json
+++ b/packages/app/frontend-http-client/package.json
@@ -47,6 +47,7 @@
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.5",
         "jest-fail-on-console": "^3.1.2",
+        "mock-xmlhttprequest": "^8.4.1",
         "mockttp": "^3.13.0",
         "rimraf": "^6.0.0",
         "typescript": "~5.8.2",

--- a/packages/app/frontend-http-client/src/index.ts
+++ b/packages/app/frontend-http-client/src/index.ts
@@ -1,5 +1,6 @@
 export {
   sendPost,
+  sendPostWithProgress,
   sendGet,
   sendPut,
   sendDelete,

--- a/packages/app/frontend-http-client/src/utils/bodyUtils.ts
+++ b/packages/app/frontend-http-client/src/utils/bodyUtils.ts
@@ -43,12 +43,12 @@ export function tryToResolveJsonBody<RequestBodySchema extends z.ZodSchema>(
   })
 }
 
-function parseResponseBody<ResponseBody>({
+export function parseResponseBody<ResponseBody>({
   response,
   responseBodySchema,
   path,
 }: {
-  response: ResponseBody
+  response: unknown
   responseBodySchema: z.ZodSchema<ResponseBody>
   path: string
 }): Either<z.ZodError, ResponseBody> {
@@ -64,7 +64,7 @@ function parseResponseBody<ResponseBody>({
     return failure(result.error)
   }
 
-  return success(response)
+  return success(result.data)
 }
 
 export function parseRequestBody<RequestBodySchema extends z.Schema>({

--- a/packages/app/frontend-http-client/src/utils/errorUtils.ts
+++ b/packages/app/frontend-http-client/src/utils/errorUtils.ts
@@ -9,3 +9,13 @@ export function buildWretchError(message: string, response: WretchResponse): Wre
 
   return error
 }
+
+export class XmlHttpRequestError extends Error {
+  readonly details?: Record<string, unknown>
+
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message)
+
+    this.details = details
+  }
+}

--- a/packages/app/frontend-http-client/tsconfig.json
+++ b/packages/app/frontend-http-client/tsconfig.json
@@ -1,4 +1,7 @@
 {
     "extends": "@lokalise/tsconfig/tsc",
-    "include": ["src/**/*", "vitest.config.ts"]
+    "include": ["src/**/*", "vitest.config.ts"],
+    "compilerOptions": {
+        "lib": ["dom"]
+    }
 }


### PR DESCRIPTION
## Changes

I've added the function that allows sending `POST` request and track its progress. This will be used for tracking file upload and has been implemented as a result of the conversation [here](https://github.com/lokalise/autopilot/pull/5354#discussion_r1971286655)

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
