### PR TITLE
Bull board should not fail if scheduler is already registered

### DIFF
--- a/packages/app/fastify-bullboard-plugin/src/bullBoard.ts
+++ b/packages/app/fastify-bullboard-plugin/src/bullBoard.ts
@@ -88,7 +88,9 @@ async function scheduleUpdates(
     (e) => fastify.log.error(resolveGlobalErrorLogObject(e)),
   )
 
-  await fastify.register(fastifySchedule)
+  // if scheduler is not registered, register it
+  if (!fastify.scheduler) await fastify.register(fastifySchedule)
+
   fastify.scheduler.addSimpleIntervalJob(
     new SimpleIntervalJob({ seconds: refreshIntervalInSeconds }, refreshTask, {
       id: 'bull-board-queues-update',


### PR DESCRIPTION
## Changes

## Checklist

- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [ ] I've updated the documentation, or no changes were necessary
- [ ] I've updated the tests, or no changes were necessary
