### PR TITLE
EXP-823 use path prefix with api contracts

### DIFF
--- a/packages/app/api-contracts/package.json
+++ b/packages/app/api-contracts/package.json
@@ -6,7 +6,7 @@
     ],
     "license": "Apache-2.0",
     "type": "module",
-    "main": "./dist/apiContracts.js",
+    "main": "./dist/index.js",
     "enableTransparentWorkspaces": "false",
     "homepage": "https://github.com/lokalise/shared-ts-libs",
     "repository": {
@@ -14,7 +14,7 @@
         "url": "git://github.com/lokalise/shared-ts-libs.git"
     },
     "exports": {
-        ".": "./dist/apiContracts.js",
+        ".": "./dist/index.js",
         "./package.json": "./package.json"
     },
     "private": false,

--- a/packages/app/api-contracts/src/apiContracts.ts
+++ b/packages/app/api-contracts/src/apiContracts.ts
@@ -1,9 +1,6 @@
 import type { ZodSchema, z } from 'zod/v4'
 import type { HttpStatusCode } from './HttpStatusCodes.ts'
 
-export type { HttpStatusCode }
-export { buildRequestPath } from './pathUtils.ts'
-
 const EMPTY_PARAMS = {}
 
 export type InferSchemaInput<T extends ZodSchema | undefined> = T extends ZodSchema

--- a/packages/app/api-contracts/src/apiContracts.ts
+++ b/packages/app/api-contracts/src/apiContracts.ts
@@ -2,6 +2,7 @@ import type { ZodSchema, z } from 'zod/v4'
 import type { HttpStatusCode } from './HttpStatusCodes.ts'
 
 export type { HttpStatusCode }
+export { buildRequestPath } from './pathUtils.ts'
 
 const EMPTY_PARAMS = {}
 

--- a/packages/app/api-contracts/src/index.ts
+++ b/packages/app/api-contracts/src/index.ts
@@ -1,0 +1,3 @@
+export * from './apiContracts.ts'
+export * from './HttpStatusCodes.ts'
+export * from './pathUtils.ts'

--- a/packages/app/api-contracts/src/pathUtils.spec.ts
+++ b/packages/app/api-contracts/src/pathUtils.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { buildRequestPath } from './pathUtils.ts'
+
+describe('buildRequestPath', () => {
+  describe('when pathPrefix is not provided', () => {
+    it('should return the original path with slash at the beginning', () => {
+      expect(buildRequestPath('/api/users')).toBe('/api/users')
+      expect(buildRequestPath('api/users')).toBe('/api/users')
+    })
+
+    it('should handle undefined pathPrefix', () => {
+      expect(buildRequestPath('/api/users', undefined)).toBe('/api/users')
+    })
+  })
+
+  describe('when pathPrefix is provided', () => {
+    it('should concatenate pathPrefix and path with single slash', () => {
+      expect(buildRequestPath('/api/users', '/v1')).toBe('/v1/api/users')
+      expect(buildRequestPath('api/users', '/v1')).toBe('/v1/api/users')
+    })
+
+    it('should handle pathPrefix without leading slash', () => {
+      expect(buildRequestPath('/api/users', 'v1')).toBe('/v1/api/users')
+      expect(buildRequestPath('api/users', 'v1')).toBe('/v1/api/users')
+    })
+
+    it('should handle pathPrefix with trailing slash', () => {
+      expect(buildRequestPath('/api/users', '/v1/')).toBe('/v1/api/users')
+      expect(buildRequestPath('api/users', '/v1/')).toBe('/v1/api/users')
+      expect(buildRequestPath('/api/users', 'v1/')).toBe('/v1/api/users')
+    })
+
+    it('should handle empty strings', () => {
+      expect(buildRequestPath('', '/v1')).toBe('/v1/')
+      expect(buildRequestPath('/api/users', '')).toBe('/api/users')
+      expect(buildRequestPath('', '')).toBe('/')
+    })
+
+    it('should handle root paths', () => {
+      expect(buildRequestPath('/', '/v1')).toBe('/v1/')
+      expect(buildRequestPath('/api/users', '/')).toBe('/api/users')
+    })
+
+    it('should handle complex nested paths', () => {
+      expect(buildRequestPath('/api/v2/users/123', '/admin/panel/')).toBe(
+        '/admin/panel/api/v2/users/123',
+      )
+      expect(buildRequestPath('api/v2/users/123', 'admin')).toBe('/admin/api/v2/users/123')
+    })
+  })
+})

