### PR TITLE
feat: update to biome 2 for custom rules

### DIFF
--- a/packages/dev/biome-config/configs/biome-base.jsonc
+++ b/packages/dev/biome-config/configs/biome-base.jsonc
@@ -1,7 +1,11 @@
 {
     "$schema": "../node_modules/@biomejs/biome/configuration_schema.json",
-    "organizeImports": {
-        "enabled": true
+    "assist": {
+        "actions": {
+            "source": {
+                "organizeImports": "on"
+            }
+        }
     },
     "json": {
         "formatter": {
@@ -25,8 +29,7 @@
         }
     },
     "files": {
-        "include": ["./**/*.ts", "./**/*.mts", "./**/*.tsx", "./**/*.json", "./**/*.jsonc"],
-        "ignore": ["./dist", "./coverage", "./node_modules"]
+        "includes": ["**/*.ts", "**/*.mts", "**/*.tsx", "**/*.json", "**/*.jsonc", "!dist", "!coverage", "!node_modules"]
     },
     "formatter": {
         "enabled": true,
@@ -51,7 +54,7 @@
                 "noUndeclaredVariables": "error"
             },
             "suspicious": {
-                "noConsoleLog": "error",
+                "noConsole": "error",
                 "useAwait": "error"
             },
             "complexity": {
@@ -67,7 +70,7 @@
     },
     "overrides": [
         {
-            "include": ["./**/*.spec.ts", "./**/*.test.ts", "./**/*.test.tsx", "**/test/**/*"],
+            "includes": ["./**/*.spec.ts", "./**/*.test.ts", "./**/*.test.tsx", "**/test/**/*"],
             "javascript": {
                 // Allow Vitest globals in test files
                 "globals": [

--- a/packages/dev/biome-config/configs/biome-frontend.jsonc
+++ b/packages/dev/biome-config/configs/biome-frontend.jsonc
@@ -11,7 +11,7 @@
         }
     },
     "files": {
-        "include": ["**/*.css"]
+        "includes": ["**/*.css"]
     },
     "css": {
         "parser": {
@@ -29,5 +29,6 @@
                 "useHookAtTopLevel": "error"
             }
         }
-    }
+    },
+    "plugins": ["./node_modules/@lokalise/biome-config/configs/plugins/no-manual-z-index.grit"]
 }

--- a/packages/dev/biome-config/configs/biome-package.jsonc
+++ b/packages/dev/biome-config/configs/biome-package.jsonc
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../node_modules/@biomejs/biome/configuration_schema.json",
+    "$schema": "../node_modules/@biomejs/biome/configuration_schema.json",
     "extends": ["./biome-base.jsonc"],
     "linter": {
         "rules": {

--- a/packages/dev/biome-config/configs/plugins/no-manual-z-index.grit
+++ b/packages/dev/biome-config/configs/plugins/no-manual-z-index.grit
@@ -1,11 +1,10 @@
 language css;
 
-// Match any CSS property that is a z-index value
+// Match the values assigned to z-index properties
 `z-index: $zIndexValue;` where {
 
-    // Make sure that we are using the design library for z-index values
-    // This is a regex that matches the assignment of a z-index value with the prefix --lok-z-index-
-    // followed by any non-whitespace characters (so that we can change/add/remove variable in the future)
+    // Check that the value is using the design library for z-index values
+    // we negate the result as failure to comply with the design library should result in the warning
     not $zIndexValue <: r"^var\(--lok-z-index-\S+\)$",
 
     // This is generating the helpful error report that points out any violation
@@ -13,6 +12,8 @@ language css;
     register_diagnostic(
         span = $zIndexValue,
         message = "lokalise/plugin/noManualZIndex :: z-index values should be set using the design library. Please use refer to https://lokalise.github.io/louis/?path=/docs/foundations-z-index--docs",
-        severity = "error",
+
+        // This is only a warning for now because I can't find a way to biome-ignore the error produced by plugins
+        severity = "warn",
     ),
 }

--- a/packages/dev/biome-config/configs/plugins/no-manual-z-index.grit
+++ b/packages/dev/biome-config/configs/plugins/no-manual-z-index.grit
@@ -1,0 +1,18 @@
+language css;
+
+// Match any CSS property that is a z-index value
+`z-index: $zIndexValue;` where {
+
+    // Make sure that we are using the design library for z-index values
+    // This is a regex that matches the assignment of a z-index value with the prefix --lok-z-index-
+    // followed by any non-whitespace characters (so that we can change/add/remove variable in the future)
+    not $zIndexValue <: r"^var\(--lok-z-index-\S+\)$",
+
+    // This is generating the helpful error report that points out any violation
+    // it's a built in function that adds the code with arrows and a description of what's wrong
+    register_diagnostic(
+        span = $zIndexValue,
+        message = "lokalise/plugin/noManualZIndex :: z-index values should be set using the design library. Please use refer to https://lokalise.github.io/louis/?path=/docs/foundations-z-index--docs",
+        severity = "error",
+    ),
+}

--- a/packages/dev/biome-config/package.json
+++ b/packages/dev/biome-config/package.json
@@ -22,6 +22,6 @@
     },
     "private": false,
     "devDependencies": {
-        "@biomejs/biome": "^1.9.4"
+        "@biomejs/biome": "^2.0.0-beta"
     }
 }


### PR DESCRIPTION
## Changes

- Updated the dev dependency to biome 2 (beta)
- Migrated the biome config files as some of the properties had changed since 1.x
- Created a custom biome rule to check that `z-index` can only have a design-token assigned
    - I had to make this a warning as I don't see a way to ignore error produced by plugins yet.
- Enforce the new warning for all frontend projects  

## Checklist

- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [ ] I've updated the documentation, or no changes were necessary
- [ ] I've updated the tests, or no changes were necessary
