### PR TITLE
Adding queue policy for SQS

### DIFF
--- a/packages/app/aws-config/src/message-queue-toolkit/MessageQueueToolkitSnsOptionsResolver.ts
+++ b/packages/app/aws-config/src/message-queue-toolkit/MessageQueueToolkitSnsOptionsResolver.ts
@@ -137,6 +137,7 @@ export class MessageQueueToolkitSnsOptionsResolver extends AbstractMessageQueueT
       queueName,
       topicConfig.queues,
       params,
+      false,
     )
 
     /* v8 ignore start */

--- a/packages/app/aws-config/src/message-queue-toolkit/MessageQueueToolkitSqsOptionsResolver.ts
+++ b/packages/app/aws-config/src/message-queue-toolkit/MessageQueueToolkitSqsOptionsResolver.ts
@@ -35,7 +35,7 @@ export class MessageQueueToolkitSqsOptionsResolver extends AbstractMessageQueueT
     queueName: string,
     params: ResolvePublisherOptionsParams<MessagePayload>,
   ): ResolvedPublisherOptions<SQSCreationConfig, SQSQueueLocatorType, MessagePayload> {
-    const resolvedQueue = this.resolveQueue(queueName, this.commandConfig, params)
+    const resolvedQueue = this.resolveQueue(queueName, this.commandConfig, params, true)
 
     return {
       creationConfig: resolvedQueue.creationConfig,
@@ -55,7 +55,7 @@ export class MessageQueueToolkitSqsOptionsResolver extends AbstractMessageQueueT
     queueName: string,
     params: ResolveConsumerOptionsParams<MessagePayloadType>,
   ): ResolvedConsumerOptions<SQSCreationConfig, SQSQueueLocatorType, MessagePayloadType> {
-    const resolvedQueue = this.resolveQueue(queueName, this.commandConfig, params)
+    const resolvedQueue = this.resolveQueue(queueName, this.commandConfig, params, true)
 
     return {
       creationConfig: resolvedQueue.creationConfig,

--- a/packages/app/aws-config/src/message-queue-toolkit/MessageQueueToolkitSqsResolver.spec.ts
+++ b/packages/app/aws-config/src/message-queue-toolkit/MessageQueueToolkitSqsResolver.spec.ts
@@ -152,6 +152,7 @@ describe('MessageQueueToolkitSqsOptionsResolver', () => {
               "queue": {
                 "Attributes": {
                   "KmsMasterKeyId": "test kmsKeyId",
+                  "Policy": "{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":["sqs:SendMessage","sqs:GetQueueAttributes","sqs:GetQueueUrl"]}]}",
                   "VisibilityTimeout": "60",
                 },
                 "QueueName": "prefix_test-mqt-queue_first",
@@ -188,6 +189,7 @@ describe('MessageQueueToolkitSqsOptionsResolver', () => {
               "queue": {
                 "Attributes": {
                   "KmsMasterKeyId": "test kmsKeyId",
+                  "Policy": "{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":["sqs:SendMessage","sqs:GetQueueAttributes","sqs:GetQueueUrl"]}]}",
                   "VisibilityTimeout": "60",
                 },
                 "QueueName": "test-mqt-queue_first",
@@ -300,6 +302,7 @@ describe('MessageQueueToolkitSqsOptionsResolver', () => {
               "queue": {
                 "Attributes": {
                   "KmsMasterKeyId": "test kmsKeyId",
+                  "Policy": "{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":["sqs:SendMessage","sqs:GetQueueAttributes","sqs:GetQueueUrl"]}]}",
                   "VisibilityTimeout": "60",
                 },
                 "QueueName": "prefix_test-mqt-queue_first",
@@ -347,6 +350,7 @@ describe('MessageQueueToolkitSqsOptionsResolver', () => {
               "queue": {
                 "Attributes": {
                   "KmsMasterKeyId": "test kmsKeyId",
+                  "Policy": "{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":["sqs:SendMessage","sqs:GetQueueAttributes","sqs:GetQueueUrl"]}]}",
                   "VisibilityTimeout": "60",
                 },
                 "QueueName": "test-mqt-queue_first",


### PR DESCRIPTION
## Changes

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Internal SQS queues now include a default access policy, enabling send message and basic attribute/URL retrieval operations without extra configuration.
  - Policy application is automatic for SQS publisher and consumer setups; external queues and SNS consumers are unaffected.

- Tests
  - Updated tests to reflect the new SQS queue policy in expected attributes.

- Documentation
  - Clarified behavior for automatically applied SQS policies on internally managed queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->