### PR TITLE
AP-6857 Allow aborting the request made by calling `sendPostWithProgress()`

### DIFF
--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -114,6 +114,30 @@ Usage example:
 })
 ```
 
+### Aborting pending requests
+Aborting requests is especially useful while uploading files. 
+
+> **Important note**: Currently it is only possible with `sendWithProgress()` function 
+
+Usage example:
+
+```ts
+const abortController = new AbortController()
+
+sendPostWithProgress({
+    path: '/',
+    data: new FormData(), 
+    headers: { Authorization: 'Bearer ...' },
+    responseBodySchema: z.object(),
+    onProgress: (progress) => {
+        console.log(`Loaded ${progress.loaded} of ${progress.total}`)
+    },
+    abortController
+})
+
+abortController.abort()
+```
+
 ## Credits
 
 This library is brought to you by a joint effort of Lokalise engineers:


### PR DESCRIPTION
## Changes

Added possibility to pass `AbortController` to abort request made by `sendPostWithProgress()`. This will be used to stop pending file uploads/

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
