### PR TITLE
Add option to set job options as a function

### DIFF
--- a/packages/app/background-jobs-common/README.md
+++ b/packages/app/background-jobs-common/README.md
@@ -90,7 +90,7 @@ To set up a queue configuration, you need to define a list of objects containing
    The delimiter is `QUEUE_GROUP_DELIMITER`.
    You can use the helper `commonBullDashboardGroupingBuilder(serviceId, moduleId)` to generate a grouping like `['serviceId', 'moduleId']`.
 - **`jobPayloadSchema`**: A Zod schema that defines the structure of the jobs payload for this queue.
-- **`jobOptions`**: Default options for jobs in this queue. See [BullMQ documentation](https://docs.bullmq.io/guide/job-options).
+- **`jobOptions`**: Default options for jobs in this queue. Can be a function that will be resolved when a job is scheduled. See [BullMQ documentation](https://docs.bullmq.io/guide/job-options).
 
 #### Job Deduplication
 

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
@@ -44,7 +44,7 @@ const supportedQueues = [
       return {
         attempts: 5,
       }
-    }
+    },
   },
 ] as const satisfies QueueConfiguration[]
 
@@ -341,9 +341,9 @@ describe('QueueManager', () => {
         metadata: { correlationId: 'correlation_id' },
       })
       expect(spyResult1).toMatchObject({
-        opts:{
-          attempts: 5
-        }
+        opts: {
+          attempts: 5,
+        },
       })
 
       const jobId2 = await queueManager.schedule('queue3', {

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.spec.ts
@@ -40,6 +40,11 @@ const supportedQueues = [
         correlationId: z.string(),
       }),
     }),
+    jobOptions() {
+      return {
+        attempts: 5,
+      }
+    }
   },
 ] as const satisfies QueueConfiguration[]
 
@@ -334,6 +339,11 @@ describe('QueueManager', () => {
         id: 'test_1',
         _execution: 'execution in progress',
         metadata: { correlationId: 'correlation_id' },
+      })
+      expect(spyResult1).toMatchObject({
+        opts:{
+          attempts: 5
+        }
       })
 
       const jobId2 = await queueManager.schedule('queue3', {

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -212,7 +212,10 @@ export class QueueManager<
   ): JobOptionsType {
     const queueConfig = this.queueRegistry.getQueueConfig(queueId)
 
-    const defaultOptions = typeof queueConfig.jobOptions === 'function' ? queueConfig.jobOptions(jobPayload) : queueConfig.jobOptions
+    const defaultOptions =
+      typeof queueConfig.jobOptions === 'function'
+        ? queueConfig.jobOptions(jobPayload)
+        : queueConfig.jobOptions
 
     const resolvedOptions: JobOptionsType = merge(
       defaultOptions ?? {},

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -210,7 +210,10 @@ export class QueueManager<
     jobPayload: JobPayloadForQueue<Queues, QueueId>,
     options?: JobOptionsType,
   ): JobOptionsType {
-    const defaultOptions = this.queueRegistry.getQueueConfig(queueId).jobOptions
+    const queueConfig = this.queueRegistry.getQueueConfig(queueId)
+
+    const defaultOptions = typeof queueConfig.jobOptions === 'function' ? queueConfig.jobOptions(jobPayload) : queueConfig.jobOptions
+
     const resolvedOptions: JobOptionsType = merge(
       defaultOptions ?? {},
       options ?? {},

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
@@ -32,8 +32,8 @@ export type QueueConfiguration<
   queueOptions?: Omit<QueueOptionsType, 'connection' | 'prefix'>
   jobPayloadSchema: PayloadSchema
   jobOptions?:
-      | JobOptionsWithDeduplicationIdBuilder<JobOptionsType>
-      | ((payload: z.infer<PayloadSchema>) => JobOptionsWithDeduplicationIdBuilder<JobOptionsType>)
+    | JobOptionsWithDeduplicationIdBuilder<JobOptionsType>
+    | ((payload: z.infer<PayloadSchema>) => JobOptionsWithDeduplicationIdBuilder<JobOptionsType>)
 }
 
 export type SupportedQueueIds<Config extends QueueConfiguration[]> = Config[number]['queueId']

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
@@ -14,7 +14,7 @@ type JobOptionsWithDeduplicationIdBuilder<JobOptionsType extends JobsOptions> = 
   'deduplication'
 > & {
   deduplication?: Omit<NonNullable<JobOptionsType['deduplication']>, 'id'> & {
-    /** Callback to allow building deduplication id base on job data*/
+    /** @deprecated Use `jobOptions` as a function with payload as an argument instead. */
     // biome-ignore lint/suspicious/noExplicitAny: We cannot infer type of JobData, but we have run time validation
     idBuilder: (JobData: any) => string
   }

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
@@ -23,13 +23,17 @@ type JobOptionsWithDeduplicationIdBuilder<JobOptionsType extends JobsOptions> = 
 export type QueueConfiguration<
   QueueOptionsType extends QueueOptions = QueueOptions,
   JobOptionsType extends JobsOptions = JobsOptions,
+  QueueIdType extends string = string,
+  PayloadSchema extends z.ZodType<BaseJobPayload> = z.ZodType<BaseJobPayload>,
 > = {
-  queueId: string
+  queueId: QueueIdType
   /** Used to compose the queue name and allow bull dashboard grouping feature */
   bullDashboardGrouping?: string[]
   queueOptions?: Omit<QueueOptionsType, 'connection' | 'prefix'>
-  jobPayloadSchema: z.ZodType<BaseJobPayload> // should extend JobPayload
-  jobOptions?: JobOptionsWithDeduplicationIdBuilder<JobOptionsType>
+  jobPayloadSchema: PayloadSchema
+  jobOptions?:
+      | JobOptionsWithDeduplicationIdBuilder<JobOptionsType>
+      | ((payload: z.infer<PayloadSchema>) => JobOptionsWithDeduplicationIdBuilder<JobOptionsType>)
 }
 
 export type SupportedQueueIds<Config extends QueueConfiguration[]> = Config[number]['queueId']


### PR DESCRIPTION
## Changes

This PR allows the use of a function that will be resolved for every scheduled job for `jobOptions`
```
  {
    queueId: LqaAsyncReviewJobProcessor.QUEUE_ID,
    jobPayloadSchema: LQA_ASYNC_REVIEW_JOB_DATA,
    jobOptions(payload:any): {
      return {
        group: {
          id: payload.withTenantGrouping ? payload.tenantId : payload.key,
        }
      }
    }
  },
```

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
