### PR TITLE
fix: Accept any fastify instance

### DIFF
--- a/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
@@ -10,6 +10,9 @@ import type {
 import type { FastifyInstance } from 'fastify'
 import type { z } from 'zod'
 
+// biome-ignore lint/suspicious/noExplicitAny: we don't care about what kind of app instance we get here
+type AnyFastifyInstance = FastifyInstance<any, any, any, any>
+
 export type RouteRequestParams<
   PathParams = undefined,
   RequestQuery = never,
@@ -52,7 +55,7 @@ export async function injectGet<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
 >(
-  app: FastifyInstance,
+  app: AnyFastifyInstance,
   apiContract: GetRouteDefinition<
     InferSchemaOutput<PathParamsSchema>,
     ResponseBodySchema,
@@ -92,7 +95,7 @@ export async function injectDelete<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
 >(
-  app: FastifyInstance,
+  app: AnyFastifyInstance,
   apiContract: DeleteRouteDefinition<
     InferSchemaOutput<PathParamsSchema>,
     ResponseBodySchema,
@@ -133,7 +136,7 @@ export async function injectPost<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
 >(
-  app: FastifyInstance,
+  app: AnyFastifyInstance,
   apiContract: PayloadRouteDefinition<
     InferSchemaOutput<PathParamsSchema>,
     RequestBodySchema,
@@ -178,7 +181,7 @@ export async function injectPut<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
 >(
-  app: FastifyInstance,
+  app: AnyFastifyInstance,
   apiContract: PayloadRouteDefinition<
     InferSchemaOutput<PathParamsSchema>,
     RequestBodySchema,
@@ -223,7 +226,7 @@ export async function injectPatch<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
 >(
-  app: FastifyInstance,
+  app: AnyFastifyInstance,
   apiContract: PayloadRouteDefinition<
     InferSchemaOutput<PathParamsSchema>,
     RequestBodySchema,


### PR DESCRIPTION
## Changes

Request injection doesn't really care what are the fastify app generics, so we can relax our requirements there

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
