### PR TITLE
Feat: faster vault utils

### DIFF
--- a/packages/app/script-utils/src/index.ts
+++ b/packages/app/script-utils/src/index.ts
@@ -1,2 +1,3 @@
 /* c8 ignore next */
 export { synchronizeEnvFileWithVault } from './vault/syncEnvWithVault.ts'
+export { vaultLogin, vaultGetVars, vaultGetVarsAsync } from './vault/vault.ts'

--- a/packages/app/script-utils/src/index.ts
+++ b/packages/app/script-utils/src/index.ts
@@ -1,3 +1,3 @@
 /* c8 ignore next */
-export { synchronizeEnvFileWithVault } from './vault/syncEnvWithVault.ts'
+export { synchronizeEnvFileWithVault, upsertEnvValue, updateEnvFile } from './vault/syncEnvWithVault.ts'
 export { vaultLogin, vaultGetVars, vaultGetVarsAsync } from './vault/vault.ts'

--- a/packages/app/script-utils/src/vault/syncEnvWithVault.ts
+++ b/packages/app/script-utils/src/vault/syncEnvWithVault.ts
@@ -13,7 +13,7 @@ import { vaultGetVars, vaultLogin } from './vault.ts'
  * @param envContents String contents of the .env file
  * @param parsedEnv Record of .env file key-values (parsed using `dotenv.parse`)
  */
-const upsertEnvValue = (
+export const upsertEnvValue = (
   key: string,
   value: string,
   envContents: string,
@@ -43,9 +43,10 @@ const upsertEnvValue = (
  *
  * @param envVars Record of variable key-values
  * @param file Path to the .env file
+ * @param createEmpty Whether to create empty file even if no variables are passed
  */
-export const updateEnvFile = (envVars: Record<string, string>, file: string) => {
-  if (Object.entries(envVars).length === 0) {
+export const updateEnvFile = (envVars: Record<string, string>, file: string, createEmpty = false) => {
+  if (Object.entries(envVars).length === 0 && !createEmpty) {
     globalLogger.info(`Skipping env file ${file}`)
     return
   }

--- a/packages/app/script-utils/src/vault/vault.ts
+++ b/packages/app/script-utils/src/vault/vault.ts
@@ -1,8 +1,11 @@
 /* c8 ignore start */
 import type { SpawnSyncReturns } from 'node:child_process'
-import { execSync } from 'node:child_process'
+import { execSync, exec } from 'node:child_process'
+import { promisify } from 'node:util'
 
 import { globalLogger } from '@lokalise/node-core'
+
+const execAsync = promisify(exec)
 
 type VaultGetTokenResponse = {
   request_id: string
@@ -102,6 +105,25 @@ export const vaultGetVars = (service: string): Record<string, string> => {
     if (isExecError(e)) {
       globalLogger.error(
         `Vault ${service} error downloading env vars -> ${e.stderr.toString()}. Make sure you're using correct path to secrets. Vault reports 403 if the path is incorrect.`,
+      )
+    }
+    return {}
+  }
+}
+
+export const vaultGetVarsAsync = async (service: string): Promise<Record<string, string>> => {
+  if (!process.env.VAULT_TOKEN) return {}
+
+  try {
+    const { stdout } = await execAsync(`vault kv get -format=json "kv/${service}/dev"`)
+    const responseJson = JSON.parse(stdout) as VaultGetVarsResponse
+
+    globalLogger.info(`Vault ${service} version: ${responseJson.data.metadata.version}`)
+    return responseJson.data.data
+  } catch (e: unknown) {
+    if (isExecError(e)) {
+      globalLogger.error(
+        `Vault ${service} error downloading env vars -> ${e.stderr?.toString()}. Make sure you're using correct path to secrets. Vault reports 403 if the path is incorrect.`,
       )
     }
     return {}

--- a/packages/app/script-utils/src/vault/vault.ts
+++ b/packages/app/script-utils/src/vault/vault.ts
@@ -43,7 +43,7 @@ const installVaultCli = () => {
     }
   } else if (osType === 'darwin') {
     // macOS
-    execSync('brew list vault || brew install vault') // installing only if not installed
+    execSync('which vault || brew install vault') // installing only if not installed
   } else {
     globalLogger.warn(
       `You are running ${osType}, which doesn't support autoinstall, please ensure that Vault is installed and is accessible globally via "vault" command.`,


### PR DESCRIPTION
## Changes

So the title is faster vault utils, but I guess really it's "enabling faster vault utils". I'm exporting some lower level utils, as logging in for every `vaultGetVars` is massively slowing startup time for autopilot when using `synchronizeEnvFileWithVault` in a loop, so really it's best to pull it out. Made a minor improvement to not `brew list` when checking vault is installed, and, the main thing that's gonna help downstream is created a new async version of vaultGetVars which is gonna help us parallelise the above mentioned loop in our startup scrtips.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
