### PR TITLE
Remove staleness parameter, we always depend on the data available

### DIFF
--- a/packages/app/healthcheck-utils/README.md
+++ b/packages/app/healthcheck-utils/README.md
@@ -1,3 +1,19 @@
 # Healthcheck Utils
 
 This package adds common utils that are used to work with healthchecks.
+
+## Usage
+
+```ts
+// this is a part of dependencies
+const store = new HealthcheckResultsStore({
+    maxHealthcheckNumber: 10,
+    healthCheckResultTtlInMsecs: 40000,
+})
+
+const job = new HealthcheckRefreshJob(dependencies, healthcheckList, {
+    intervalInMs: 15000,
+})
+
+await job.asyncRegister()
+```

--- a/packages/app/healthcheck-utils/package.json
+++ b/packages/app/healthcheck-utils/package.json
@@ -29,29 +29,29 @@
         "postversion": "biome check --write package.json"
     },
     "dependencies": {
-        "@lokalise/node-core": "^13.1.0",
+        "@lokalise/node-core": "^13.6.0",
         "@supercharge/promise-pool": "^3.2.0",
-        "redis-semaphore": "^5.6.1",
+        "redis-semaphore": "^5.6.2",
         "toad-cache": "^3.7.0"
     },
     "peerDependencies": {
         "@lokalise/background-jobs-common": ">=12.0.0",
         "ioredis": "^5.4.1",
         "prom-client": "^15.1.3",
-        "toad-scheduler": "^3.0.1"
+        "toad-scheduler": "^3.1.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@lokalise/background-jobs-common": "^12.0.0",
+        "@lokalise/background-jobs-common": "^12.3.0",
         "@lokalise/biome-config": "^2.0.0",
-        "@lokalise/node-core": "^13.1.0",
+        "@lokalise/node-core": "^13.6.0",
         "@lokalise/tsconfig": "^1.3.0",
-        "@vitest/coverage-v8": "^3.0.7",
-        "ioredis": "^5.4.1",
+        "@vitest/coverage-v8": "^3.1.2",
+        "ioredis": "^5.6.1",
         "prom-client": "^15.1.3",
         "rimraf": "^6.0.1",
-        "toad-scheduler": "^3.0.1",
+        "toad-scheduler": "^3.1.0",
         "typescript": "5.8.3",
-        "vitest": "^3.0.7"
+        "vitest": "^3.1.2"
     }
 }

--- a/packages/app/healthcheck-utils/src/HealthcheckResultsStore.spec.ts
+++ b/packages/app/healthcheck-utils/src/HealthcheckResultsStore.spec.ts
@@ -7,7 +7,6 @@ import {
 const testParams: HealthcheckResultsStoreParams = {
   maxHealthcheckNumber: 2,
   healthCheckResultTtlInMsecs: 5000,
-  stalenessThresholdInMsecs: 1000,
 }
 
 type TestHealthchecks = 'db' | 'redis'


### PR DESCRIPTION
## Changes

We now preemptively populate healthcheck store, and always assume that if value is not there, check has failed.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
