### PR TITLE
chore: bump peer fastify-extras in aws-config

### DIFF
--- a/packages/app/aws-config/package.json
+++ b/packages/app/aws-config/package.json
@@ -40,7 +40,7 @@
         "@aws-sdk/client-sns": "^3.750.0",
         "@aws-sdk/client-sqs": "^3.750.0",
         "@aws-sdk/credential-providers": "^3.750.0",
-        "@lokalise/fastify-extras": ">=27.0.0",
+        "@lokalise/fastify-extras": ">=30.0.0",
         "@lokalise/node-core": ">=13.0.0",
         "@lokalise/universal-ts-utils": ">=4.0.0",
         "@message-queue-toolkit/core": ">=20.0.0",


### PR DESCRIPTION
## Changes

Trying to get around this error when trying to update to zod 4 & company:

<img width="692" height="304" alt="Screenshot 2025-09-19 at 08 55 45" src="https://github.com/user-attachments/assets/5e4dccf9-6dc5-45a7-bced-a4d169030d6d" />

It is only this peer dependency that is on fastify-extras 27, as all dev ones are on 30 already. We're planning to update Autopilot and Maestro to zod 4 and fastify-extras 30 as well, so while this is a breaking change it hopefully won't cause disruptions.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
