### PR TITLE
Switch to consume api-contracts lib

### DIFF
--- a/packages/app/fastify-api-contracts/README.md
+++ b/packages/app/fastify-api-contracts/README.md
@@ -57,14 +57,14 @@ app.withTypeProvider<ZodTypeProvider>().route(postRoute)
 
 await app.ready()
 
-// used in tests, you can use '@lokalise/universal-ts-utils/frontend-http-client' in production code
+// used in tests, you can use '@lokalise/frontend-http-client' in production code
 const postResponse = await injectPost(app, contract, {
     pathParams: { userId: '1'},
     body: { id: '2' },
     headers: { authorization: 'some-value'} // can be passed directly
 })
 
-// used in tests, you can use '@lokalise/universal-ts-utils/frontend-http-client' in production code
+// used in tests, you can use '@lokalise/frontend-http-client' in production code
 const getResponse = await injectGet(app, contract, {
     pathParams: { userId: '1' },
     headers: async () => { authorization: 'some-value'} // headers producing function (sync or async) can be passed as well
@@ -78,6 +78,7 @@ import {
     buildFastifyPayloadRoute, 
     buildFastifyPayloadRouteHandler 
 } from '@lokalise/fastify-api-contracts'
+import { buildPayloadRoute } from '@lokalise/api-contracts'
 
 const contract = buildPayloadRoute({
     method: 'post',

--- a/packages/app/fastify-api-contracts/README.md
+++ b/packages/app/fastify-api-contracts/README.md
@@ -1,6 +1,6 @@
 # API contract support for fastify
 
-This package adds support for generating fastify routes using universal API contracts, created with `@lokalise/universal-ts-utils/`
+This package adds support for generating fastify routes using universal API contracts, created with `@lokalise/api-contracts`
 
 This module requires `fastify-type-provider-zod` type provider to work and is ESM-only.
 
@@ -11,7 +11,7 @@ Basic usage pattern:
 ```ts
 import { buildFastifyNoPayloadRoute, buildFastifyPayloadRoute, injectPost, injectGet } from '@lokalise/fastify-api-contracts'
 
-import { buildGetRoute, buildPayloadRoute } from '@lokalise/universal-ts-utils/node'
+import { buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
 import {
     type ZodTypeProvider,
     serializerCompiler,

--- a/packages/app/fastify-api-contracts/package.json
+++ b/packages/app/fastify-api-contracts/package.json
@@ -7,6 +7,11 @@
     "main": "./dist/index.js",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "exports": {
+        ".": "./dist/index.js",
+        "./package.json": "./package.json"
+    },
+    "keywords": ["fastify", "api", "contracts", "route", "definition", "contract"],
     "homepage": "https://github.com/lokalise/shared-ts-libs",
     "repository": {
         "type": "git",
@@ -27,19 +32,19 @@
     "dependencies": {},
     "peerDependencies": {
         "@lokalise/node-core": ">=13.5.0",
-        "@lokalise/universal-ts-utils": ">=4.2.1",
+        "@lokalise/api-contracts": ">=4.1.0",
         "fastify": ">=5.0.0",
         "zod": "^3.24.2"
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@lokalise/api-contracts": "^4.1.0",
         "@lokalise/biome-config": "^1.5.0",
-        "@lokalise/tsconfig": "^1.0.2",
-        "@lokalise/universal-ts-utils": "^4.2.1",
-        "@vitest/coverage-v8": "^3.0.7",
+        "@lokalise/tsconfig": "~1.0.2",
+        "@vitest/coverage-v8": "^3.0.9",
         "fastify-type-provider-zod": "^4.0.2",
         "rimraf": "^6.0.1",
         "typescript": "5.8.2",
-        "vitest": "^3.0.7"
+        "vitest": "^3.0.9"
     }
 }

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.metadataMapper.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.metadataMapper.spec.ts
@@ -1,4 +1,4 @@
-import { buildGetRoute, buildPayloadRoute } from '@lokalise/universal-ts-utils/node'
+import { buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import { buildFastifyNoPayloadRoute, buildFastifyPayloadRoute } from './fastifyApiContracts.js'

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.metadataMapper.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.metadataMapper.spec.ts
@@ -9,7 +9,7 @@ type Metadata = {
   myProp?: string[]
 }
 
-declare module '@lokalise/universal-ts-utils/api-contracts/apiContracts' {
+declare module '@lokalise/api-contracts' {
   interface CommonRouteDefinitionMetadata extends Metadata {}
 }
 

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -1,8 +1,4 @@
-import {
-  buildDeleteRoute,
-  buildGetRoute,
-  buildPayloadRoute,
-} from '@lokalise/universal-ts-utils/node'
+import { buildDeleteRoute, buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
 import { type RouteOptions, fastify } from 'fastify'
 import {
   type ZodTypeProvider,

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -1,10 +1,10 @@
-import { copyWithoutUndefined } from '@lokalise/node-core'
 import {
   type DeleteRouteDefinition,
   type GetRouteDefinition,
   type PayloadRouteDefinition,
   mapRouteToPath,
-} from '@lokalise/universal-ts-utils/node'
+} from '@lokalise/api-contracts'
+import { copyWithoutUndefined } from '@lokalise/node-core'
 import type { z } from 'zod'
 import type {
   ApiContractMetadataToRouteMapper,

--- a/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiRequestInjector.ts
@@ -1,12 +1,9 @@
-import type {
-  InferSchemaInput,
-  InferSchemaOutput,
-} from '@lokalise/universal-ts-utils/api-contracts/apiContracts'
+import type { InferSchemaInput, InferSchemaOutput } from '@lokalise/api-contracts'
 import type {
   DeleteRouteDefinition,
   GetRouteDefinition,
   PayloadRouteDefinition,
-} from '@lokalise/universal-ts-utils/node'
+} from '@lokalise/api-contracts'
 import type { FastifyInstance } from 'fastify'
 import type { z } from 'zod'
 

--- a/packages/app/fastify-api-contracts/src/index.ts
+++ b/packages/app/fastify-api-contracts/src/index.ts
@@ -1,4 +1,3 @@
-/* c8 ignore next 2 */
 export {
   buildFastifyNoPayloadRoute,
   buildFastifyNoPayloadRouteHandler,

--- a/packages/app/fastify-api-contracts/src/types.ts
+++ b/packages/app/fastify-api-contracts/src/types.ts
@@ -1,5 +1,5 @@
 import type http from 'node:http'
-import type { CommonRouteDefinition } from '@lokalise/universal-ts-utils/node'
+import type { CommonRouteDefinition } from '@lokalise/api-contracts'
 import type { FastifyReply, FastifyRequest, FastifySchema, RouteOptions } from 'fastify'
 import type { z } from 'zod'
 


### PR DESCRIPTION
## Changes

Use api-contracts library instead of universal-utils

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
