### PR TITLE
chore: Do not report muted unrecoverableError

### DIFF
--- a/packages/app/background-jobs-common/README.md
+++ b/packages/app/background-jobs-common/README.md
@@ -109,6 +109,30 @@ const supportedQueues = [
 ] as const satisfies QueueConfiguration[]
 ```
 
+### Do not report UnrecoverableError
+
+By default, unrecoverable errors (BullMQ) are passed to the error reporting system. If you want to disable this behavior,
+throw `MutedUnrecoverableError` error instead. This will prevent the error from being reported and job will not be retried.
+
+```ts
+import { MutedUnrecoverableError } from '@lokalise/background-jobs-common'
+
+export class Processor extends AbstractBackgroundJobProcessorNew<Data> {
+  constructor(dependencies: BackgroundJobProcessorNewDependencies<Data>) {
+    super(dependencies)
+  }
+
+  protected async process(
+    _job: Job<JobPayloadForQueue<QueueConfiguration, QueueId>>,
+    _requestContext: RequestContext,
+  ): Promise < void > {
+    doSomeProcessing();
+
+    throw new MutedUnrecoverableError('Do not retry the job, and do not report the error')
+  }
+}
+```
+
 ### Common jobs
 
 For that type of job, you will need to extend `AbstractBackgroundJobProcessorNew` and implement a `processInternal`

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
@@ -17,7 +17,7 @@ import type { BackgroundJobProcessorSpy } from '../spy/BackgroundJobProcessorSpy
 import type { BackgroundJobProcessorSpyInterface } from '../spy/types.js'
 import type { BullmqProcessor, RequestContext, SafeJob } from '../types.js'
 import {
-  isJobMissingError,
+  isJobMissingError, isMutedUnrecoverableJobError,
   isStalledJobError,
   isUnrecoverableJobError,
   resolveJobId,
@@ -293,15 +293,17 @@ export abstract class AbstractBackgroundJobProcessorNew<
     const requestContext = this.monitor.getRequestContext(job)
 
     requestContext.logger.error(resolveGlobalErrorLogObject(error))
-    this.errorReporter.report({
-      error,
-      context: {
-        jobId: resolveJobId(job),
-        jobName: job.name,
-        'x-request-id': job.data.metadata.correlationId,
-        errorJson: JSON.stringify(pino.stdSerializers.err(error)),
-      },
-    })
+    if (!isMutedUnrecoverableJobError(error)) {
+      this.errorReporter.report({
+        error,
+        context: {
+          jobId: resolveJobId(job),
+          jobName: job.name,
+          'x-request-id': job.data.metadata.correlationId,
+          errorJson: JSON.stringify(pino.stdSerializers.err(error)),
+        },
+      })
+    }
 
     if (
       isUnrecoverableJobError(error) ||

--- a/packages/app/background-jobs-common/src/background-job-processor/utils.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/utils.ts
@@ -5,6 +5,7 @@ import type { JobsOptions } from 'bullmq'
 import { Redis } from 'ioredis'
 import { DEFAULT_JOB_CONFIG } from './constants.js'
 import type { SafeJob } from './types.js'
+import { MUTED_UNRECOVERABLE_ERROR_SYMBOL } from '../errors/MutedUnrecoverableError.js'
 
 export const daysToSeconds = (days: number): number => days * 24 * 60 * 60
 
@@ -14,6 +15,10 @@ export const resolveJobId = (job?: SafeJob<unknown>): string => job?.id ?? 'unkn
 
 export const isUnrecoverableJobError = (error: Error): boolean =>
   error.name === 'UnrecoverableError'
+
+export const isMutedUnrecoverableJobError = (error: Error): boolean =>
+    // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
+    isUnrecoverableJobError(error) && (error as any)[MUTED_UNRECOVERABLE_ERROR_SYMBOL] === true
 
 export const isStalledJobError = (error: Error): boolean =>
   error.message === 'job stalled more than allowable limit'

--- a/packages/app/background-jobs-common/src/errors/MutedUnrecoverableError.ts
+++ b/packages/app/background-jobs-common/src/errors/MutedUnrecoverableError.ts
@@ -1,0 +1,15 @@
+import { UnrecoverableError } from 'bullmq'
+
+export const MUTED_UNRECOVERABLE_ERROR_SYMBOL = Symbol.for('MUTED_UNRECOVERABLE_ERROR_KEY')
+const UNRECOVERABLE_ERROR_NAME = 'UnrecoverableError'
+
+export class MutedUnrecoverableError extends UnrecoverableError {
+    constructor(message?: string) {
+        super(message)
+        this.name = UNRECOVERABLE_ERROR_NAME
+    }
+}
+
+Object.defineProperty(MutedUnrecoverableError.prototype, MUTED_UNRECOVERABLE_ERROR_SYMBOL, {
+    value: true,
+})

--- a/packages/app/background-jobs-common/src/index.ts
+++ b/packages/app/background-jobs-common/src/index.ts
@@ -1,5 +1,7 @@
 import type { TransactionObservabilityManager } from '@lokalise/node-core'
 
+export * from './errors/MutedUnrecoverableError.js'
+
 export type { TransactionObservabilityManager }
 export * from './background-job-processor/index.js'
 export type { BarrierCallback, BarrierResult } from './background-job-processor/barrier/barrier.js'


### PR DESCRIPTION
## Changes

Add ability to not to report UnrecoverableError (from bullmq), but pass it down to stop retrying job

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
