### PR TITLE
Expose contract on a route

### DIFF
--- a/packages/app/fastify-api-contracts/README.md
+++ b/packages/app/fastify-api-contracts/README.md
@@ -4,7 +4,7 @@ This package adds support for generating fastify routes using universal API cont
 
 This module requires `fastify-type-provider-zod` type provider to work and is ESM-only.
 
-# Usage
+## Usage
 
 Basic usage pattern:
 
@@ -97,4 +97,14 @@ const handler = buildFastifyPayloadRouteHandler(contract,
 const routes = [
     buildFastifyPayloadRoute(contract, handler),
 ]
+```
+
+## Accessing the contract
+
+In case you need some of the contract data within your lifecycle hook or a handler, it is exposed as a part of a route config, and can be accessed like this:
+
+```ts
+const route = buildFastifyNoPayloadRoute(contract, (req) => {
+    const { apiContract } = req.routeOptions.config
+})
 ```

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.metadataMapper.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.metadataMapper.spec.ts
@@ -28,10 +28,20 @@ describe('fastifyApiContracts - api contract metadata mapper', () => {
       const route = buildFastifyNoPayloadRoute(
         contract,
         () => Promise.resolve(),
-        (metadata) => (metadata?.myProp ? { config: metadata.myProp.join('-') } : {}),
+        (metadata) =>
+          metadata?.myProp
+            ? {
+                config: {
+                  myProp: metadata.myProp.join('-'),
+                },
+              }
+            : {},
       )
 
-      expect(route.config).toEqual('test1-test2')
+      expect(route.config).toEqual({
+        myProp: 'test1-test2',
+        apiContract: expect.any(Object),
+      })
     })
   })
 
@@ -51,10 +61,13 @@ describe('fastifyApiContracts - api contract metadata mapper', () => {
       const route = buildFastifyPayloadRoute(
         contract,
         () => Promise.resolve(),
-        (metadata) => (metadata?.myProp ? { config: metadata.myProp.join('-') } : {}),
+        (metadata) => (metadata?.myProp ? { config: { myProp: metadata.myProp.join('-') } } : {}),
       )
 
-      expect(route.config).toBe('test3-test4')
+      expect(route.config).toEqual({
+        myProp: 'test3-test4',
+        apiContract: expect.any(Object),
+      })
     })
   })
 })

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -82,7 +82,7 @@ describe('fastifyApiContracts', () => {
   })
   describe('buildFastifyNoPayloadRoute', () => {
     it('uses API spec to build valid GET route in fastify app', async () => {
-      expect.assertions(4)
+      expect.assertions(6)
       const contract = buildGetRoute({
         successResponseBodySchema: BODY_SCHEMA,
         requestPathParamsSchema: PATH_PARAMS_SCHEMA,
@@ -91,11 +91,13 @@ describe('fastifyApiContracts', () => {
       })
 
       const route = buildFastifyNoPayloadRoute(contract, (req) => {
+        expect(req.routeOptions.config.apiContract).toBe(contract)
         expect(req.params.userId).toEqual('1')
         // satisfies checks if type is inferred properly in route
         expect(req.query.testIds satisfies string[] | undefined).toBeUndefined()
         return Promise.resolve(JSON.stringify({}))
       })
+      expect(route.config.apiContract).toBe(contract)
 
       expectTypeOf(route).toEqualTypeOf<
         RouteType<
@@ -283,7 +285,7 @@ describe('fastifyApiContracts', () => {
   })
   describe('buildFastifyPayloadRoute', () => {
     it('uses API spec to build valid POST route in fastify app', async () => {
-      expect.assertions(3)
+      expect.assertions(5)
       const contract = buildPayloadRoute({
         method: 'post',
         requestBodySchema: REQUEST_BODY_SCHEMA,
@@ -293,10 +295,12 @@ describe('fastifyApiContracts', () => {
       })
 
       const route = buildFastifyPayloadRoute(contract, (req) => {
+        expect(req.routeOptions.config.apiContract).toBe(contract)
         expect(req.params.userId).toEqual('1')
         expect(req.body.id).toEqual('2')
         return Promise.resolve()
       })
+      expect(route.config.apiContract).toBe(contract)
 
       expectTypeOf(route).toEqualTypeOf<
         RouteType<

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -4,6 +4,7 @@ import {
   type PayloadRouteDefinition,
   mapRouteToPath,
 } from '@lokalise/api-contracts'
+import type { CommonRouteDefinition } from '@lokalise/api-contracts'
 import { copyWithoutUndefined } from '@lokalise/node-core'
 import type { z } from 'zod'
 import type {
@@ -16,6 +17,12 @@ import type {
 
 type OptionalZodSchema = z.Schema | undefined
 type InferredOptionalSchema<Schema> = Schema extends z.Schema ? z.infer<Schema> : undefined
+
+declare module 'fastify' {
+  interface FastifyContextConfig {
+    apiContract: CommonRouteDefinition<unknown>
+  }
+}
 
 /**
  * Infers handler request type automatically from the contract for GET or DELETE methods
@@ -102,8 +109,22 @@ export function buildFastifyNoPayloadRoute<
   InferredOptionalSchema<RequestQuerySchema>,
   InferredOptionalSchema<RequestHeaderSchema>
 > {
+  const routeMetadata = contractMetadataToRouteMapper(apiContract.metadata)
+  const mergedConfig = routeMetadata.config
+    ? {
+        ...routeMetadata.config,
+        apiContract,
+      }
+    : {
+        apiContract,
+      }
+  const mergedMetadata = {
+    ...routeMetadata,
+    config: mergedConfig,
+  }
+
   return {
-    ...contractMetadataToRouteMapper(apiContract.metadata),
+    ...mergedMetadata,
     method: apiContract.method,
     url: mapRouteToPath(apiContract),
     handler,
@@ -195,8 +216,22 @@ export function buildFastifyPayloadRoute<
   InferredOptionalSchema<RequestQuerySchema>,
   InferredOptionalSchema<RequestHeaderSchema>
 > {
+  const routeMetadata = contractMetadataToRouteMapper(apiContract.metadata)
+  const mergedConfig = routeMetadata.config
+    ? {
+        ...routeMetadata.config,
+        apiContract,
+      }
+    : {
+        apiContract,
+      }
+  const mergedMetadata = {
+    ...routeMetadata,
+    config: mergedConfig,
+  }
+
   return {
-    ...contractMetadataToRouteMapper(apiContract.metadata),
+    ...mergedMetadata,
     method: apiContract.method,
     url: mapRouteToPath(apiContract),
     handler,


### PR DESCRIPTION
## Changes

We could then rely on contract metadata in our plugins directly.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