--- a/packages/app/api-contracts/src/pathUtils.ts
+++ b/packages/app/api-contracts/src/pathUtils.ts
@@ -21,8 +21,8 @@ export function buildRequestPath(path: string, pathPrefix?: string): string {
   }
 
   // Remove trailing slash from pathPrefix and leading slash from path
-  const cleanPrefix = pathPrefix.replace(/\/$/, '')
-  const cleanPath = path.replace(/^\//, '')
+  const cleanPrefix = pathPrefix.endsWith('/') ? pathPrefix.slice(0, -1) : pathPrefix
+  const cleanPath = path.startsWith('/') ? path.slice(1) : path
 
   return ensureStartsWithSlash(`${cleanPrefix}/${cleanPath}`)
 }

--- a/packages/app/api-contracts/src/pathUtils.ts
+++ b/packages/app/api-contracts/src/pathUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Builds a request path by combining a base path with an optional path prefix.
+ * Ensures proper slash handling to avoid double slashes or missing slashes.
+ *
+ * @param path - The base path for the request
+ * @param pathPrefix - Optional prefix to prepend to the path
+ * @returns The combined path with proper slash formatting
+ *
+ * @example
+ * ```typescript
+ * buildRequestPath('/api/users') // '/api/users'
+ * buildRequestPath('api/users') // '/api/users'
+ * buildRequestPath('/api/users', 'v1') // '/v1/api/users'
+ * buildRequestPath('/api/users', '/v1/') // '/v1/api/users'
+ * buildRequestPath('api/users', 'v1') // '/v1/api/users'
+ * ```
+ */
+export function buildRequestPath(path: string, pathPrefix?: string): string {
+  if (!pathPrefix) {
+    return ensureStartsWithSlash(path)
+  }
+
+  // Remove trailing slash from pathPrefix and leading slash from path
+  const cleanPrefix = pathPrefix.replace(/\/$/, '')
+  const cleanPath = path.replace(/^\//, '')
+
+  return ensureStartsWithSlash(`${cleanPrefix}/${cleanPath}`)
+}
+
+function ensureStartsWithSlash(str: string): string {
+  return str.startsWith('/') ? str : `/${str}`
+}

--- a/packages/app/backend-http-client/README.md
+++ b/packages/app/backend-http-client/README.md
@@ -124,3 +124,10 @@ const responseBodyGet = await sendByGetRoute(client, someGetRouteDefinition,
         }
 )
 ```
+
+The following parameters can be specified when sending API contract-based requests:
+- `body` - request body (only applicable for `sendByPayloadRoute`, type needs to match with contract definition)
+- `queryParams` - query parameters (type needs to match with contract definition)
+- `headers` - custom headers to be sent with the request (type needs to match with contract definition)
+- `pathParams` – parameters used for path resolver (type needs to match with contract definition)
+- `pathPrefix` - optional prefix to be prepended to the path resolved by the contract's path resolver

--- a/packages/app/backend-http-client/src/client/apiContractTypes.ts
+++ b/packages/app/backend-http-client/src/client/apiContractTypes.ts
@@ -173,6 +173,7 @@ export type PayloadRouteRequestParams<
     ? never
     : RequestHeader | (() => RequestHeader) | (() => Promise<RequestHeader>)
   pathParams: PathParams extends undefined ? never : PathParams
+  pathPrefix?: string
 } extends infer Mandatory
   ? {
       [K in keyof Mandatory as Mandatory[K] extends never ? never : K]: Mandatory[K]
@@ -189,6 +190,7 @@ export type RouteRequestParams<
     ? never
     : RequestHeader | (() => RequestHeader) | (() => Promise<RequestHeader>)
   pathParams: PathParams extends undefined ? never : PathParams
+  pathPrefix?: string
 } extends infer Mandatory
   ? {
       [K in keyof Mandatory as Mandatory[K] extends never ? never : K]: Mandatory[K]

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -680,6 +680,50 @@ describe('httpClient', () => {
       expect(result.result.statusCode).toBe(204)
       expect(result.result.body).toBeNull()
     })
+
+    it('works with path prefix', async () => {
+      const schema = z.object({
+        category: z.string(),
+        description: z.string(),
+        id: z.number(),
+        image: z.string(),
+        price: z.number(),
+        rating: z.object({
+          count: z.number(),
+          rate: z.number(),
+        }),
+        title: z.string(),
+      })
+
+      const apiContract = buildGetRoute({
+        successResponseBodySchema: schema,
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      client
+        .intercept({
+          path: 'resources/products/1',
+          method: 'GET',
+        })
+        .reply(200, mockProduct1, { headers: JSON_HEADERS })
+
+      const result = await sendByGetRoute(
+        client,
+        apiContract,
+        {
+          pathPrefix: 'resources',
+        },
+        {
+          validateResponse: true,
+          throwOnError: true,
+          requestLabel: 'dummy',
+          reqContext,
+        },
+      )
+
+      expect(result.result.body).toEqual(mockProduct1)
+    })
   })
 
   describe('DELETE', () => {
@@ -995,6 +1039,41 @@ describe('httpClient', () => {
         ]]
       `)
     })
