### PR TITLE
feat: assert is never utility function

### DIFF
--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -56,7 +56,7 @@
         "@lokalise/tsconfig": "^1.3.0",
         "@types/node": "^24.0.3",
         "@vitest/coverage-v8": "^3.2.3",
-        "bullmq": "^5.56.4",
+        "bullmq": "^5.56.5",
         "ioredis": "^5.6.1",
         "rimraf": "^6.0.1",
         "toad-scheduler": "^3.1.0",

--- a/packages/app/fastify-bullboard-plugin/package.json
+++ b/packages/app/fastify-bullboard-plugin/package.json
@@ -42,7 +42,7 @@
         "@lokalise/node-core": "^14.1.0",
         "awilix": "^12.0.5",
         "awilix-manager": "^6.1.0",
-        "bullmq": "5.56.4",
+        "bullmq": "5.56.5",
         "cross-env": "^7.0.3",
         "fastify": "^5.4.0",
         "fastify-graceful-shutdown": "^4.0.1",

--- a/packages/app/universal-ts-utils/README.md
+++ b/packages/app/universal-ts-utils/README.md
@@ -408,7 +408,7 @@ switch (value) {
 
     default:
         return assertIsNever(value);
-    //                   ^^^^^ - TS error that we don't handle 'case3'
+    //                       ^^^^^ - TS error that we don't handle 'case3'
 }
 ```
 

--- a/packages/app/universal-ts-utils/README.md
+++ b/packages/app/universal-ts-utils/README.md
@@ -4,56 +4,65 @@ Isomorphic general-purpose TS utils
 
 ## Overview
 
-The `universal-ts-utils` package provides a set of isomorphic, general-purpose TypeScript utilities for various common tasks.
-
-
+The `universal-ts-utils` package provides a set of isomorphic, general-purpose TypeScript utilities for various common
+tasks.
 
 ## Usage
 
-This package is designed to be used in both client (frontend) and server (backend) environments. For optimization purposes, 
-it intentionally does **not** have an index file to facilitate efficient tree-shaking by frontend bundlers. 
-Frontend bundlers strip out unused parts of dependencies to minimize bundle size, but an index file would include everything, 
+This package is designed to be used in both client (frontend) and server (backend) environments. For optimization
+purposes,
+it intentionally does **not** have an index file to facilitate efficient tree-shaking by frontend bundlers.
+Frontend bundlers strip out unused parts of dependencies to minimize bundle size, but an index file would include
+everything,
 negating this benefit.
 
-To enhance the backend experience, we provide a `node.ts` file that aggregates and re-exports all functions, emulating 
-a typical index file. Frontend imports remain modular, while backend imports can leverage the convenience of the `node.ts` 
+To enhance the backend experience, we provide a `node.ts` file that aggregates and re-exports all functions, emulating
+a typical index file. Frontend imports remain modular, while backend imports can leverage the convenience of the
+`node.ts`
 entry point.
 
 ### Import Examples
 
 **Frontend:**
+
 ```typescript
 import { chunk } from '@lokalise/universal-ts-utils/array/chunk';
 ```
 
 **Backend:**
+
 ```typescript
 import { chunk } from '@lokalise/universal-ts-utils/node';
 ```
 
-
-
 ## Methods
 
 ### Array Utilities
+
 This section describes utility functions to work with arrays efficiently and elegantly.
 
 #### `callChunked`
+
 A utility method to process an array in chunks asynchronously.
 
 ```typescript
 const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 const processChunk = (chunk: number[]): Promise<void> => {
-  console.log('Processing chunk', chunk)
-  return Promise.resolve()
+    console.log('Processing chunk', chunk)
+    return Promise.resolve()
 };
 
 callChunked(3, items, processChunk)
-  .then(() => { console.log('All chunks processed') })
-  .catch((e) => { console.error('Error processing chunks:', e) })
+    .then(() => {
+        console.log('All chunks processed')
+    })
+    .catch((e) => {
+        console.error('Error processing chunks:', e)
+    })
 ```
 
 #### `chunk`
+
 Divides the original array into smaller arrays, each of the specified `chunkSize`.
 
 ```typescript
