### PR TITLE
Fastify API contracts Route type narrowing down types

### DIFF
--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -1,5 +1,5 @@
 import { buildDeleteRoute, buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
-import { type RouteOptions, fastify } from 'fastify'
+import { fastify } from 'fastify'
 import {
   type ZodTypeProvider,
   serializerCompiler,
@@ -20,6 +20,7 @@ import {
   injectPost,
   injectPut,
 } from './fastifyApiRequestInjector.js'
+import type { RouteType } from './types.js'
 
 const REQUEST_BODY_SCHEMA = z.object({
   id: z.string(),
@@ -38,7 +39,7 @@ const REQUEST_QUERY_SCHEMA = z.object({
   limit: z.coerce.number().gt(0).default(10),
 })
 
-async function initApp(route: RouteOptions) {
+async function initApp<Route extends RouteType>(route: Route) {
   const app = fastify({
     logger: false,
     disableRequestLogging: true,

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -5,7 +5,7 @@ import {
   serializerCompiler,
   validatorCompiler,
 } from 'fastify-type-provider-zod'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { z } from 'zod'
 import {
   buildFastifyNoPayloadRoute,
@@ -84,6 +84,16 @@ describe('fastifyApiContracts', () => {
         return Promise.resolve()
       })
 
+      expectTypeOf(route).toEqualTypeOf<
+        RouteType<
+          z.infer<typeof BODY_SCHEMA>,
+          undefined,
+          z.infer<typeof PATH_PARAMS_SCHEMA>,
+          z.infer<typeof REQUEST_QUERY_SCHEMA>,
+          undefined
+        >
+      >()
+
       const app = await initApp(route)
       const response = await injectGet(app, contract, {
         pathParams: { userId: '1' },
@@ -112,6 +122,16 @@ describe('fastifyApiContracts', () => {
 
       const route = buildFastifyNoPayloadRoute(contract, handler)
 
+      expectTypeOf(route).toEqualTypeOf<
+        RouteType<
+          z.infer<typeof BODY_SCHEMA>,
+          undefined,
+          z.infer<typeof PATH_PARAMS_SCHEMA>,
+          z.infer<typeof REQUEST_QUERY_SCHEMA>,
+          z.infer<typeof HEADERS_SCHEMA>
+        >
+      >()
+
       const app = await initApp(route)
       const response = await injectGet(app, contract, {
         headers: () => Promise.resolve({ authorization: 'dummy' }),
@@ -135,6 +155,16 @@ describe('fastifyApiContracts', () => {
         return Promise.resolve()
       })
 
+      expectTypeOf(route).toEqualTypeOf<
+        RouteType<
+          z.infer<typeof BODY_SCHEMA>,
+          undefined,
+          z.infer<typeof PATH_PARAMS_SCHEMA>,
+          undefined,
+          undefined
+        >
+      >()
+
       const app = await initApp(route)
       const response = await injectDelete(app, contract, {
         pathParams: { userId: '1' },
@@ -156,6 +186,16 @@ describe('fastifyApiContracts', () => {
         expect(req.params.userId).toEqual('1')
         return Promise.resolve()
       })
+
+      expectTypeOf(route).toEqualTypeOf<
+        RouteType<
+          z.infer<typeof BODY_SCHEMA>,
+          undefined,
+          z.infer<typeof PATH_PARAMS_SCHEMA>,
+          undefined,
+          z.infer<typeof HEADERS_SCHEMA>
+        >
+      >()
 
       const app = await initApp(route)
       // using headers directly
@@ -207,6 +247,16 @@ describe('fastifyApiContracts', () => {
         return Promise.resolve()
       })
 
+      expectTypeOf(route).toEqualTypeOf<
+        RouteType<
+          z.infer<typeof BODY_SCHEMA>,
+          z.infer<typeof REQUEST_BODY_SCHEMA>,
+          z.infer<typeof PATH_PARAMS_SCHEMA>,
+          undefined,
+          undefined
+        >
+      >()
+
       const app = await initApp(route)
       const response = await injectPost(app, contract, {
         pathParams: { userId: '1' },
@@ -235,6 +285,16 @@ describe('fastifyApiContracts', () => {
       })
 
       const route = buildFastifyPayloadRoute(contract, handler)
+
+      expectTypeOf(route).toEqualTypeOf<
+        RouteType<
+          z.infer<typeof BODY_SCHEMA>,
+          z.infer<typeof REQUEST_BODY_SCHEMA>,
+          z.infer<typeof PATH_PARAMS_SCHEMA>,
+          undefined,
+          z.infer<typeof HEADERS_SCHEMA>
+        >
+      >()
 
       const app = await initApp(route)
       const response = await injectPost(app, contract, {

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -91,7 +91,13 @@ export function buildFastifyNoPayloadRoute<
     InferredOptionalSchema<RequestHeaderSchema>
   >,
   contractMetadataToRouteMapper: ApiContractMetadataToRouteMapper = () => ({}),
-): RouteType {
+): RouteType<
+  InferredOptionalSchema<ResponseBodySchema>,
+  undefined,
+  InferredOptionalSchema<PathParams>,
+  InferredOptionalSchema<RequestQuerySchema>,
+  InferredOptionalSchema<RequestHeaderSchema>
+> {
   return {
     ...contractMetadataToRouteMapper(apiContract.metadata),
     method: apiContract.method,
@@ -178,7 +184,13 @@ export function buildFastifyPayloadRoute<
     InferredOptionalSchema<RequestHeaderSchema>
   >,
   contractMetadataToRouteMapper: ApiContractMetadataToRouteMapper = () => ({}),
-): RouteType {
+): RouteType<
+  InferredOptionalSchema<ResponseBodySchema>,
+  InferredOptionalSchema<RequestBodySchema>,
+  InferredOptionalSchema<PathParams>,
+  InferredOptionalSchema<RequestQuerySchema>,
+  InferredOptionalSchema<RequestHeaderSchema>
+> {
   return {
     ...contractMetadataToRouteMapper(apiContract.metadata),
     method: apiContract.method,

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -15,7 +15,7 @@ import type {
 } from './types.js'
 
 type OptionalZodSchema = z.Schema | undefined
-type InferredOptionalSchema<Schema> = Schema extends z.Schema ? z.infer<Schema> : never
+type InferredOptionalSchema<Schema> = Schema extends z.Schema ? z.infer<Schema> : undefined
 
 /**
  * Infers handler request type automatically from the contract for GET or DELETE methods

--- a/packages/app/fastify-api-contracts/src/types.ts
+++ b/packages/app/fastify-api-contracts/src/types.ts
@@ -1,7 +1,23 @@
-import type http from 'node:http'
 import type { CommonRouteDefinition } from '@lokalise/api-contracts'
-import type { FastifyReply, FastifyRequest, FastifySchema, RouteOptions } from 'fastify'
+import type {
+  FastifySchema,
+  RouteOptions,
+  RouteGenericInterface,
+  RouteHandlerMethod,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from 'fastify'
 import type { z } from 'zod'
+
+interface FastifyContractRouteInterface<ReplyType, BodyType, ParamsType, QueryType, HeadersType>
+  extends RouteGenericInterface {
+  Body: BodyType
+  Headers: HeadersType
+  Params: ParamsType
+  Querystring: QueryType
+  Reply: ReplyType
+}
 
 /**
  * Default fastify fields + fastify-swagger fields
@@ -12,49 +28,40 @@ export type ExtendedFastifySchema = FastifySchema & {
   summary?: string
 }
 
-export type RouteType = RouteOptions<
-  http.Server,
-  http.IncomingMessage,
-  http.ServerResponse,
-  // biome-ignore lint/suspicious/noExplicitAny: it's ok
-  any,
-  // biome-ignore lint/suspicious/noExplicitAny: it's ok
-  any,
-  // biome-ignore lint/suspicious/noExplicitAny: it's ok
-  any,
-  // biome-ignore lint/suspicious/noExplicitAny: it's ok
-  any,
-  // biome-ignore lint/suspicious/noExplicitAny: it's ok
-  any
+export type RouteType<
+  ReplyType = unknown,
+  BodyType = unknown,
+  ParamsType = unknown,
+  QueryType = unknown,
+  HeadersType = unknown,
+> = RouteOptions<
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  FastifyContractRouteInterface<ReplyType, BodyType, ParamsType, QueryType, HeadersType>
 >
 
 /**
  * Handler for POST, PUT and PATCH methods
  */
-export type FastifyPayloadHandlerFn<ReplyType, BodyType, ParamsType, QueryType, HeadersType> = (
-  req: FastifyRequest<{
-    Body: BodyType
-    Headers: HeadersType
-    Params: ParamsType
-    Querystring: QueryType
-    Reply: ReplyType
-  }>,
-  reply: FastifyReply,
-) => Promise<void>
+export type FastifyPayloadHandlerFn<ReplyType, BodyType, ParamsType, QueryType, HeadersType> =
+  RouteHandlerMethod<
+    RawServerDefault,
+    RawRequestDefaultExpression,
+    RawReplyDefaultExpression,
+    FastifyContractRouteInterface<ReplyType, BodyType, ParamsType, QueryType, HeadersType>
+  >
 
 /**
  * Handler for GET and DELETE methods
  */
-export type FastifyNoPayloadHandlerFn<ReplyType, ParamsType, QueryType, HeadersType> = (
-  req: FastifyRequest<{
-    Body: never
-    Headers: HeadersType
-    Params: ParamsType
-    Querystring: QueryType
-    Reply: ReplyType
-  }>,
-  reply: FastifyReply<{ Body: ReplyType }>,
-) => Promise<void>
+export type FastifyNoPayloadHandlerFn<ReplyType, ParamsType, QueryType, HeadersType> =
+  RouteHandlerMethod<
+    RawServerDefault,
+    RawRequestDefaultExpression,
+    RawReplyDefaultExpression,
+    FastifyContractRouteInterface<ReplyType, undefined, ParamsType, QueryType, HeadersType>
+  >
 
 /**
  * Callback method to transform api contract in to fastify route

--- a/packages/app/fastify-api-contracts/src/types.ts
+++ b/packages/app/fastify-api-contracts/src/types.ts
@@ -1,12 +1,12 @@
 import type { CommonRouteDefinition } from '@lokalise/api-contracts'
 import type {
   FastifySchema,
-  RouteOptions,
-  RouteGenericInterface,
-  RouteHandlerMethod,
   RawReplyDefaultExpression,
   RawRequestDefaultExpression,
   RawServerDefault,
+  RouteGenericInterface,
+  RouteHandlerMethod,
+  RouteOptions,
 } from 'fastify'
 import type { z } from 'zod'
 
@@ -29,11 +29,16 @@ export type ExtendedFastifySchema = FastifySchema & {
 }
 
 export type RouteType<
-  ReplyType = unknown,
-  BodyType = unknown,
-  ParamsType = unknown,
-  QueryType = unknown,
-  HeadersType = unknown,
+  // biome-ignore lint/suspicious/noExplicitAny: It's ok
+  ReplyType = any,
+  // biome-ignore lint/suspicious/noExplicitAny: It's ok
+  BodyType = any,
+  // biome-ignore lint/suspicious/noExplicitAny: It's ok
+  ParamsType = any,
+  // biome-ignore lint/suspicious/noExplicitAny: It's ok
+  QueryType = any,
+  // biome-ignore lint/suspicious/noExplicitAny: It's ok
+  HeadersType = any,
 > = RouteOptions<
   RawServerDefault,
   RawRequestDefaultExpression,


### PR DESCRIPTION
## Changes
Narrowing down Fasrtify route type to improve type checks on services and `opinionated-machine`

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
