### PR TITLE
fix: Properly handle empty responses for non-payload routes

### DIFF
--- a/packages/app/fastify-api-contracts/package.json
+++ b/packages/app/fastify-api-contracts/package.json
@@ -39,13 +39,13 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@lokalise/api-contracts": "^4.1.2",
-        "@lokalise/biome-config": "^1.5.0",
-        "@lokalise/tsconfig": "~1.0.2",
-        "@vitest/coverage-v8": "^3.0.9",
+        "@lokalise/api-contracts": "^4.3.0",
+        "@lokalise/biome-config": "^1.6.1",
+        "@lokalise/tsconfig": "~1.2.0",
+        "@vitest/coverage-v8": "^3.1.1",
         "fastify-type-provider-zod": "^4.0.2",
         "rimraf": "^6.0.1",
         "typescript": "5.8.3",
-        "vitest": "^3.0.9"
+        "vitest": "^3.1.1"
     }
 }

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -66,6 +66,19 @@ describe('fastifyApiContracts', () => {
       const handler = buildFastifyNoPayloadRouteHandler(contract, () => Promise.resolve())
       expect(handler).toBeTypeOf('function')
     })
+
+    it('builds a GET handler with empty response', () => {
+      const contract = buildGetRoute({
+        successResponseBodySchema: BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestQuerySchema: REQUEST_QUERY_SCHEMA,
+        isEmptyResponseExpected: true,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const handler = buildFastifyNoPayloadRouteHandler(contract, () => Promise.resolve())
+      expect(handler).toBeTypeOf('function')
+    })
   })
   describe('buildFastifyNoPayloadRoute', () => {
     it('uses API spec to build valid GET route in fastify app', async () => {

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -32,14 +32,18 @@ export function buildFastifyNoPayloadRouteHandler<
         ResponseBodySchema,
         PathParams,
         RequestQuerySchema,
-        RequestHeaderSchema
+        RequestHeaderSchema,
+        boolean,
+        boolean
       >
     | DeleteRouteDefinition<
         InferredOptionalSchema<PathParams>,
         ResponseBodySchema,
         PathParams,
         RequestQuerySchema,
-        RequestHeaderSchema
+        RequestHeaderSchema,
+        boolean,
+        boolean
       >,
   handler: FastifyNoPayloadHandlerFn<
     InferredOptionalSchema<ResponseBodySchema>,


### PR DESCRIPTION
## Changes

This ensures that GET contracts work fine with empty responses

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
