### PR TITLE
feat: support union types on responses

### DIFF
--- a/packages/app/api-contracts/package.json
+++ b/packages/app/api-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lokalise/api-contracts",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "files": [
         "dist"
     ],

--- a/packages/app/api-contracts/src/apiContracts.ts
+++ b/packages/app/api-contracts/src/apiContracts.ts
@@ -281,7 +281,7 @@ export function buildDeleteRoute<
  */
 export function mapRouteToPath(
   // biome-ignore lint/suspicious/noExplicitAny: We don't care about types here, we just need Zod schema
-  routeDefinition: CommonRouteDefinition<any, any, any, any, any, any>,
+  routeDefinition: CommonRouteDefinition<any, any, any, any, any, any, any>,
 ): string {
   if (!routeDefinition.requestPathParamsSchema) {
     return routeDefinition.pathResolver(EMPTY_PARAMS)

--- a/packages/app/api-contracts/src/apiContracts.ts
+++ b/packages/app/api-contracts/src/apiContracts.ts
@@ -28,6 +28,9 @@ export type CommonRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 > = {
   isNonJSONResponseExpected?: IsNonJSONResponseExpected
   isEmptyResponseExpected?: IsEmptyResponseExpected
@@ -36,7 +39,7 @@ export type CommonRouteDefinition<
   requestQuerySchema?: RequestQuerySchema
   requestHeaderSchema?: RequestHeaderSchema
   pathResolver: RoutePathResolver<InferSchemaOutput<PathParamsSchema>>
-  responseSchemasByStatusCode?: Partial<Record<HttpStatusCode, z.Schema>>
+  responseSchemasByStatusCode?: ResponseSchemasByStatusCode
   metadata?: CommonRouteDefinitionMetadata
 
   /*
@@ -62,13 +65,17 @@ export type PayloadRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 > = CommonRouteDefinition<
   SuccessResponseBodySchema,
   PathParamsSchema,
   RequestQuerySchema,
   RequestHeaderSchema,
   IsNonJSONResponseExpected,
-  IsEmptyResponseExpected
+  IsEmptyResponseExpected,
+  ResponseSchemasByStatusCode
 > & {
   method: 'post' | 'put' | 'patch'
   requestBodySchema: RequestBodySchema
@@ -81,13 +88,17 @@ export type GetRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 > = CommonRouteDefinition<
   SuccessResponseBodySchema,
   PathParamsSchema,
   RequestQuerySchema,
   RequestHeaderSchema,
   IsNonJSONResponseExpected,
-  IsEmptyResponseExpected
+  IsEmptyResponseExpected,
+  ResponseSchemasByStatusCode
 > & {
   method: 'get'
 }
@@ -99,13 +110,17 @@ export type DeleteRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 > = CommonRouteDefinition<
   SuccessResponseBodySchema,
   PathParamsSchema,
   RequestQuerySchema,
   RequestHeaderSchema,
   IsNonJSONResponseExpected,
-  IsEmptyResponseExpected
+  IsEmptyResponseExpected,
+  ResponseSchemasByStatusCode
 > & {
   method: 'delete'
 }
@@ -118,6 +133,9 @@ export function buildPayloadRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   params: PayloadRouteDefinition<
     RequestBodySchema,
@@ -126,7 +144,8 @@ export function buildPayloadRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
 ): PayloadRouteDefinition<
   RequestBodySchema,
@@ -135,7 +154,8 @@ export function buildPayloadRoute<
   RequestQuerySchema,
   RequestHeaderSchema,
   IsNonJSONResponseExpected,
-  IsEmptyResponseExpected
+  IsEmptyResponseExpected,
+  ResponseSchemasByStatusCode
 > {
   return {
     isEmptyResponseExpected: params.isEmptyResponseExpected ?? (false as IsEmptyResponseExpected),
@@ -163,6 +183,9 @@ export function buildGetRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   params: Omit<
     GetRouteDefinition<
@@ -171,7 +194,8 @@ export function buildGetRoute<
       RequestQuerySchema,
       RequestHeaderSchema,
       IsNonJSONResponseExpected,
-      IsEmptyResponseExpected
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
     >,
     'method'
   >,
@@ -181,7 +205,8 @@ export function buildGetRoute<
   RequestQuerySchema,
   RequestHeaderSchema,
   IsNonJSONResponseExpected,
-  IsEmptyResponseExpected
+  IsEmptyResponseExpected,
+  ResponseSchemasByStatusCode
 > {
   return {
     isEmptyResponseExpected: params.isEmptyResponseExpected ?? (false as IsEmptyResponseExpected),
@@ -208,6 +233,9 @@ export function buildDeleteRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   params: Omit<
     DeleteRouteDefinition<
@@ -216,7 +244,8 @@ export function buildDeleteRoute<
       RequestQuerySchema,
       RequestHeaderSchema,
       IsNonJSONResponseExpected,
-      IsEmptyResponseExpected
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
     >,
     'method'
   >,
@@ -226,7 +255,8 @@ export function buildDeleteRoute<
   RequestQuerySchema,
   RequestHeaderSchema,
   IsNonJSONResponseExpected,
-  IsEmptyResponseExpected
+  IsEmptyResponseExpected,
+  ResponseSchemasByStatusCode
 > {
   return {
     isEmptyResponseExpected: params.isEmptyResponseExpected ?? (true as IsEmptyResponseExpected),

--- a/packages/app/api-contracts/vitest.config.ts
+++ b/packages/app/api-contracts/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
 
-// biome-ignore lint/style/noDefaultExport: <explanation>
+// biome-ignore lint/style/noDefaultExport: vitest expects this
 export default defineConfig({
   test: {
     globals: true,

--- a/packages/app/backend-http-client/package.json
+++ b/packages/app/backend-http-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lokalise/backend-http-client",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "author": {
         "name": "Lokalise",
         "url": "https://lokalise.com/"
@@ -43,12 +43,12 @@
     },
     "peerDependencies": {
         "@lokalise/node-core": ">=13.1.0",
-        "@lokalise/api-contracts": ">=5.0.0",
+        "@lokalise/api-contracts": ">=5.1.0",
         "zod": ">=3.25.56"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",
-        "@lokalise/api-contracts": "^5.0.0",
+        "@lokalise/api-contracts": "^5.1.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/node-core": "^14.2.1",
         "@lokalise/tsconfig": "^1.3.0",

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -2,6 +2,7 @@ import type { Readable } from 'node:stream'
 import type {
   DeleteRouteDefinition,
   GetRouteDefinition,
+  HttpStatusCode,
   InferSchemaInput,
   InferSchemaOutput,
   PayloadRouteDefinition,
@@ -443,6 +444,9 @@ export function sendByPayloadRoute<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
   DoThrowOnError extends boolean = DEFAULT_THROW_ON_ERROR,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   client: Client,
   routeDefinition: PayloadRouteDefinition<
@@ -452,7 +456,8 @@ export function sendByPayloadRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -499,6 +504,9 @@ export function sendByGetRoute<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
   DoThrowOnError extends boolean = DEFAULT_THROW_ON_ERROR,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   client: Client,
   routeDefinition: GetRouteDefinition<
@@ -507,7 +515,8 @@ export function sendByGetRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -551,6 +560,9 @@ export function sendByDeleteRoute<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
   DoThrowOnError extends boolean = DEFAULT_THROW_ON_ERROR,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   client: Client,
   routeDefinition: DeleteRouteDefinition<
@@ -559,7 +571,8 @@ export function sendByDeleteRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,

--- a/packages/app/fastify-api-contracts/package.json
+++ b/packages/app/fastify-api-contracts/package.json
@@ -50,7 +50,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",
-        "@lokalise/api-contracts": "^5.0.0",
+        "@lokalise/api-contracts": "^5.1.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/tsconfig": "~1.2.0",
         "@vitest/coverage-v8": "^3.1.1",

--- a/packages/app/fastify-api-contracts/package.json
+++ b/packages/app/fastify-api-contracts/package.json
@@ -44,7 +44,7 @@
     "dependencies": {},
     "peerDependencies": {
         "@lokalise/node-core": ">=13.5.0",
-        "@lokalise/api-contracts": ">=5.0.0",
+        "@lokalise/api-contracts": ">=5.1.0",
         "fastify": ">=5.0.0",
         "zod": ">=3.25.56"
     },

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.response-types.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.response-types.spec.ts
@@ -1,0 +1,167 @@
+import { buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
+import { fastify } from 'fastify'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import {
+  buildFastifyNoPayloadRoute,
+  buildFastifyNoPayloadRouteHandler,
+} from './fastifyApiContracts.js'
+import type { RouteType } from './types.js'
+
+// Test schemas
+const SuccessResponseSchema = z.object({
+  data: z.string(),
+  status: z.literal('success'),
+})
+
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+  status: z.literal('error'),
+})
+
+const ValidationErrorSchema = z.object({
+  errors: z.array(z.string()),
+  status: z.literal('validation_error'),
+})
+
+const NotFoundSchema = z.object({
+  message: z.string(),
+  status: z.literal('not_found'),
+})
+
+// Test route with multiple response schemas
+const getRouteWithMultipleResponses = buildGetRoute({
+  pathResolver: () => '/test',
+  successResponseBodySchema: SuccessResponseSchema,
+  requestQuerySchema: z.object({
+    input: z.string(),
+  }),
+  responseSchemasByStatusCode: {
+    400: ErrorResponseSchema,
+    422: ValidationErrorSchema,
+  },
+})
+
+// Test route with only success response schema (no responseSchemasByStatusCode)
+const _getRouteSuccessOnly = buildGetRoute({
+  pathResolver: () => '/success-only',
+  successResponseBodySchema: SuccessResponseSchema,
+})
+
+// Test route with no success response schema (undefined), only responseSchemasByStatusCode
+const _getRouteErrorsOnly = buildGetRoute({
+  pathResolver: () => '/errors-only',
+  successResponseBodySchema: undefined,
+  responseSchemasByStatusCode: {
+    400: ErrorResponseSchema,
+    404: NotFoundSchema,
+  },
+})
+
+// Test route where success schema is also included in responseSchemasByStatusCode
+const _getRouteWithDuplicateSuccess = buildGetRoute({
+  pathResolver: () => '/duplicate-success',
+  successResponseBodySchema: SuccessResponseSchema,
+  responseSchemasByStatusCode: {
+    200: SuccessResponseSchema,
+    400: ErrorResponseSchema,
+    422: ValidationErrorSchema,
+  },
+})
+
+const _postRouteWithMultipleResponses = buildPayloadRoute({
+  method: 'post' as const,
+  pathResolver: () => '/test',
+  requestBodySchema: z.object({ input: z.string() }),
+  successResponseBodySchema: SuccessResponseSchema,
+  responseSchemasByStatusCode: {
+    400: ErrorResponseSchema,
+    422: ValidationErrorSchema,
+  },
+})
+
+// POST route with only success response schema
+const _postRouteSuccessOnly = buildPayloadRoute({
+  method: 'post' as const,
+  pathResolver: () => '/success-only',
+  requestBodySchema: z.object({ data: z.string() }),
+  successResponseBodySchema: SuccessResponseSchema,
+})
+
+// POST route with no success response schema, only responseSchemasByStatusCode
+const _postRouteErrorsOnly = buildPayloadRoute({
+  method: 'post' as const,
+  pathResolver: () => '/errors-only',
+  requestBodySchema: z.object({ action: z.string() }),
+  successResponseBodySchema: undefined,
+  responseSchemasByStatusCode: {
+    400: ErrorResponseSchema,
+    404: NotFoundSchema,
+  },
+})
+
+async function initApp<Route extends RouteType>(route: Route) {
+  const app = fastify({
+    logger: false,
+    disableRequestLogging: true,
+  })
+
+  // Simple validation that just passes through - focusing on response type testing
+  app.setValidatorCompiler(() => () => true)
+  app.setSerializerCompiler(() => (data) => JSON.stringify(data))
+
+  app.route(route)
+  await app.ready()
+  return app
+}
+
+describe('Response types with multiple status codes', () => {
+  describe('GET endpoint with multiple response types', () => {
+    it('should return success response', async () => {
+      const getHandler = buildFastifyNoPayloadRouteHandler(
+        getRouteWithMultipleResponses,
+        async (request, reply) => {
+          // this should pass, it is coming from ErrorResponseSchema
+          if (request.query.input === 'error') {
+            await reply.status(400).send({
+              error: 'error',
+              status: 'error' as const,
+            })
+            return
+          }
+
+          // this should not pass, field dummy does not exist, and status is not supported by any schema either
+          if (request.query.input === 'invalid_error') {
+            await reply.status(400).send({
+              dummy: 'error',
+              //@ts-expect-error This does not correspond to any schema
+              status: 'invalid' as const,
+            })
+            return
+          }
+
+          await reply.status(200).send({
+            data: 'success',
+            status: 'success' as const,
+          })
+        },
+      )
+
+      const route = buildFastifyNoPayloadRoute(getRouteWithMultipleResponses, getHandler)
+      const app = await initApp(route)
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        data: 'success',
+        status: 'success',
+      })
+
+      await app.close()
+    })
+  })
+})

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.response-types.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.response-types.spec.ts
@@ -1,4 +1,4 @@
-import { buildGetRoute, buildPayloadRoute } from '@lokalise/api-contracts'
+import { buildGetRoute } from '@lokalise/api-contracts'
 import { fastify } from 'fastify'
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
 import { describe, expect, it } from 'vitest'
@@ -22,12 +22,6 @@ const ValidationErrorSchema = z.object({
   errors: z.array(z.string()),
 })
 
-const NotFoundSchema = z.object({
-  message: z.string(),
-  status: z.literal('not_found'),
-})
-
-// Test route with multiple response schemas
 const getRouteWithMultipleResponses = buildGetRoute({
   pathResolver: () => '/test',
   successResponseBodySchema: SuccessResponseSchema,
@@ -41,62 +35,12 @@ const getRouteWithMultipleResponses = buildGetRoute({
   },
 })
 
-// Test route with only success response schema (no responseSchemasByStatusCode)
-const _getRouteSuccessOnly = buildGetRoute({
-  pathResolver: () => '/success-only',
-  successResponseBodySchema: SuccessResponseSchema,
-})
-
-// Test route with no success response schema (undefined), only responseSchemasByStatusCode
-const _getRouteErrorsOnly = buildGetRoute({
-  pathResolver: () => '/errors-only',
-  successResponseBodySchema: undefined,
-  responseSchemasByStatusCode: {
-    400: ErrorResponseSchema,
-    404: NotFoundSchema,
-  },
-})
-
-// Test route where success schema is also included in responseSchemasByStatusCode
-const _getRouteWithDuplicateSuccess = buildGetRoute({
-  pathResolver: () => '/duplicate-success',
-  successResponseBodySchema: SuccessResponseSchema,
-  responseSchemasByStatusCode: {
-    200: SuccessResponseSchema,
-    400: ErrorResponseSchema,
-    422: ValidationErrorSchema,
-  },
-})
-
-const _postRouteWithMultipleResponses = buildPayloadRoute({
-  method: 'post',
+const getRouteWithSingleResponse = buildGetRoute({
   pathResolver: () => '/test',
-  requestBodySchema: z.object({ input: z.string() }),
   successResponseBodySchema: SuccessResponseSchema,
-  responseSchemasByStatusCode: {
-    400: ErrorResponseSchema,
-    422: ValidationErrorSchema,
-  },
-})
-
-// POST route with only success response schema
-const _postRouteSuccessOnly = buildPayloadRoute({
-  method: 'post',
-  pathResolver: () => '/success-only',
-  requestBodySchema: z.object({ data: z.string() }),
-  successResponseBodySchema: SuccessResponseSchema,
-})
-
-// POST route with no success response schema, only responseSchemasByStatusCode
-const _postRouteErrorsOnly = buildPayloadRoute({
-  method: 'post',
-  pathResolver: () => '/errors-only',
-  requestBodySchema: z.object({ action: z.string() }),
-  successResponseBodySchema: undefined,
-  responseSchemasByStatusCode: {
-    400: ErrorResponseSchema,
-    404: NotFoundSchema,
-  },
+  requestQuerySchema: z.object({
+    input: z.string(),
+  }),
 })
 
 async function initApp<Route extends RouteType>(route: Route) {
@@ -230,6 +174,92 @@ describe('Response types with multiple status codes', () => {
         },
       })
       expect(response500.statusCode).toBe(500)
+
+      await app.close()
+    })
+  })
+
+  describe('GET endpoint with single response type', () => {
+    it('should return responses according to defined schemas', async () => {
+      const getHandler = buildFastifyNoPayloadRouteHandler(
+        getRouteWithSingleResponse,
+        async (request, reply) => {
+          if (request.query!.input === 'error') {
+            reply.code(200)
+            await reply.send({
+              //@ts-expect-error Invalid response - these fields don't exist in any schema
+              error: 'error',
+            })
+            return
+          }
+
+          if (request.query!.input === 'validation') {
+            reply.code(200)
+            await reply.send({
+              //@ts-expect-error Invalid response - these fields don't exist in any schema
+              errors: ['validation error'],
+            })
+            return
+          }
+
+          // Test with invalid response
+          if (request.query!.input === 'invalid_error') {
+            await reply.status(200).send({
+              //@ts-expect-error Invalid response - these fields don't exist in any schema
+              completely: 'wrong',
+              fields: 'here',
+            })
+            return
+          }
+
+          reply.code(200)
+          await reply.send({
+            data: 'success',
+          })
+        },
+      )
+
+      const route = buildFastifyNoPayloadRoute(getRouteWithSingleResponse, getHandler)
+      const app = await initApp(route)
+
+      const response200 = await app.inject({
+        method: 'GET',
+        url: '/test',
+        query: {
+          input: 'data',
+        },
+      })
+      expect(response200.statusCode).toBe(200)
+
+      const response500a = await app.inject({
+        method: 'GET',
+        url: '/test',
+        query: {
+          input: 'error',
+        },
+      })
+      // ToDo should use success schema for validation when map is not defined
+      expect(response500a.statusCode).toBe(200)
+
+      const response500b = await app.inject({
+        method: 'GET',
+        url: '/test',
+        query: {
+          input: 'validation',
+        },
+      })
+      // ToDo should use success schema for validation when map is not defined
+      expect(response500b.statusCode).toBe(200)
+
+      const response500c = await app.inject({
+        method: 'GET',
+        url: '/test',
+        query: {
+          input: 'invalid_error',
+        },
+      })
+      // ToDo should use success schema for validation when map is not defined
+      expect(response500c.statusCode).toBe(200)
 
       await app.close()
     })

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -1,4 +1,4 @@
-import type { CommonRouteDefinition } from '@lokalise/api-contracts'
+import type { CommonRouteDefinition, HttpStatusCode } from '@lokalise/api-contracts'
 import {
   type DeleteRouteDefinition,
   type GetRouteDefinition,
@@ -18,6 +18,39 @@ import type {
 type OptionalZodSchema = z.Schema | undefined
 type InferredOptionalSchema<Schema> = Schema extends z.Schema ? z.infer<Schema> : undefined
 
+// Helper to create a union of all response types from responseSchemasByStatusCode
+// Filters out undefined values that come from Partial<Record<...>>
+type InferResponseUnion<T> = T extends object
+  ? {
+      [K in keyof T as T[K] extends z.Schema ? K : never]: T[K] extends z.Schema
+        ? z.infer<T[K]>
+        : never
+    }[keyof { [K in keyof T as T[K] extends z.Schema ? K : never]: T[K] }]
+  : never
+
+// Build response type - either a union of all schemas or just the success schema
+// Note: This creates a union type of all possible responses, which means TypeScript
+// will accept any of the response types regardless of the status code being set.
+// This is a limitation compared to Fastify's native multi-reply system which can
+// narrow types based on the status code. Full multi-reply support would require
+// deeper integration with Fastify's SchemaCompiler generic system.
+type BuildResponseType<SuccessSchema, ResponseSchemasByStatusCode> =
+  ResponseSchemasByStatusCode extends object
+    ? keyof ResponseSchemasByStatusCode extends never
+      ? SuccessSchema extends z.Schema
+        ? z.infer<SuccessSchema>
+        : undefined
+      :
+          | InferResponseUnion<ResponseSchemasByStatusCode>
+          | (SuccessSchema extends z.Schema
+              ? 200 extends keyof ResponseSchemasByStatusCode
+                ? never
+                : z.infer<SuccessSchema>
+              : never)
+    : SuccessSchema extends z.Schema
+      ? z.infer<SuccessSchema>
+      : undefined
+
 declare module 'fastify' {
   interface FastifyContextConfig {
     apiContract: CommonRouteDefinition
@@ -32,6 +65,9 @@ export function buildFastifyNoPayloadRouteHandler<
   PathParams extends OptionalZodSchema = undefined,
   RequestQuerySchema extends OptionalZodSchema = undefined,
   RequestHeaderSchema extends OptionalZodSchema = undefined,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   _apiContract:
     | GetRouteDefinition<
@@ -40,7 +76,8 @@ export function buildFastifyNoPayloadRouteHandler<
         RequestQuerySchema,
         RequestHeaderSchema,
         boolean,
-        boolean
+        boolean,
+        ResponseSchemasByStatusCode
       >
     | DeleteRouteDefinition<
         ResponseBodySchema,
@@ -48,20 +85,16 @@ export function buildFastifyNoPayloadRouteHandler<
         RequestQuerySchema,
         RequestHeaderSchema,
         boolean,
-        boolean
+        boolean,
+        ResponseSchemasByStatusCode
       >,
   handler: FastifyNoPayloadHandlerFn<
-    InferredOptionalSchema<ResponseBodySchema>,
+    BuildResponseType<ResponseBodySchema, ResponseSchemasByStatusCode>,
     InferredOptionalSchema<PathParams>,
     InferredOptionalSchema<RequestQuerySchema>,
     InferredOptionalSchema<RequestHeaderSchema>
   >,
-): FastifyNoPayloadHandlerFn<
-  InferredOptionalSchema<ResponseBodySchema>,
-  InferredOptionalSchema<PathParams>,
-  InferredOptionalSchema<RequestQuerySchema>,
-  InferredOptionalSchema<RequestHeaderSchema>
-> {
+): typeof handler {
   return handler
 }
 
@@ -81,7 +114,9 @@ export function buildFastifyNoPayloadRoute<
         RequestQuerySchema,
         RequestHeaderSchema,
         boolean,
-        boolean
+        boolean,
+        // biome-ignore lint/suspicious/noExplicitAny: this is expected
+        any
       >
     | DeleteRouteDefinition<
         ResponseBodySchema,
@@ -89,7 +124,9 @@ export function buildFastifyNoPayloadRoute<
         RequestQuerySchema,
         RequestHeaderSchema,
         boolean,
-        boolean
+        boolean,
+        // biome-ignore lint/suspicious/noExplicitAny: this is expected
+        any
       >,
   handler: FastifyNoPayloadHandlerFn<
     InferredOptionalSchema<ResponseBodySchema>,
@@ -147,6 +184,9 @@ export function buildFastifyPayloadRouteHandler<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   _apiContract: PayloadRouteDefinition<
     RequestBodySchema,
@@ -155,22 +195,17 @@ export function buildFastifyPayloadRouteHandler<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   handler: FastifyPayloadHandlerFn<
-    InferredOptionalSchema<ResponseBodySchema>,
+    BuildResponseType<ResponseBodySchema, ResponseSchemasByStatusCode>,
     InferredOptionalSchema<RequestBodySchema>,
     InferredOptionalSchema<PathParams>,
     InferredOptionalSchema<RequestQuerySchema>,
     InferredOptionalSchema<RequestHeaderSchema>
   >,
-): FastifyPayloadHandlerFn<
-  InferredOptionalSchema<ResponseBodySchema>,
-  InferredOptionalSchema<RequestBodySchema>,
-  InferredOptionalSchema<PathParams>,
-  InferredOptionalSchema<RequestQuerySchema>,
-  InferredOptionalSchema<RequestHeaderSchema>
-> {
+): typeof handler {
   return handler
 }
 
@@ -193,7 +228,9 @@ export function buildFastifyPayloadRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    // biome-ignore lint/suspicious/noExplicitAny: this is expected
+    any
   >,
   handler: FastifyPayloadHandlerFn<
     InferredOptionalSchema<ResponseBodySchema>,

--- a/packages/app/frontend-http-client/package.json
+++ b/packages/app/frontend-http-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lokalise/frontend-http-client",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "description": "Opinionated HTTP client for the frontend",
     "files": [
         "dist/**",
@@ -40,13 +40,13 @@
         "fast-querystring": "^1.1.2"
     },
     "peerDependencies": {
-        "@lokalise/api-contracts": ">=5.0.0",
+        "@lokalise/api-contracts": ">=5.1.0",
         "wretch": "^2.8.0",
         "zod": ">=3.25.56"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",
-        "@lokalise/api-contracts": "^5.0.0",
+        "@lokalise/api-contracts": "^5.1.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/tsconfig": "~1.3.0",
         "@types/node": "^24.0.3",

--- a/packages/app/frontend-http-client/src/client.ts
+++ b/packages/app/frontend-http-client/src/client.ts
@@ -1,6 +1,7 @@
 import type {
   DeleteRouteDefinition,
   GetRouteDefinition,
+  HttpStatusCode,
   InferSchemaInput,
   InferSchemaOutput,
   PayloadRouteDefinition,
@@ -399,6 +400,9 @@ export function sendByPayloadRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   wretch: T,
   routeDefinition: PayloadRouteDefinition<
@@ -408,7 +412,8 @@ export function sendByPayloadRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -452,6 +457,9 @@ export function sendByGetRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   wretch: T,
   routeDefinition: GetRouteDefinition<
@@ -460,7 +468,8 @@ export function sendByGetRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -499,6 +508,9 @@ export function sendByDeleteRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
+  ResponseSchemasByStatusCode extends
+    | Partial<Record<HttpStatusCode, z.Schema>>
+    | undefined = undefined,
 >(
   wretch: T,
   routeDefinition: DeleteRouteDefinition<
@@ -507,7 +519,8 @@ export function sendByDeleteRoute<
     RequestQuerySchema,
     RequestHeaderSchema,
     IsNonJSONResponseExpected,
-    IsEmptyResponseExpected
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,

--- a/packages/app/universal-testing-utils/package.json
+++ b/packages/app/universal-testing-utils/package.json
@@ -44,25 +44,25 @@
         "postversion": "biome check --write package.json"
     },
     "peerDependencies": {
-        "@lokalise/api-contracts": ">=5.0.0",
+        "@lokalise/api-contracts": ">=5.1.0",
         "mockttp": ">=3.17.0",
         "msw": ">=2.7.0",
         "zod": ">=3.25.56"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",
-        "@lokalise/api-contracts": "^5.0.0",
+        "@lokalise/api-contracts": "^5.1.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/frontend-http-client": "^6.0.0",
         "@lokalise/tsconfig": "^1.3.0",
-        "@vitest/coverage-v8": "^3.2.2",
-        "mockttp": "^4.0.1",
-        "msw": "^2.10.2",
+        "@vitest/coverage-v8": "^3.2.4",
+        "mockttp": "^4.1.0",
+        "msw": "^2.11.1",
         "rimraf": "^6.0.1",
         "typescript": "5.9.2",
-        "vitest": "^3.2.2",
+        "vitest": "^3.2.4",
         "wretch": "^2.11.0",
-        "zod": "^4.0.17"
+        "zod": "^4.1.5"
     },
     "dependencies": {}
 }

--- a/packages/app/universal-testing-utils/package.json
+++ b/packages/app/universal-testing-utils/package.json
@@ -53,7 +53,7 @@
         "@biomejs/biome": "^2.1.4",
         "@lokalise/api-contracts": "^5.1.0",
         "@lokalise/biome-config": "^3.1.0",
-        "@lokalise/frontend-http-client": "^6.0.0",
+        "@lokalise/frontend-http-client": "^6.1.0",
         "@lokalise/tsconfig": "^1.3.0",
         "@vitest/coverage-v8": "^3.2.4",
         "mockttp": "^4.1.0",

--- a/packages/app/universal-testing-utils/src/MockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/MockttpHelper.spec.ts
@@ -38,6 +38,23 @@ describe('MockttpHelper', () => {
             `)
     })
 
+    it('enforces POST contract', async () => {
+      await mockttpHelper.mockValidResponse(postContract, {
+        // @ts-expect-error this should fail - wrong property
+        responseBody: { id: '1', wrong: 'wrong' },
+      })
+
+      const response = await sendByPayloadRoute(wretchClient, postContract, {
+        body: { name: 'frf' },
+      })
+
+      expect(response).toMatchInlineSnapshot(`
+            {
+              "id": "1",
+            }
+          `)
+    })
+
     it('mocks POST request with path params', async () => {
       await mockttpHelper.mockValidResponse(postContractWithPathParams, {
         pathParams: { userId: '3' },

--- a/packages/app/universal-testing-utils/src/MockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/MockttpHelper.ts
@@ -1,7 +1,9 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: Expected for mocking
 import {
   type CommonRouteDefinition,
   type InferSchemaInput,
   mapRouteToPath,
+  type PayloadRouteDefinition,
 } from '@lokalise/api-contracts'
 import type { Mockttp, RequestRuleBuilder } from 'mockttp'
 import type { z } from 'zod/v4'
@@ -17,6 +19,8 @@ export type PayloadMockParamsNoPath<ResponseBody> = {
   responseBody: ResponseBody
 }
 
+type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
+
 export class MockttpHelper {
   private readonly mockServer: Mockttp
 
@@ -27,32 +31,41 @@ export class MockttpHelper {
   async mockValidResponse<
     ResponseBodySchema extends z.Schema,
     PathParamsSchema extends z.Schema | undefined,
-    RequestQuerySchema extends z.Schema | undefined = undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
-    contract: CommonRouteDefinition<
-      ResponseBodySchema,
-      PathParamsSchema,
-      RequestQuerySchema,
-      RequestHeaderSchema,
-      IsNonJSONResponseExpected,
-      IsEmptyResponseExpected,
-      ResponseSchemasByStatusCode
-    >,
+    contract:
+      | CommonRouteDefinition<
+          ResponseBodySchema,
+          PathParamsSchema,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
+        >
+      | PayloadRouteDefinition<
+          z.Schema | undefined,
+          ResponseBodySchema,
+          PathParamsSchema,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
+        >,
     params: PathParamsSchema extends undefined
       ? PayloadMockParamsNoPath<InferSchemaInput<ResponseBodySchema>>
       : PayloadMockParams<InferSchemaInput<PathParamsSchema>, InferSchemaInput<ResponseBodySchema>>,
   ): Promise<void> {
-    const path = contract.requestPathParamsSchema
-      ? // @ts-expect-error this is safe
-        contract.pathResolver(params.pathParams)
-      : mapRouteToPath(contract)
-    let mockttp: RequestRuleBuilder
     // @ts-expect-error this is safe
-    const method: 'get' | 'delete' | 'post' | 'patch' | 'put' = contract.method
+    const pathParams = params.pathParams
+
+    const path =
+      contract.requestPathParamsSchema && pathParams && contract.pathResolver
+        ? contract.pathResolver(pathParams)
+        : mapRouteToPath(contract)
+
+    let mockttp: RequestRuleBuilder
+    const method = ('method' in contract ? contract.method : 'get') as HttpMethod
 
     switch (method) {
       case 'get':

--- a/packages/app/universal-testing-utils/src/MockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/MockttpHelper.ts
@@ -27,8 +27,21 @@ export class MockttpHelper {
   async mockValidResponse<
     ResponseBodySchema extends z.Schema,
     PathParamsSchema extends z.Schema | undefined,
+    RequestQuerySchema extends z.Schema | undefined = undefined,
+    RequestHeaderSchema extends z.Schema | undefined = undefined,
+    IsNonJSONResponseExpected extends boolean = false,
+    IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
-    contract: CommonRouteDefinition<ResponseBodySchema, PathParamsSchema>,
+    contract: CommonRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >,
     params: PathParamsSchema extends undefined
       ? PayloadMockParamsNoPath<InferSchemaInput<ResponseBodySchema>>
       : PayloadMockParams<InferSchemaInput<PathParamsSchema>, InferSchemaInput<ResponseBodySchema>>,

--- a/packages/app/universal-testing-utils/src/MswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.spec.ts
@@ -66,6 +66,28 @@ describe('MswHelper', () => {
             `)
     })
 
+    it('enforces POST request with path params contract', async () => {
+      mswHelper.mockValidResponse(postContractWithPathParams, server, {
+        // @ts-expect-error this should fail - wrong property
+        pathParams: { userId: '3', invalid: 'invalid' },
+        // @ts-expect-error this should fail - wrong property
+        responseBody: { id: '2', invalidField: 'frfr' },
+      })
+
+      const response = await sendByPayloadRoute(wretchClient, postContractWithPathParams, {
+        pathParams: {
+          userId: '3',
+        },
+        body: { name: 'frf' },
+      })
+
+      expect(response).toMatchInlineSnapshot(`
+              {
+                "id": "2",
+              }
+            `)
+    })
+
     it('mocks GET request without path params', async () => {
       mswHelper.mockValidResponse(getContract, server, {
         responseBody: { id: '1' },
@@ -182,6 +204,21 @@ describe('MswHelper', () => {
                 "wrongId": "1",
               }
             `)
+    })
+
+    it('accepts any response shape', async () => {
+      mswHelper.mockAnyResponse(postContract, server, {
+        responseBody: { wrongId: '1', wrongField: 'wrong' },
+      })
+
+      const response = await wretchClient.post({ name: 'frf' }, mapRouteToPath(postContract))
+
+      expect(await response.json()).toMatchInlineSnapshot(`
+        {
+          "wrongField": "wrong",
+          "wrongId": "1",
+        }
+      `)
     })
 
     it('mocks GET request without path params', async () => {

--- a/packages/app/universal-testing-utils/src/MswHelper.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.ts
@@ -57,9 +57,21 @@ export type MockEndpointParams<
   ResponseBodySchema extends z.Schema<JsonBodyType>,
   PathParamsSchema extends z.Schema | undefined,
   RequestQuerySchema extends z.Schema | undefined,
+  RequestHeaderSchema extends z.Schema | undefined = undefined,
+  IsNonJSONResponseExpected extends boolean = false,
+  IsEmptyResponseExpected extends boolean = false,
+  ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
 > = {
   server: SetupServerApi
-  contract: CommonRouteDefinition<ResponseBodySchema, PathParamsSchema, RequestQuerySchema>
+  contract: CommonRouteDefinition<
+    ResponseBodySchema,
+    PathParamsSchema,
+    RequestQuerySchema,
+    RequestHeaderSchema,
+    IsNonJSONResponseExpected,
+    IsEmptyResponseExpected,
+    ResponseSchemasByStatusCode
+  >
   pathParams: InferSchemaOutput<PathParamsSchema>
   // biome-ignore lint/suspicious/noExplicitAny: we accept any input
   responseBody: any
@@ -78,8 +90,20 @@ export class MswHelper {
     ResponseBodySchema extends z.Schema<JsonBodyType>,
     PathParamsSchema extends z.Schema | undefined,
     RequestQuerySchema extends z.Schema | undefined,
+    RequestHeaderSchema extends z.Schema | undefined = undefined,
+    IsNonJSONResponseExpected extends boolean = false,
+    IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
-    contract: CommonRouteDefinition<ResponseBodySchema, PathParamsSchema, RequestQuerySchema>,
+    contract: CommonRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >,
     pathParams: InferSchemaOutput<PathParamsSchema>,
   ) {
     const path = contract.requestPathParamsSchema
@@ -97,7 +121,21 @@ export class MswHelper {
     ResponseBodySchema extends z.Schema<JsonBodyType>,
     PathParamsSchema extends z.Schema | undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
-  >(params: MockEndpointParams<ResponseBodySchema, PathParamsSchema, RequestQuerySchema>) {
+    RequestHeaderSchema extends z.Schema | undefined = undefined,
+    IsNonJSONResponseExpected extends boolean = false,
+    IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
+  >(
+    params: MockEndpointParams<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >,
+  ) {
     const { method, resolvedPath } = this.resolveParams(params.contract, params.pathParams)
     params.server.use(
       http[method](resolvedPath, () => {
@@ -115,8 +153,20 @@ export class MswHelper {
     ResponseBodySchema extends z.Schema<JsonBodyType>,
     PathParamsSchema extends z.Schema | undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
+    RequestHeaderSchema extends z.Schema | undefined = undefined,
+    IsNonJSONResponseExpected extends boolean = false,
+    IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
-    contract: CommonRouteDefinition<ResponseBodySchema, PathParamsSchema, RequestQuerySchema>,
+    contract: CommonRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >,
     server: SetupServerApi,
     params: PathParamsSchema extends undefined
       ? MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>
@@ -137,8 +187,20 @@ export class MswHelper {
     ResponseBodySchema extends z.Schema<JsonBodyType>,
     PathParamsSchema extends z.Schema | undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
+    RequestHeaderSchema extends z.Schema | undefined = undefined,
+    IsNonJSONResponseExpected extends boolean = false,
+    IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
-    contract: CommonRouteDefinition<ResponseBodySchema, PathParamsSchema, RequestQuerySchema>,
+    contract: CommonRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >,
     server: SetupServerApi,
     params: MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>,
   ): void {
@@ -174,6 +236,7 @@ export class MswHelper {
     RequestHeaderSchema extends z.Schema | undefined = undefined,
     IsNonJSONResponseExpected extends boolean = false,
     IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
     contract:
       | CommonRouteDefinition<
@@ -182,9 +245,19 @@ export class MswHelper {
           RequestQuerySchema,
           RequestHeaderSchema,
           IsNonJSONResponseExpected,
-          IsEmptyResponseExpected
+          IsEmptyResponseExpected,
+          ResponseSchemasByStatusCode
         >
-      | PayloadRouteDefinition<RequestBodySchema>,
+      | PayloadRouteDefinition<
+          RequestBodySchema,
+          ResponseBodySchema,
+          PathParamsSchema,
+          RequestQuerySchema,
+          RequestHeaderSchema,
+          IsNonJSONResponseExpected,
+          IsEmptyResponseExpected,
+          ResponseSchemasByStatusCode
+        >,
     server: SetupServerApi,
     params: PathParamsSchema extends undefined
       ? MockWithImplementationParamsNoPath<
@@ -227,11 +300,23 @@ export class MswHelper {
     )
   }
 
-  mockAnyResponse<PathParamsSchema extends z.Schema | undefined>(
+  mockAnyResponse<
+    PathParamsSchema extends z.Schema | undefined,
+    RequestQuerySchema extends z.Schema | undefined = undefined,
+    RequestHeaderSchema extends z.Schema | undefined = undefined,
+    IsNonJSONResponseExpected extends boolean = false,
+    IsEmptyResponseExpected extends boolean = false,
+    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
+  >(
     contract: CommonRouteDefinition<
       // biome-ignore lint/suspicious/noExplicitAny: we accept any input
       any,
-      PathParamsSchema
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
     >,
     server: SetupServerApi,
     params: PathParamsSchema extends undefined

--- a/packages/app/universal-testing-utils/src/MswHelper.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.ts
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: expected here
 import {
   type CommonRouteDefinition,
   type InferSchemaInput,
@@ -53,27 +54,12 @@ function joinURL(base: string, path: string): string {
   return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
 }
 
-export type MockEndpointParams<
-  ResponseBodySchema extends z.Schema<JsonBodyType>,
-  PathParamsSchema extends z.Schema | undefined,
-  RequestQuerySchema extends z.Schema | undefined,
-  RequestHeaderSchema extends z.Schema | undefined = undefined,
-  IsNonJSONResponseExpected extends boolean = false,
-  IsEmptyResponseExpected extends boolean = false,
-  ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
-> = {
+export type MockEndpointParams<PathParamsSchema extends z.Schema | undefined> = {
   server: SetupServerApi
-  contract: CommonRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
-  >
+  contract:
+    | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any>
+    | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any>
   pathParams: InferSchemaOutput<PathParamsSchema>
-  // biome-ignore lint/suspicious/noExplicitAny: we accept any input
   responseBody: any
   responseCode: number
   validateResponse: boolean
@@ -86,24 +72,10 @@ export class MswHelper {
     this.baseUrl = baseUrl
   }
 
-  private resolveParams<
-    ResponseBodySchema extends z.Schema<JsonBodyType>,
-    PathParamsSchema extends z.Schema | undefined,
-    RequestQuerySchema extends z.Schema | undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
-  >(
-    contract: CommonRouteDefinition<
-      ResponseBodySchema,
-      PathParamsSchema,
-      RequestQuerySchema,
-      RequestHeaderSchema,
-      IsNonJSONResponseExpected,
-      IsEmptyResponseExpected,
-      ResponseSchemasByStatusCode
-    >,
+  private resolveParams<PathParamsSchema extends z.Schema | undefined>(
+    contract:
+      | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any>
+      | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any>,
     pathParams: InferSchemaOutput<PathParamsSchema>,
   ) {
     const path = contract.requestPathParamsSchema
@@ -111,30 +83,13 @@ export class MswHelper {
       : mapRouteToPath(contract)
 
     const resolvedPath = joinURL(this.baseUrl, path)
-    // @ts-expect-error
-    const method: HttpMethod = contract.method
+    const method = ('method' in contract ? contract.method : 'get') as HttpMethod
 
     return { method, resolvedPath }
   }
 
-  private registerEndpointMock<
-    ResponseBodySchema extends z.Schema<JsonBodyType>,
-    PathParamsSchema extends z.Schema | undefined,
-    RequestQuerySchema extends z.Schema | undefined = undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
-  >(
-    params: MockEndpointParams<
-      ResponseBodySchema,
-      PathParamsSchema,
-      RequestQuerySchema,
-      RequestHeaderSchema,
-      IsNonJSONResponseExpected,
-      IsEmptyResponseExpected,
-      ResponseSchemasByStatusCode
-    >,
+  private registerEndpointMock<PathParamsSchema extends z.Schema | undefined>(
+    params: MockEndpointParams<PathParamsSchema>,
   ) {
     const { method, resolvedPath } = this.resolveParams(params.contract, params.pathParams)
     params.server.use(
@@ -152,21 +107,27 @@ export class MswHelper {
   mockValidResponse<
     ResponseBodySchema extends z.Schema<JsonBodyType>,
     PathParamsSchema extends z.Schema | undefined,
-    RequestQuerySchema extends z.Schema | undefined = undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
-    contract: CommonRouteDefinition<
-      ResponseBodySchema,
-      PathParamsSchema,
-      RequestQuerySchema,
-      RequestHeaderSchema,
-      IsNonJSONResponseExpected,
-      IsEmptyResponseExpected,
-      ResponseSchemasByStatusCode
-    >,
+    contract:
+      | CommonRouteDefinition<
+          ResponseBodySchema,
+          PathParamsSchema,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
+        >
+      | PayloadRouteDefinition<
+          z.Schema | undefined,
+          ResponseBodySchema,
+          PathParamsSchema,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
+        >,
     server: SetupServerApi,
     params: PathParamsSchema extends undefined
       ? MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>
@@ -183,32 +144,32 @@ export class MswHelper {
     })
   }
 
-  mockValidResponseWithAnyPath<
-    ResponseBodySchema extends z.Schema<JsonBodyType>,
-    PathParamsSchema extends z.Schema | undefined,
-    RequestQuerySchema extends z.Schema | undefined = undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
-  >(
-    contract: CommonRouteDefinition<
-      ResponseBodySchema,
-      PathParamsSchema,
-      RequestQuerySchema,
-      RequestHeaderSchema,
-      IsNonJSONResponseExpected,
-      IsEmptyResponseExpected,
-      ResponseSchemasByStatusCode
-    >,
+  mockValidResponseWithAnyPath<ResponseBodySchema extends z.Schema<JsonBodyType>>(
+    contract:
+      | CommonRouteDefinition<
+          ResponseBodySchema,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
+        >
+      | PayloadRouteDefinition<
+          z.Schema | undefined,
+          ResponseBodySchema,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
+        >,
     server: SetupServerApi,
     params: MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>,
   ): void {
     const pathParams = contract.requestPathParamsSchema
-      ? Object.keys(
-          // @ts-expect-error this is fine
-          (contract.requestPathParamsSchema as unknown as ZodObject<unknown>).shape,
-        ).reduce(
+      ? Object.keys((contract.requestPathParamsSchema as ZodObject<any>).shape).reduce(
           (acc, value) => {
             acc[value] = '*'
             return acc
@@ -221,8 +182,7 @@ export class MswHelper {
       responseBody: params.responseBody,
       contract,
       server,
-      // @ts-expect-error this is safe
-      pathParams,
+      pathParams: pathParams as any,
       responseCode: params.responseCode ?? 200,
       validateResponse: true,
     })
@@ -232,103 +192,52 @@ export class MswHelper {
     ResponseBodySchema extends z.Schema,
     PathParamsSchema extends z.Schema | undefined,
     RequestBodySchema extends z.Schema | undefined = undefined,
-    RequestQuerySchema extends z.Schema | undefined = undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
   >(
     contract:
       | CommonRouteDefinition<
           ResponseBodySchema,
           PathParamsSchema,
-          RequestQuerySchema,
-          RequestHeaderSchema,
-          IsNonJSONResponseExpected,
-          IsEmptyResponseExpected,
-          ResponseSchemasByStatusCode
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
         >
       | PayloadRouteDefinition<
           RequestBodySchema,
           ResponseBodySchema,
           PathParamsSchema,
-          RequestQuerySchema,
-          RequestHeaderSchema,
-          IsNonJSONResponseExpected,
-          IsEmptyResponseExpected,
-          ResponseSchemasByStatusCode
+          z.Schema | undefined,
+          z.Schema | undefined,
+          boolean,
+          boolean,
+          any // ResponseSchemasByStatusCode - not used in mocking
         >,
     server: SetupServerApi,
     params: PathParamsSchema extends undefined
-      ? MockWithImplementationParamsNoPath<
-          PathParams,
-          // @ts-expect-error fixme, after v4 migration
-          InferSchemaInput<RequestBodySchema>,
-          InferSchemaInput<ResponseBodySchema>
-        >
-      : MockWithImplementationParams<
-          // @ts-expect-error fixme, after v4 migration
-          InferSchemaInput<PathParamsSchema>,
-          InferSchemaInput<RequestBodySchema>,
-          InferSchemaInput<ResponseBodySchema>
-        >,
+      ? MockWithImplementationParamsNoPath<any, any, any>
+      : MockWithImplementationParams<any, any, any>,
   ): void {
-    // @ts-expect-error this is safe
-
+    // @ts-expect-error pathParams might not exist
     const { method, resolvedPath } = this.resolveParams(contract, params.pathParams)
 
     server.use(
       http[method](resolvedPath, async (requestInfo) => {
-        return HttpResponse.json(
-          // @ts-expect-error fixme, after v4 migration
-          await params.handleRequest(
-            // @ts-expect-error fixme, after v4 migration
-            requestInfo as Parameters<
-              HttpResponseResolver<
-                // @ts-expect-error fixme, after v4 migration
-                InferSchemaInput<PathParamsSchema>,
-                InferSchemaInput<RequestBodySchema>,
-                InferSchemaInput<ResponseBodySchema>
-              >
-            >[0],
-          ),
-          {
-            status: params.responseCode,
-          },
-        )
+        return HttpResponse.json(await params.handleRequest(requestInfo), {
+          status: params.responseCode,
+        })
       }),
     )
   }
 
-  mockAnyResponse<
-    PathParamsSchema extends z.Schema | undefined,
-    RequestQuerySchema extends z.Schema | undefined = undefined,
-    RequestHeaderSchema extends z.Schema | undefined = undefined,
-    IsNonJSONResponseExpected extends boolean = false,
-    IsEmptyResponseExpected extends boolean = false,
-    ResponseSchemasByStatusCode extends Partial<Record<number, z.Schema>> | undefined = undefined,
-  >(
-    contract: CommonRouteDefinition<
-      // biome-ignore lint/suspicious/noExplicitAny: we accept any input
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      RequestHeaderSchema,
-      IsNonJSONResponseExpected,
-      IsEmptyResponseExpected,
-      ResponseSchemasByStatusCode
-    >,
+  mockAnyResponse<PathParamsSchema extends z.Schema | undefined>(
+    contract:
+      | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any>
+      | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any>,
     server: SetupServerApi,
     params: PathParamsSchema extends undefined
-      ? MockParamsNoPath<
-          // biome-ignore lint/suspicious/noExplicitAny: we accept any input
-          InferSchemaInput<any>
-        >
-      : MockParams<
-          InferSchemaInput<PathParamsSchema>,
-          // biome-ignore lint/suspicious/noExplicitAny: we accept any input
-          InferSchemaInput<any>
-        >,
+      ? MockParamsNoPath<InferSchemaInput<any>>
+      : MockParams<InferSchemaInput<PathParamsSchema>, InferSchemaInput<any>>,
   ): void {
     this.registerEndpointMock({
       responseBody: params.responseBody,

--- a/packages/app/universal-testing-utils/vitest.config.ts
+++ b/packages/app/universal-testing-utils/vitest.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/index.ts'],
       thresholds: {
-        lines: 90,
+        lines: 95,
         functions: 100,
-        branches: 80,
-        statements: 90,
+        branches: 82,
+        statements: 95,
       },
     },
   },


### PR DESCRIPTION
## Changes

Accept not only successful responses, but also values adhering to one of the error schemas.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