@@ -62,6 +71,7 @@ const result = chunk(numbers, 2) // Returns: [[1, 2], [3, 4], [5]]
 ```
 
 #### `NonEmptyArray`
+
 Represents an array that is guaranteed to have at least one element.
 This type ensures that operations requiring at least one element (e.g., accessing the first element)
 are safe at both runtime and compile time, removing the need for additional checks.
@@ -74,6 +84,7 @@ console.log(array[0]); // OK
 ```
 
 #### `defineNonEmptyArray`
+
 Infers the type of the given array as NonEmptyArray<T>.
 Use this function when you want TypeScript to infer the non-empty
 nature of the array instead of manually defining it as NonEmptyArray.
@@ -84,20 +95,23 @@ const arr = defineNonEmptyArray([{ some: 'value' }]);
 ```
 
 #### `isNonEmptyArray`
-Checks if the given array is non-empty. This function acts as a type guard to confirm that the array contains at least 
-one element, and it refines the type to a tuple, indicating that the first element exists. This is useful to ensure 
+
+Checks if the given array is non-empty. This function acts as a type guard to confirm that the array contains at least
+one element, and it refines the type to a tuple, indicating that the first element exists. This is useful to ensure
 operations are not performed on empty arrays, providing type-level assurances.
 
 ```typescript
 const array: number[] = [1, 2, 3]
 if (isNonEmptyArray(array)) {
-  console.log(array[0]) // OK
-  const _: [number, ...number[]] = array // TS type works
+    console.log(array[0]) // OK
+    const _: [number, ...number[]] = array // TS type works
 }
 ```
 
 #### `mapNonEmptyArray`
-Maps over a NonEmptyArray, applying the given mapper function to each element, and returns a new NonEmptyArray with the mapped values.
+
+Maps over a NonEmptyArray, applying the given mapper function to each element, and returns a new NonEmptyArray with the
+mapped values.
 This function ensures that the result retains the NonEmptyArray type, unlike the standard Array.prototype.map,
 which infers the result as a regular array, losing the guarantee of being non-empty.
 
@@ -111,6 +125,7 @@ const _: NonEmptyArray<string> = stringCasted;
 ```
 
 #### `removeFalsy`
+
 Removes all falsy values from an array and returns a new array containing only truthy values.
 
 ```typescript
@@ -119,6 +134,7 @@ const result = removeFalsy(array) // Returns: [1, 'hello', true]
 ```
 
 #### `removeNullish`
+
 Removes all nullish values from an array and returns a new array containing only non-nullish elements.
 
 ```typescript
@@ -127,7 +143,8 @@ const result = removeNullish(array) // Returns: [1, 'hello', true, false, '']
 ```
 
 #### `sort`
-Sorts an array of strings or numbers in either ascending or descending order. This function returns a sorted copy of 
+
+Sorts an array of strings or numbers in either ascending or descending order. This function returns a sorted copy of
 the original array and does not modify the input, making it safe to use without side effects.
 
 ```typescript
@@ -136,14 +153,15 @@ const b = sort([3, 1, 2], 'desc') // Returns: [3, 2, 1]
 ```
 
 #### `sortByField`
-Sorts an array of objects based on a specified field and order. This function returns a sorted copy of the original 
+
+Sorts an array of objects based on a specified field and order. This function returns a sorted copy of the original
 array and does not affect the original, ensuring no side effects.
 
 ```typescript
 const data = [
-  { name: 'Zara', age: 22 },
-  { name: 'Alex', age: 30 },
-  { name: 'John', age: 25 }
+    { name: 'Zara', age: 22 },
+    { name: 'Alex', age: 30 },
+    { name: 'John', age: 25 }
 ]
 const sortedByName = sortByField(data, 'name')
 // Returns: [
@@ -154,6 +172,7 @@ const sortedByName = sortByField(data, 'name')
 ```
 
 #### `unique`
+
 Returns a new array containing only unique elements from the given array while preserving the order of first occurrence.
 This function uses a `Set` to store unique elements and then converts it back to an array.
 
@@ -163,6 +182,7 @@ const result = unique(numbers) // Returns: [1, 2, 3, 4, 5]
 ```
 
 #### `uniqueByProperty`
+
 Removes duplicates from an array of objects by a property and returns new array.
 
 ```typescript
