### PR TITLE
Updated dependencies between packages

### DIFF
--- a/packages/app/backend-http-client/package.json
+++ b/packages/app/backend-http-client/package.json
@@ -43,12 +43,12 @@
     },
     "peerDependencies": {
         "@lokalise/node-core": ">=13.1.0",
-        "@lokalise/api-contracts": ">=5.1.0",
+        "@lokalise/api-contracts": ">=5.4.0",
         "zod": ">=3.25.56"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",
-        "@lokalise/api-contracts": "^5.1.0",
+        "@lokalise/api-contracts": "^5.4.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/node-core": "^14.2.1",
         "@lokalise/tsconfig": "^1.3.0",

--- a/packages/app/frontend-http-client/package.json
+++ b/packages/app/frontend-http-client/package.json
@@ -40,13 +40,13 @@
         "fast-querystring": "^1.1.2"
     },
     "peerDependencies": {
-        "@lokalise/api-contracts": ">=5.1.0",
+        "@lokalise/api-contracts": ">=5.4.0",
         "wretch": "^2.8.0",
         "zod": ">=3.25.56"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.1.4",
-        "@lokalise/api-contracts": "^5.1.0",
+        "@lokalise/api-contracts": "^5.4.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/tsconfig": "~1.3.0",
         "@types/node": "^24.0.3",


### PR DESCRIPTION
## Changes

`backend-http-client` and `frontend-http-client` should rely on newest version of `api-contracts` which contains utils for `pathPrefix` handling. 
All 3 packages were released within the same PR, that's why the dependency update was missed

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
