### PR TITLE
chore: Add summary to API contracts and pass-through description

### DIFF
--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -102,6 +102,8 @@ export function buildFastifyNoPayloadRoute<
       querystring: apiContract.requestQuerySchema,
       headers: apiContract.requestHeaderSchema,
       describe: apiContract.description,
+      description: apiContract.description,
+      summary: apiContract.summary,
       response: apiContract.responseSchemasByStatusCode,
     } satisfies ExtendedFastifySchema),
   }
@@ -188,6 +190,8 @@ export function buildFastifyPayloadRoute<
       querystring: apiContract.requestQuerySchema,
       headers: apiContract.requestHeaderSchema,
       describe: apiContract.description,
+      description: apiContract.description,
+      summary: apiContract.summary,
       response: apiContract.responseSchemasByStatusCode,
     } satisfies ExtendedFastifySchema),
   }

--- a/packages/app/fastify-api-contracts/src/types.ts
+++ b/packages/app/fastify-api-contracts/src/types.ts
@@ -6,7 +6,11 @@ import type { z } from 'zod'
 /**
  * Default fastify fields + fastify-swagger fields
  */
-export type ExtendedFastifySchema = FastifySchema & { describe?: string }
+export type ExtendedFastifySchema = FastifySchema & {
+  describe?: string
+  description?: string
+  summary?: string
+}
 
 export type RouteType = RouteOptions<
   http.Server,

--- a/packages/app/universal-ts-utils/src/public/api-contracts/__snapshots__/apiContracts.spec.ts.snap
+++ b/packages/app/universal-ts-utils/src/public/api-contracts/__snapshots__/apiContracts.spec.ts.snap
@@ -85,6 +85,7 @@ exports[`apiContracts > buildDeleteRoute > sets default delete route values 1`] 
       "version": 1,
     },
   },
+  "summary": undefined,
 }
 `;
 
@@ -245,6 +246,7 @@ exports[`apiContracts > buildGetRoute > resolves path params 1`] = `
       "version": 1,
     },
   },
+  "summary": undefined,
 }
 `;
 
@@ -482,6 +484,7 @@ exports[`apiContracts > buildGetRoute > sets default get route values 1`] = `
       "version": 1,
     },
   },
+  "summary": undefined,
 }
 `;
 
@@ -790,5 +793,6 @@ exports[`apiContracts > buildPayloadRoute > sets default change route values 1`]
       "version": 1,
     },
   },
+  "summary": undefined,
 }
 `;

--- a/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
+++ b/packages/app/universal-ts-utils/src/public/api-contracts/apiContracts.ts
@@ -37,6 +37,7 @@ export type CommonRouteDefinition<
   pathResolver: RoutePathResolver<InferSchemaOutput<PathParamsSchema>>
   responseSchemasByStatusCode?: Partial<Record<HttpStatusCode, z.Schema>>
   description?: string
+  summary?: string
   metadata?: CommonRouteDefinitionMetadata
 }
 
@@ -144,6 +145,7 @@ export function buildPayloadRoute<
     requestQuerySchema: params.requestQuerySchema,
     successResponseBodySchema: params.successResponseBodySchema,
     description: params.description,
+    summary: params.summary,
     responseSchemasByStatusCode: params.responseSchemasByStatusCode,
     metadata: params.metadata,
   }
@@ -190,6 +192,7 @@ export function buildGetRoute<
     requestQuerySchema: params.requestQuerySchema,
     successResponseBodySchema: params.successResponseBodySchema,
     description: params.description,
+    summary: params.summary,
     responseSchemasByStatusCode: params.responseSchemasByStatusCode,
     metadata: params.metadata,
   }
@@ -236,6 +239,7 @@ export function buildDeleteRoute<
     requestQuerySchema: params.requestQuerySchema,
     successResponseBodySchema: params.successResponseBodySchema,
     description: params.description,
+    summary: params.summary,
     responseSchemasByStatusCode: params.responseSchemasByStatusCode,
     metadata: params.metadata,
   }


### PR DESCRIPTION
## Changes

This PR improves API contract definition, used for generating OpenApi schemas:
- Add summary property to API contracts
- Pass-through description to schema.description

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