@@ -175,10 +195,12 @@ const result = uniqueByProperty(array) // Returns: [{ id: 'a', value: 1 }, { id:
 ```
 
 ### Object Utilities
+
 This section describes utility functions to work with objects efficiently and elegantly.
 
 #### `areDeepEqual`
-Determines if two values are deeply equal. This function handles primitive types, arrays, and objects. For arrays and 
+
+Determines if two values are deeply equal. This function handles primitive types, arrays, and objects. For arrays and
 objects, it performs a recursive equality check.
 
 ```typescript
@@ -192,8 +214,9 @@ areDeepEqual([{ id: 1 }], [{ id: 1 }]) // true
 ```
 
 #### `convertDateFieldsToIsoString`
+
 Recursively converts all Date fields in an object or array of objects to ISO string format. This function retains the
-structure of the input, ensuring non-Date fields remain unchanged, while Date fields are replaced with their ISO string 
+structure of the input, ensuring non-Date fields remain unchanged, while Date fields are replaced with their ISO string
 representations.
 
 ```typescript
@@ -207,43 +230,46 @@ const result = convertDateFieldsToIsoString(obj)
 ```
 
 #### `copyWithoutEmpty`
-Creates a shallow copy of an object, excluding properties with "empty" values. An "empty" value includes `null`, 
+
+Creates a shallow copy of an object, excluding properties with "empty" values. An "empty" value includes `null`,
 `undefined`, and empty strings (`''`).
 
 ```typescript
 const source = {
-  name: 'Alice',
-  age: null,
-  occupation: '',
-  location: 'Wonderland',
-  status: undefined
+    name: 'Alice',
+    age: null,
+    occupation: '',
+    location: 'Wonderland',
+    status: undefined
 }
 const result = copyWithoutEmpty(source); // Returns: { name: 'Alice', location: 'Wonderland' }
 ```
 
 #### `copyWithoutNullish`
+
 Creates a shallow copy of an object, excluding properties with nullish values.
 
 ```typescript
 const source = {
-  name: 'Alice',
-  age: null,
-  occupation: 'Explorer',
-  location: undefined,
-  status: 'Active'
+    name: 'Alice',
+    age: null,
+    occupation: 'Explorer',
+    location: undefined,
+    status: 'Active'
 }
 const result = copyWithoutNullish(source) // Returns: { name: 'Alice', occupation: 'Explorer', status: 'Active' }
 ```
 
 #### `deepClone`
+
 Returns a deep cloned copy of an object.
 
 This function utilizes the `structuredClone` method, which is capable of deep cloning complex objects, including
 nested structures. However, it has limitations and does not support cloning functions, Error objects, WeakMap,
 WeakSet, DOM nodes, and certain other browser-specific objects like Window.
 
-When using this methid be aware of `structuredClone` limitations, be aware of its limitations. It cannot clone 
-functions, Error objects, certain web platform objects, and symbols, among others. For such cases, consider using 
+When using this methid be aware of `structuredClone` limitations, be aware of its limitations. It cannot clone
+functions, Error objects, certain web platform objects, and symbols, among others. For such cases, consider using
 custom cloning logic.
 
 ```typescript
@@ -253,15 +279,16 @@ const cloned = deepClone(original)
 ```
 
 #### `groupBy`
-Groups an array of objects based on the value of a specified key. This function iterates over the input array and 
-organizes the objects into groups, where each group is associated with a unique key value obtained from the specified 
+
+Groups an array of objects based on the value of a specified key. This function iterates over the input array and
+organizes the objects into groups, where each group is associated with a unique key value obtained from the specified
 selector.
 
 ```typescript
 const users = [
-  { name: 'Alice', age: 30 },
-  { name: 'Bob', age: 25 },
-  { name: 'Charlie', age: 30 }
+    { name: 'Alice', age: 30 },
+    { name: 'Bob', age: 25 },
+    { name: 'Charlie', age: 30 }
 ]
 const groupedByAge = groupBy(users, 'age')
 // Returns:{
@@ -271,7 +298,8 @@ const groupedByAge = groupBy(users, 'age')
 ```
 
 #### `groupByPath`
-Groups an array of objects based on a specified key path. This function supports nested keys, allowing the use of dot 
+
+Groups an array of objects based on a specified key path. This function supports nested keys, allowing the use of dot
 notation to group objects by deeply nested properties.
 
 ```typescript
