### PR TITLE
Relax default type for response schemas

### DIFF
--- a/packages/app/api-contracts/src/apiContracts.ts
+++ b/packages/app/api-contracts/src/apiContracts.ts
@@ -65,9 +65,9 @@ export type PayloadRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
-  ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
-    | undefined = undefined,
+  ResponseSchemasByStatusCode extends Partial<Record<HttpStatusCode, z.Schema>> | undefined =
+    | Record<HttpStatusCode, z.Schema>
+    | undefined,
 > = CommonRouteDefinition<
   SuccessResponseBodySchema,
   PathParamsSchema,
@@ -88,9 +88,9 @@ export type GetRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
-  ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
-    | undefined = undefined,
+  ResponseSchemasByStatusCode extends Partial<Record<HttpStatusCode, z.Schema>> | undefined =
+    | Record<HttpStatusCode, z.Schema>
+    | undefined,
 > = CommonRouteDefinition<
   SuccessResponseBodySchema,
   PathParamsSchema,
@@ -110,9 +110,9 @@ export type DeleteRouteDefinition<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
-  ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
-    | undefined = undefined,
+  ResponseSchemasByStatusCode extends Partial<Record<HttpStatusCode, z.Schema>> | undefined =
+    | Record<HttpStatusCode, z.Schema>
+    | undefined,
 > = CommonRouteDefinition<
   SuccessResponseBodySchema,
   PathParamsSchema,
@@ -133,9 +133,9 @@ export function buildPayloadRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
-  ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
-    | undefined = undefined,
+  ResponseSchemasByStatusCode extends Partial<Record<HttpStatusCode, z.Schema>> | undefined =
+    | Record<HttpStatusCode, z.Schema>
+    | undefined,
 >(
   params: PayloadRouteDefinition<
     RequestBodySchema,
@@ -183,9 +183,9 @@ export function buildGetRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
-  ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
-    | undefined = undefined,
+  ResponseSchemasByStatusCode extends Partial<Record<HttpStatusCode, z.Schema>> | undefined =
+    | Record<HttpStatusCode, z.Schema>
+    | undefined,
 >(
   params: Omit<
     GetRouteDefinition<
@@ -233,9 +233,9 @@ export function buildDeleteRoute<
   RequestHeaderSchema extends z.Schema | undefined = undefined,
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = true,
-  ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
-    | undefined = undefined,
+  ResponseSchemasByStatusCode extends Partial<Record<HttpStatusCode, z.Schema>> | undefined =
+    | Record<HttpStatusCode, z.Schema>
+    | undefined,
 >(
   params: Omit<
     DeleteRouteDefinition<


### PR DESCRIPTION
## Changes

Only absence of response map was accepted by default, which was too strict

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded API contracts to accept either partial or complete status-code-to-schema mappings across route definitions and their builders.
  - Improves flexibility for defining response schemas without affecting runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->