### PR TITLE
Add test for type inference when handling multiple query values, separated by commas

### DIFF
--- a/packages/app/frontend-http-client/package.json
+++ b/packages/app/frontend-http-client/package.json
@@ -42,17 +42,17 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@lokalise/api-contracts": "^4.1.0",
+        "@lokalise/api-contracts": "^4.3.0",
         "@lokalise/biome-config": "^1.6.1",
-        "@lokalise/tsconfig": "~1.0.2",
-        "@types/node": "^22.13.14",
-        "@vitest/coverage-v8": "^3.0.9",
+        "@lokalise/tsconfig": "~1.2.0",
+        "@types/node": "^22.14.1",
+        "@vitest/coverage-v8": "^3.1.1",
         "jest-fail-on-console": "^3.3.1",
         "mock-xmlhttprequest": "^8.4.1",
-        "mockttp": "^3.17.0",
+        "mockttp": "^3.17.1",
         "rimraf": "^6.0.1",
         "typescript": "~5.8.3",
-        "vitest": "^3.0.9"
+        "vitest": "^3.1.1"
     },
     "keywords": ["frontend", "web", "browser", "http", "client", "zod", "validation", "typesafe"]
 }


### PR DESCRIPTION
## Changes

Illustrate that use-case works as expected

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
