### PR TITLE
Allow Get Route Contract to have empty response.

### DIFF
--- a/packages/app/api-contracts/src/apiContracts.ts
+++ b/packages/app/api-contracts/src/apiContracts.ts
@@ -81,8 +81,8 @@ export type GetRouteDefinition<
   PathParamsSchema extends z.Schema<PathParams> | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
   RequestHeaderSchema extends z.Schema | undefined = undefined,
-  IsNonJSONResponseExpected extends boolean = false,
-  IsEmptyResponseExpected extends boolean = false,
+  IsNonJSONResponseExpected extends boolean = boolean,
+  IsEmptyResponseExpected extends boolean = boolean,
 > = CommonRouteDefinition<
   PathParams,
   SuccessResponseBodySchema,


### PR DESCRIPTION
We want to use a 204 with no content on a Get endpoint here:

https://github.com/lokalise/autopilot/pull/5664/files#diff-b568a28d846a8c953d129e18f5ed874d5f9a442d970c4b85f419f06e879f0278R498

We believe this is a semantically correct use of this status code, it will be provided when there is no content and we don't expect there to be any content. This is distinct from `data: []` which could be empty for another reason, like the import hasn't begun, or there was some unknown issue. See:

![image](https://github.com/user-attachments/assets/e33bea31-9497-4a8c-b293-16590583f0df)

However our API contracts don't allow get routes to be empty, and give a type error trying to build a fastify route like this, so I'm proposing loosening this type. I'm open to this being challenged, but personally I don't see why we should restrict GET requests to never being empty if the HTTP spec allows it and it makes sense for certain use-cases.

## Changes

Please describe

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
