### PR TITLE
Correct exports configuration for Biome v2 compatibility

### DIFF
--- a/packages/dev/biome-config/package.json
+++ b/packages/dev/biome-config/package.json
@@ -16,9 +16,7 @@
         "url": "git://github.com/lokalise/shared-ts-libs.git"
     },
     "exports": {
-        "./*": [
-            "./configs/*.jsonc"
-        ]
+        "./configs/*": "./configs/*"
     },
     "private": false,
     "devDependencies": {


### PR DESCRIPTION
## Changes

Fix malformed exports pattern that was causing module resolution failures with Biome v2. Replace array syntax with proper wildcard mapping to resolve imports like @lokalise/biome-config/configs/biome-base.jsonc correctly.

- Change exports from `"./*": ["./configs/*.jsonc"]` to `"./configs/*": "./configs/*"`
- Ensures compliance with Node.js ES module specifications
- Resolves "unexpected target in imports or exports" error


## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
