### PR TITLE
Update zod for backend-http-client

### DIFF
--- a/packages/app/backend-http-client/package.json
+++ b/packages/app/backend-http-client/package.json
@@ -34,9 +34,9 @@
         "postversion": "biome check --write package.json"
     },
     "dependencies": {
-        "undici": "^7.6.0",
+        "undici": "^7.9.0",
         "undici-retry": "^6.0.0",
-        "zod": "^3.24.2"
+        "zod": "^3.25.3"
     },
     "peerDependencies": {
         "@lokalise/node-core": ">=13.1.0",
@@ -46,11 +46,11 @@
         "@biomejs/biome": "^1.9.4",
         "@lokalise/api-contracts": "^4.1.1",
         "@lokalise/biome-config": "^2.0.0",
-        "@lokalise/node-core": "^14.0.0",
+        "@lokalise/node-core": "^14.0.1",
         "@lokalise/tsconfig": "^1.3.0",
-        "@types/node": "^22.13.14",
-        "@vitest/coverage-v8": "^3.0.9",
+        "@types/node": "^22.15.19",
+        "@vitest/coverage-v8": "^3.1.4",
         "typescript": "^5.8.3",
-        "vitest": "^3.0.9"
+        "vitest": "^3.1.4"
     }
 }

--- a/packages/app/backend-http-client/package.json
+++ b/packages/app/backend-http-client/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "undici": "^7.9.0",
         "undici-retry": "^6.0.0",
-        "zod": "^3.25.3"
+        "zod": "^3.25.7"
     },
     "peerDependencies": {
         "@lokalise/node-core": ">=13.1.0",

--- a/packages/app/backend-http-client/src/client/apiContractTypes.ts
+++ b/packages/app/backend-http-client/src/client/apiContractTypes.ts
@@ -1,6 +1,6 @@
 import type { FreeformRecord } from '@lokalise/node-core'
 import type { RequestResult } from 'undici-retry'
-import type { ZodSchema, z } from 'zod'
+import type { ZodSchema, z } from 'zod/v3'
 
 export type HeadersObject = Record<string, string>
 export type HeadersSource = HeadersObject | (() => HeadersObject) | (() => Promise<HeadersObject>)

--- a/packages/app/backend-http-client/src/client/constants.ts
+++ b/packages/app/backend-http-client/src/client/constants.ts
@@ -1,7 +1,7 @@
 import type { MayOmit } from '@lokalise/node-core'
 import type { Client } from 'undici'
 
-import { z } from 'zod'
+import { z } from 'zod/v3'
 import type { RequestOptions } from './types.ts'
 
 export const DEFAULT_OPTIONS = {

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -1,7 +1,7 @@
 import type { Interceptable } from 'undici'
 import { Client, MockAgent, setGlobalDispatcher } from 'undici'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { z } from 'zod'
+import { z } from 'zod/v3'
 
 import { buildDeleteRoute, buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
 import { JSON_HEADERS } from './constants.ts'

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -11,7 +11,7 @@ import type {
   RequestResult,
   RetryConfig,
 } from 'undici-retry'
-import type { ZodError, ZodSchema, z } from 'zod'
+import type { ZodError, ZodSchema, z } from 'zod/v3'
 
 import type {
   DeleteRouteDefinition,

--- a/packages/app/backend-http-client/src/client/types.ts
+++ b/packages/app/backend-http-client/src/client/types.ts
@@ -1,7 +1,7 @@
 import type { DefiniteEither } from '@lokalise/node-core'
 import type { Client } from 'undici'
 import type { Either, InternalRequestError, RequestResult, RetryConfig } from 'undici-retry'
-import type { ZodSchema } from 'zod'
+import type { ZodSchema } from 'zod/v3'
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export type RecordObject = Record<string, any>

--- a/packages/app/frontend-http-client/src/client.spec.ts
+++ b/packages/app/frontend-http-client/src/client.spec.ts
@@ -232,7 +232,7 @@ describe('frontend-http-client', () => {
       expect(responseBody satisfies z.infer<typeof responseBodySchema>).toEqual({
         data: {
           code: 99,
-          url: 'http://localhost:8000/users/1?sort=-startDate%2CendDate',
+          url: `${mockServer.url}/users/1?sort=-startDate%2CendDate`,
         },
       })
     })


### PR DESCRIPTION
## Changes

Underlying libraries need to be updated to start using and expecting v4 zod, meanwhile we can start preparing by bumping the dependency version and pinning classic version explicitly.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
