### PR TITLE
feat: add details to MutedUnrecoverableError

### DIFF
--- a/packages/app/background-jobs-common/src/background-job-processor/errors/MutedUnrecoverableError.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/errors/MutedUnrecoverableError.ts
@@ -3,9 +3,12 @@ import { UnrecoverableError } from 'bullmq'
 export const MUTED_UNRECOVERABLE_ERROR_SYMBOL = Symbol.for('MUTED_UNRECOVERABLE_ERROR_KEY')
 
 export class MutedUnrecoverableError extends UnrecoverableError {
-  constructor(message?: string, public readonly cause?: unknown) {
+  public readonly details?: Record<string, unknown>
+
+  constructor(message?: string, details?: Record<string, unknown>) {
     super(message)
     this.name = UnrecoverableError.name
+    this.details = details
   }
 }
 

--- a/packages/app/background-jobs-common/src/background-job-processor/errors/MutedUnrecoverableError.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/errors/MutedUnrecoverableError.ts
@@ -3,7 +3,7 @@ import { UnrecoverableError } from 'bullmq'
 export const MUTED_UNRECOVERABLE_ERROR_SYMBOL = Symbol.for('MUTED_UNRECOVERABLE_ERROR_KEY')
 
 export class MutedUnrecoverableError extends UnrecoverableError {
-  constructor(message?: string) {
+  constructor(message?: string, public readonly cause?: unknown) {
     super(message)
     this.name = UnrecoverableError.name
   }


### PR DESCRIPTION
## Changes

Add details to `MutedUnrecoverableError`, so we can maintain some data from initial error when rethrowing this one.

Context: https://github.com/lokalise/content-type-app-engine/pull/567#discussion_r2178303680

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
