### PR TITLE
Fixing the route type to allow any type provider and logger

### DIFF
--- a/packages/app/fastify-api-contracts/src/types.ts
+++ b/packages/app/fastify-api-contracts/src/types.ts
@@ -43,7 +43,15 @@ export type RouteType<
   RawServerDefault,
   RawRequestDefaultExpression,
   RawReplyDefaultExpression,
-  FastifyContractRouteInterface<ReplyType, BodyType, ParamsType, QueryType, HeadersType>
+  FastifyContractRouteInterface<ReplyType, BodyType, ParamsType, QueryType, HeadersType>,
+  // biome-ignore lint/suspicious/noExplicitAny: it's ok
+  any,
+  // biome-ignore lint/suspicious/noExplicitAny: it's ok
+  any,
+  // biome-ignore lint/suspicious/noExplicitAny: it's ok
+  any,
+  // biome-ignore lint/suspicious/noExplicitAny: it's ok
+  any
 >
 
 /**


### PR DESCRIPTION
## Changes

Trying to fix build issues caused by the auto-inferred logger and typeProvider

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
