### PR TITLE
chore: update module to Node18 in lokalise/tsconfig

### DIFF
--- a/packages/dev/tsconfig/configs/tsc.json
+++ b/packages/dev/tsconfig/configs/tsc.json
@@ -2,6 +2,6 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "extends": "./base.json",
     "compilerOptions": {
-        "module": "Node16"
+        "module": "Node18"
     }
 }


### PR DESCRIPTION
## Changes

This PR updated lokalise/tsconfig/tsc module value to Node18 to support json imports
https://www.typescriptlang.org/tsconfig/#node16node18nodenext

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