@@ -293,16 +321,17 @@ const usersGroupedByCity = groupByPath(users, 'address.city')
 ```
 
 #### `groupByUnique`
-Groups an array of objects based on the unique value of a specified key. This function iterates over the input array 
-and organizes the objects into groups, where each group is associated with a unique key value obtained from the 
+
+Groups an array of objects based on the unique value of a specified key. This function iterates over the input array
+and organizes the objects into groups, where each group is associated with a unique key value obtained from the
 specified selector.
 
 If a duplicate key value is encountered, an error is thrown, ensuring the uniqueness of each key in the output.
 
 ```typescript
 const users = [
-  { id: 'a1', name: 'Alice' },
-  { id: 'b2', name: 'Bob' }
+    { id: 'a1', name: 'Alice' },
+    { id: 'b2', name: 'Bob' }
 ]
 const groupedById = groupByUnique(users, 'id');
 // Returns:{
@@ -312,6 +341,7 @@ const groupedById = groupByUnique(users, 'id');
 ```
 
 #### `isEmpty`
+
 Checks if an object or an array of objects is empty.
 
 - For an object, it is considered empty if it has no own enumerable properties with non-undefined values.
@@ -323,6 +353,7 @@ const isEmptyObj = isEmpty(emptyObject) // true
 ```
 
 #### `pick`
+
 Picks specified properties from an object and returns a new object with those properties. This function allows you to
 create a subset of an object by specifying which properties should be picked. You can also control whether properties
 with `undefined` or `null` values should be included in the result through the options parameter.
@@ -333,6 +364,7 @@ const result = pick(source, ['a']) // Returns: { a: 1 }
 ```
 
 #### `transformToKebabCase`
+
 Transforms the keys of an object or array of objects from camelCase or snake_case to kebab-case. This transformation
 is applied recursively, ensuring any nested objects are also processed. Non-object inputs are returned unchanged.
 
@@ -342,12 +374,13 @@ const result = transformToKebabCase(obj)
 console.log(result) // Returns: { 'my-id': 1, 'creation-date': 1, meta-obj: { 'update-date': 1 } }
 ```
 
-
 ### String Utilities
+
 This section describes utility functions to work with strings efficiently and elegantly.
 
 #### `trimText`
-Trims whitespace and `&nbsp;` characters from the beginning and end of a given string. Extracts and provides the 
+
+Trims whitespace and `&nbsp;` characters from the beginning and end of a given string. Extracts and provides the
 removed part as `prefix` and `suffix` properties.
 
 ```typescript
@@ -355,11 +388,32 @@ const text = '  Hello, World!  '
 const result = trimText(text) // Returns: { value: 'Hello, World!', prefix: '  ', suffix: '  ' }
 ```
 
-
 ### Type Utilities
+
 This section describes utility functions to work with types efficiently and elegantly.
 
+#### `assertIsNever`
+
+Asserts that the provided value is of type `never` and will cause a TypeScript error if it is not.
+This is useful for exhaustive type checking in switch statements or conditional types,
+ensuring that all possible cases have been handled.
+
+```typescript
+const value: "case1" | "case2" | "case3" = getSomeValue();
+
+switch (value) {
+    case 'case1':
+    case 'case2':
+        return 'Handled case2';
+
+    default:
+        return assertIsNever(value);
+    //                   ^^^^^ - TS error that we don't handle 'case3'
+}
+```
+
 #### `FreeformRecord`
+
 Utility type to representing a record with keys of a specified type and values of any type.
 
 ```typescript
@@ -368,6 +422,7 @@ const numberKeyRecord: FreeformRecord<number> = { 1: "one", 2: "two" }
 ```
 
 #### `hasMessage`
+
 Type guard to determine if a given value is an object with a string property `message`.
 
 ```typescript
@@ -376,6 +431,7 @@ const b = hasMessage({ error: 'Hello, world!' }) // true
 ```
 
 #### `isError`
+
 Type guard to determine if a given value is an `Error` object.
 
 ```typescript
@@ -384,6 +440,7 @@ const b = isError(new Error()) // True
 ```
 
 #### `isObject`
