### PR TITLE
feat: Expose asyncRegister for periodic jobs

### DIFF
--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -43,7 +43,7 @@
     "peerDependencies": {
         "bullmq": "^5.28.2",
         "ioredis": "^5.4.1",
-        "toad-scheduler": "^3.0.1",
+        "toad-scheduler": "^3.1.0",
         "zod": "^3.24.1"
     },
     "devDependencies": {
@@ -55,7 +55,7 @@
         "bullmq": "^5.31.2",
         "ioredis": "^5.4.1",
         "rimraf": "^6.0.1",
-        "toad-scheduler": "^3.0.1",
+        "toad-scheduler": "^3.1.0",
         "typescript": "5.8.3",
         "vitest": "^3.0.7",
         "zod": "^3.24.1"

--- a/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.spec.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.spec.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import type { ErrorReport, ErrorReporter } from '@lokalise/node-core'
 import type { Redis } from 'ioredis'
 import { ToadScheduler } from 'toad-scheduler'
@@ -60,6 +61,21 @@ describe('AbstractPeriodicJob', () => {
     await vi.waitUntil(() => executionIds.length === 3)
     expect(executionIds).toMatchObject([expect.any(String), expect.any(String), expect.any(String)])
 
+    await job.dispose()
+  })
+
+  it('should await first processing when using asyncRegister', async () => {
+    let counter = 0
+    const processMock = async () => {
+      await setTimeout(100)
+      counter++
+      return Promise.resolve()
+    }
+    const job = new FakePeriodicJob(processMock, {
+      scheduler,
+    })
+    await job.asyncRegister()
+    expect(counter).toBe(1)
     await job.dispose()
   })
 

--- a/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.ts
@@ -83,7 +83,7 @@ export abstract class AbstractPeriodicJob {
       const job = new SimpleIntervalJob(
         {
           milliseconds: this.options.schedule.intervalInMs,
-          runImmediately: false,
+          runImmediately: this.options.runImmediately,
         },
         task,
         {

--- a/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/AbstractPeriodicJob.ts
@@ -57,6 +57,7 @@ export abstract class AbstractPeriodicJob {
           : DEFAULT_LOCK_TIMEOUT,
         ...options.singleConsumerMode,
       },
+      runImmediately: options.runImmediately ?? true,
     }
     this.logger = logger ?? globalLogger
     this.redis = redis
@@ -72,6 +73,38 @@ export abstract class AbstractPeriodicJob {
     }
   }
 
+  /**
+   * Awaits first job execution if runImmediately is set
+   */
+  public async asyncRegister(): Promise<void> {
+    const task = createTask(this.logger, this)
+
+    if (this.options.schedule.intervalInMs) {
+      const job = new SimpleIntervalJob(
+        {
+          milliseconds: this.options.schedule.intervalInMs,
+          runImmediately: false,
+        },
+        task,
+        {
+          id: this.jobId,
+          preventOverrun: true,
+        },
+      )
+
+      if (this.options.runImmediately) {
+        await job.executeAsync()
+      }
+      this.scheduler.addSimpleIntervalJob(job)
+      return
+    }
+
+    return this.register()
+  }
+
+  /**
+   * Fire-and-forgets first job execution if runImmediately is set
+   */
   public register(): void {
     const task = createTask(this.logger, this)
 
@@ -80,7 +113,7 @@ export abstract class AbstractPeriodicJob {
         new SimpleIntervalJob(
           {
             milliseconds: this.options.schedule.intervalInMs,
-            runImmediately: true,
+            runImmediately: this.options.runImmediately,
           },
           task,
           {

--- a/packages/app/background-jobs-common/src/periodic-jobs/periodicJobTypes.ts
+++ b/packages/app/background-jobs-common/src/periodic-jobs/periodicJobTypes.ts
@@ -61,6 +61,10 @@ export type BackgroundJobConfiguration = {
    * If true, the job will log when it starts and finishes. Default is false
    */
   shouldLogExecution?: boolean
+  /**
+   * If true, job will be triggered immediately when registered. Default is true
+   */
+  runImmediately?: boolean
 }
 
 export type LockConfiguration = {


### PR DESCRIPTION
## Changes

This allows awaiting for the job to be executed before proceeding

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