+
+    it('works with path prefix', async () => {
+      const schema = z.object({
+        id: z.number(),
+      })
+
+      const apiContract = buildDeleteRoute({
+        successResponseBodySchema: schema,
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      client
+        .intercept({
+          path: 'resources/products/1',
+          method: 'DELETE',
+        })
+        .reply(200, { id: 1 }, { headers: JSON_HEADERS })
+
+      const result = await sendByDeleteRoute(
+        client,
+        apiContract,
+        {
+          pathPrefix: 'resources',
+        },
+        {
+          validateResponse: true,
+          throwOnError: true,
+          requestLabel: 'dummy',
+          reqContext,
+        },
+      )
+
+      expect(result.result.body).toEqual({ id: 1 })
+    })
   })
 
   describe('sendByPayloadRoute', () => {
@@ -1117,6 +1196,43 @@ describe('httpClient', () => {
       )
 
       expect(result.result.body).toEqual(mockProduct1)
+    })
+
+    it('works with path prefix', async () => {
+      const schema = z.object({
+        id: z.number(),
+      })
+
+      const apiContract = buildPayloadRoute({
+        successResponseBodySchema: schema,
+        requestPathParamsSchema: z.undefined(),
+        method: 'post',
+        requestBodySchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      client
+        .intercept({
+          path: 'resources/products/1',
+          method: 'POST',
+        })
+        .reply(200, { id: 1 }, { headers: JSON_HEADERS })
+
+      const result = await sendByPayloadRoute(
+        client,
+        apiContract,
+        {
+          pathPrefix: '/resources/',
+        },
+        {
+          validateResponse: true,
+          throwOnError: true,
+          requestLabel: 'dummy',
+          reqContext,
+        },
+      )
+
+      expect(result.result.body).toEqual({ id: 1 })
     })
   })
 

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -1062,7 +1062,7 @@ describe('httpClient', () => {
         client,
         apiContract,
         {
-          pathPrefix: 'resources',
+          pathPrefix: 'resources/',
         },
         {
           validateResponse: true,

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -7,6 +7,7 @@ import type {
   InferSchemaOutput,
   PayloadRouteDefinition,
 } from '@lokalise/api-contracts'
+import { buildRequestPath } from '@lokalise/api-contracts'
 import { copyWithoutUndefined } from '@lokalise/node-core'
 import type { FormData } from 'undici'
 import { Client } from 'undici'
@@ -481,7 +482,7 @@ export function sendByPayloadRoute<
     // @ts-expect-error TS loses exact string type during uppercasing
     routeDefinition.method.toUpperCase(),
     // @ts-expect-error magic type inferring happening
-    routeDefinition.pathResolver(params.pathParams),
+    buildRequestPath(routeDefinition.pathResolver(params.pathParams), params.pathPrefix),
     // @ts-expect-error magic type inferring happening
     params.body,
     {
@@ -539,7 +540,7 @@ export function sendByGetRoute<
     // @ts-expect-error TS loses exact string type during uppercasing
     routeDefinition.method.toUpperCase(),
     // @ts-expect-error magic type inferring happening
-    routeDefinition.pathResolver(params.pathParams),
+    buildRequestPath(routeDefinition.pathResolver(params.pathParams), params.pathPrefix),
     {
       isEmptyResponseExpected: routeDefinition.isEmptyResponseExpected ?? false,
       // @ts-expect-error FixMe
@@ -595,7 +596,7 @@ export function sendByDeleteRoute<
     // @ts-expect-error TS loses exact string type during uppercasing
     routeDefinition.method.toUpperCase(),
     // @ts-expect-error magic type inferring happening
-    routeDefinition.pathResolver(params.pathParams),
+    buildRequestPath(routeDefinition.pathResolver(params.pathParams), params.pathPrefix),
     {
       isEmptyResponseExpected: routeDefinition.isEmptyResponseExpected ?? true,
       // @ts-expect-error FixMe

--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -95,6 +95,13 @@ const responseBody2 = await sendByGetRoute(client, someGetRouteDefinition, {
 })
 ```
 
+The following parameters can be specified when sending API contract-based requests:
+- `body` - request body (only applicable for `sendByPayloadRoute`, type needs to match with contract definition)
+- `queryParams` - query parameters (type needs to match with contract definition)
+- `headers` - custom headers to be sent with the request (type needs to match with contract definition)
+- `pathParams` – parameters used for path resolver (type needs to match with contract definition)
+- `pathPrefix` - optional prefix to be prepended to the path resolved by the contract's path resolver
+
 ### Tracking request progress
 Tracking requests progress is especially useful while uploading files. 
 

--- a/packages/app/frontend-http-client/src/client.spec.ts
+++ b/packages/app/frontend-http-client/src/client.spec.ts
@@ -501,6 +501,91 @@ describe('frontend-http-client', () => {
         },
       })
     })
+
+    it('works with path prefix for GET routes', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forGet('/v1/users/1').thenJson(200, { id: 1 })
+
+      const responseBodySchema = z.object({
+        id: z.number(),
+      })
+
+      const pathSchema = z.object({
+        userId: z.number(),
+      })
+
+      const routeDefinition = buildGetRoute({
+        successResponseBodySchema: responseBodySchema,
+        requestPathParamsSchema: pathSchema,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByGetRoute(client, routeDefinition, {
+        pathParams: {
+          userId: 1,
+        },
+        pathPrefix: 'v1',
+      })
+
+      expect(responseBody).toEqual({ id: 1 })
+    })
+
+    it('works with path prefix for POST routes', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forPost('/v1/users/1').thenJson(200, { id: 1 })
+
+      const responseBodySchema = z.object({
+        id: z.number(),
+      })
+
+      const pathSchema = z.object({
+        userId: z.number(),
+      })
+
+      const routeDefinition = buildPayloadRoute({
+        method: 'post',
+        successResponseBodySchema: responseBodySchema,
+        requestPathParamsSchema: pathSchema,
+        requestBodySchema: undefined,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByPayloadRoute(client, routeDefinition, {
+        pathParams: {
+          userId: 1,
+        },
+        pathPrefix: 'v1',
+      })
+
+      expect(responseBody).toEqual({ id: 1 })
+    })
+
+    it('works with path prefix for DELETE routes', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forDelete('/v1/users/1').thenReply(204)
+
+      const pathSchema = z.object({
+        userId: z.number(),
+      })
+
+      const routeDefinition = buildDeleteRoute({
+        successResponseBodySchema: undefined,
+        requestPathParamsSchema: pathSchema,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByDeleteRoute(client, routeDefinition, {
+        pathParams: {
+          userId: 1,
+        },
+        pathPrefix: 'v1',
+      })
+
+      expect(responseBody).toBeNull()
+    })
   })
 
   describe('sendPost', () => {

--- a/packages/app/frontend-http-client/src/client.ts
+++ b/packages/app/frontend-http-client/src/client.ts
@@ -6,6 +6,7 @@ import type {
   InferSchemaOutput,
   PayloadRouteDefinition,
 } from '@lokalise/api-contracts'
+import { buildRequestPath } from '@lokalise/api-contracts'
 import type { WretchResponse } from 'wretch'
 import { type ZodSchema, z } from 'zod/v4'
 import type {
@@ -441,7 +442,7 @@ export function sendByPayloadRoute<
     queryParams: params.queryParams,
     queryParamsSchema: routeDefinition.requestQuerySchema,
     // @ts-expect-error magic type inferring happening
-    path: routeDefinition.pathResolver(params.pathParams),
+    path: buildRequestPath(routeDefinition.pathResolver(params.pathParams), params.pathPrefix),
     // @ts-expect-error FixMe
     headers: params.headers,
     // @ts-expect-error magic type inferring happening
@@ -492,7 +493,7 @@ export function sendByGetRoute<
     queryParams: params.queryParams,
     queryParamsSchema: routeDefinition.requestQuerySchema,
     // @ts-expect-error magic type inferring happening
-    path: routeDefinition.pathResolver(params.pathParams),
+    path: buildRequestPath(routeDefinition.pathResolver(params.pathParams), params.pathPrefix),
     // @ts-expect-error FixMe
     headers: params.headers,
     // @ts-expect-error magic type inferring happening
@@ -543,7 +544,7 @@ export function sendByDeleteRoute<
     queryParams: params.queryParams,
     queryParamsSchema: routeDefinition.requestQuerySchema,
     // @ts-expect-error magic type inferring happening
-    path: routeDefinition.pathResolver(params.pathParams),
+    path: buildRequestPath(routeDefinition.pathResolver(params.pathParams), params.pathPrefix),
     // @ts-expect-error FIXME
     headers: params.headers,
     // @ts-expect-error FIXME

--- a/packages/app/frontend-http-client/src/types.ts
+++ b/packages/app/frontend-http-client/src/types.ts
@@ -173,6 +173,7 @@ export type PayloadRouteRequestParams<
     ? never
     : RequestHeader | (() => RequestHeader) | (() => Promise<RequestHeader>)
   pathParams: PathParams extends undefined ? never : PathParams
+  pathPrefix?: string
 } extends infer Mandatory
   ? {
       [K in keyof Mandatory as Mandatory[K] extends never ? never : K]: Mandatory[K]
@@ -189,6 +190,7 @@ export type RouteRequestParams<
     ? never
     : RequestHeader | (() => RequestHeader) | (() => Promise<RequestHeader>)
   pathParams: PathParams extends undefined ? never : PathParams
+  pathPrefix?: string
 } extends infer Mandatory
   ? {
       [K in keyof Mandatory as Mandatory[K] extends never ? never : K]: Mandatory[K]


### PR DESCRIPTION
## Changes

Adds `pathPrefix` optional param to api-contract related types in `backend-http-client` and `frontend-http-client`

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