+
 Type guard to determine if a given value is a non-null object in TypeScript.
 
 ```typescript
@@ -392,22 +449,25 @@ const b = isObject('hello') // False
 ```
 
 #### `isStandardizedError`
+
 Type guard to determine if a given value is a `StandardizedError` object. This function checks whether the provided
-input conforms to the `StandardizedError` structure, which is commonly used in libraries (e.g., Fastify). 
+input conforms to the `StandardizedError` structure, which is commonly used in libraries (e.g., Fastify).
 Specifically, it verifies that the input is an object containing `code` and `message` properties, both of type `string`.
 
 ```typescript
 const a = isStandardizedError({ code: 'code', message: 'test' }) // True
 const b = isStandardizedError({ hello: 'world' }) // False
 ```
+
 #### `MakeRequired`
+
 Utility type to makes specified keys required in a type, while keeping the rest of the keys as they are.
 
 ```typescript
 type Config = {
-  host?: string
-  port?: number
-  secure?: boolean
+    host?: string
+    port?: number
+    secure?: boolean
 }
 type StrictConfig = MakeRequired<Config, 'host'>
 
@@ -416,13 +476,14 @@ const config2: StrictConfig = { host: "localhost", secure: true }
 ```
 
 #### `MayOmit`
+
 Utility type to makes specified keys in a type optional, while keeping the rest of the keys as they are.
 
 ```typescript
 type Config = {
-  host: string
-  port: number
-  secure: boolean
+    host: string
+    port: number
+    secure: boolean
 }
 type PartialConfig = MayOmit<Config, 'port' | 'secure'>
 
@@ -431,7 +492,8 @@ const config2: PartialConfig = { host: "localhost", port: 8080 }
 ```
 
 #### `ObjectValues`
-Utility type to extract all possible value types from a given object, allowing for type-safe usage when accessing 
+
+Utility type to extract all possible value types from a given object, allowing for type-safe usage when accessing
 the values.
 
 ```typescript
@@ -443,15 +505,21 @@ const invalidValue: MyType = 'invalid' // TypeScript error
 ```
 
 ### Other Utilities
+
 This section describes other utility functions included in this package.
 
 #### `waitAndRetry`
+
 Asynchronously retries a predicate function until it returns a truthy value or the maximum number of retries is
 reached.
 
 ```typescript
 const conditionMet = () => Math.random() > 0.9
 waitAndRetry(conditionMet, 50, 10)
-  .then((result) => { console.log('Condition met:', result) })
-  .catch((error) => { console.error('An error occurred:', error) })
+    .then((result) => {
+        console.log('Condition met:', result)
+    })
+    .catch((error) => {
+        console.error('An error occurred:', error)
+    })
 ```

--- a/packages/app/universal-ts-utils/src/node.ts
+++ b/packages/app/universal-ts-utils/src/node.ts
@@ -29,6 +29,7 @@ export * from './public/object/transformToKebabCase.ts'
 // string
 export * from './public/string/trimText.ts'
 // type
