### PR TITLE
Make prisma-utils CI more predictable by pinning dependency

### DIFF
--- a/packages/app/prisma-utils/package.json
+++ b/packages/app/prisma-utils/package.json
@@ -45,10 +45,10 @@
         "@lokalise/backend-http-client": "^2.3.0",
         "@lokalise/fastify-extras": "^27.0.0",
         "@lokalise/tsconfig": "^1.3.0",
-        "@prisma/client": "^6.0.1",
+        "@prisma/client": "~6.6.0",
         "@vitest/coverage-v8": "^3.0.7",
         "cross-env": "^7.0.3",
-        "prisma": "^6.0.1",
+        "prisma": "~6.6.0",
         "rimraf": "^6.0.1",
         "typescript": "5.8.3",
         "vitest": "^3.0.7"

--- a/packages/app/prisma-utils/package.json
+++ b/packages/app/prisma-utils/package.json
@@ -33,7 +33,7 @@
         "postversion": "biome check --write package.json"
     },
     "dependencies": {
-        "@lokalise/node-core": "^14.0.0"
+        "@lokalise/node-core": "^14.0.1"
     },
     "peerDependencies": {
         "@prisma/client": ">=5.0.0 <7.0.0",
@@ -42,15 +42,15 @@
     "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@lokalise/biome-config": "^2.0.0",
-        "@lokalise/backend-http-client": "^2.3.0",
-        "@lokalise/fastify-extras": "^27.0.0",
+        "@lokalise/backend-http-client": "^5.0.0",
+        "@lokalise/fastify-extras": "^27.4.0",
         "@lokalise/tsconfig": "^1.3.0",
-        "@prisma/client": "~6.6.0",
-        "@vitest/coverage-v8": "^3.0.7",
+        "@prisma/client": "~6.8.2",
+        "@vitest/coverage-v8": "^3.1.4",
         "cross-env": "^7.0.3",
-        "prisma": "~6.6.0",
+        "prisma": "~6.8.2",
         "rimraf": "^6.0.1",
         "typescript": "5.8.3",
-        "vitest": "^3.0.7"
+        "vitest": "^3.1.4"
     }
 }


### PR DESCRIPTION
## Changes

CI started failing again, pinning version to avoid

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