+export * from './public/type/assertIsNever.ts'
 export * from './public/type/FreeformRecord.ts'
 export * from './public/type/hasMessage.ts'
 export * from './public/type/isError.ts'

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.test.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.test.ts
@@ -24,5 +24,14 @@ describe('assertIsNever', () => {
     it('should throw an error with descriptive message for null values', () => {
       expect(() => assertIsNever(null as never)).toThrowError('Unexpected value: null')
     })
+
+    it('should handle a recursive structure passed into to the function', () => {
+      const recursiveObject: any = { key: 'value' }
+      recursiveObject.self = recursiveObject
+
+      expect(() => assertIsNever(recursiveObject as never)).toThrowError(
+        'Unexpected value: [object Object]',
+      )
+    })
   })
 })

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.test.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.test.ts
@@ -1,0 +1,8 @@
+import { expect } from 'vitest'
+import { assertIsNever } from './assertIsNever.js'
+
+describe('assertIsNever', () => {
+  it('should throw an error if a non-never value is passed in', () => {
+    expect(() => assertIsNever('not-never' as never)).toThrowError()
+  })
+})

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.test.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.test.ts
@@ -5,4 +5,24 @@ describe('assertIsNever', () => {
   it('should throw an error if a non-never value is passed in', () => {
     expect(() => assertIsNever('not-never' as never)).toThrowError()
   })
+
+  describe('assertIsNever', () => {
+    it('should throw an error if a non-never value is passed in', () => {
+      expect(() => assertIsNever('not-never' as never)).toThrowError()
+    })
+
+    it('should throw an error with descriptive message for string values', () => {
+      expect(() => assertIsNever('test' as never)).toThrowError('Unexpected value: "test"')
+    })
+
+    it('should throw an error with descriptive message for object values', () => {
+      expect(() => assertIsNever({ key: 'value' } as never)).toThrowError(
+        'Unexpected value: {"key":"value"}',
+      )
+    })
+
+    it('should throw an error with descriptive message for null values', () => {
+      expect(() => assertIsNever(null as never)).toThrowError('Unexpected value: null')
+    })
+  })
 })

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
@@ -1,0 +1,29 @@
+/**
+ * Asserts that the provided value is of type `never` and will cause a TypeScript error if it is not.
+ *
+ * This is useful for exhaustive type checking in switch statements or conditional types,
+ * ensuring that all possible cases have been handled.
+ *
+ * @param value - The value to assert as `never`.
+ * @throws {Error} Throws an error if the value is not of type `never`.
+ *
+ * @example
+ * ```typescript
+ * const value: "case1" | "case2" = getSomeValue();
+ *
+ * switch (value) {
+ *   case 'case1':
+ *     return 'Handled case1';
+ *
+ *   case 'case2':
+ *     return 'Handled case2';
+ *
+ *   default:
+ *     // This will trigger an error if there are unhandled cases
+ *     return assertIsNever(value);
+ * }
+ * ```
+ */
+export const assertIsNever = (value: never): never => {
+  throw new Error(`Unexpected value: ${JSON.stringify(value)}`)
+}

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
@@ -25,5 +25,5 @@
  * ```
  */
 export const assertIsNever = (value: never): never => {
-  throw new Error(`Unexpected value: ${JSON.stringify(value)}`)
+  throw new Error(`Unexpected value: ${value}`)
 }

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
@@ -1,5 +1,9 @@
 /**
  * Asserts that the provided value is of type `never` and will cause a TypeScript error if it is not.
+ * The goal of this is to error at build time if there is a case that is not covered.
+ * There is a fallback for runtime is something sneaks though. We are not trying to determine if something
+ * is `never` (i.e. `(value: unknown): value is never => {...}`) – we are, instead, trying to catch the case
+ * that something is not `never` when we expect it to be. In reality, this should ALWAYS be unreachable code.
  *
  * This is useful for exhaustive type checking in switch statements or conditional types,
  * ensuring that all possible cases have been handled.

--- a/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
+++ b/packages/app/universal-ts-utils/src/public/type/assertIsNever.ts
@@ -25,5 +25,14 @@
  * ```
  */
 export const assertIsNever = (value: never): never => {
-  throw new Error(`Unexpected value: ${value}`)
+  let stringValue: string = `${value}`
+
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: We should never here, but is a case has been missed this will not be never..
+    stringValue = typeof (value as any) === 'string' ? `"${value}"` : JSON.stringify(value)
+  } catch (_error) {
+    // If JSON.stringify fails, we fall back to the default string representation
+  }
+
+  throw new Error(`Unexpected value: ${stringValue}.`)
 }

--- a/packages/dev/biome-config/configs/biome-base.jsonc
+++ b/packages/dev/biome-config/configs/biome-base.jsonc
@@ -75,6 +75,9 @@
                         "maxAllowedComplexity": 15
                     }
                 }
+            },
+            "nursery": {
+                "useExhaustiveSwitchCases": "error"
             }
         }
     },


### PR DESCRIPTION
## Changes

FINALLY lift a utility function that I have written a number of times into a shared utility.

The `assertIsNever` method asserts that the provided value is of type `never` and will cause a TypeScript error if it is not.

This is useful for exhaustive type checking in switch statements or conditional types, ensuring that all possible cases have been handled.

```typescript
const value: "case1" | "case2" = getSomeValue();

switch (value) {  
    case 'case1':    
        return 'Handled case1';  

    case 'case2':    
        return 'Handled case2';  

    default:    
        // This will trigger an error if there are unhandled cases    
        return assertIsNever(value);
}
```

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
