### PR TITLE
Use correct interface

### DIFF
--- a/packages/app/universal-testing-utils/README.md
+++ b/packages/app/universal-testing-utils/README.md
@@ -34,7 +34,7 @@ Reusable testing utilities that are potentially relevant for both backend and fr
 import { buildRestContract } from '@lokalise/api-contracts'
 import { sendByContract } from '@lokalise/frontend-http-client'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import wretch, { type Wretch } from 'wretch'
 import { z } from 'zod/v4'
 import { MswHelper } from '@lokalise/universal-testing-utils'
@@ -59,7 +59,7 @@ describe('MswHelper', () => {
     const mswHelper = new MswHelper(BASE_URL)
     const wretchClient = wretch(BASE_URL)
 
-    beforeEach(() => { server.listen({ onUnhandledRequest: 'error' }) })
+    beforeAll(() => { server.listen({ onUnhandledRequest: 'error' }) })
     afterEach(() => { server.resetHandlers() })
     afterAll(() => { server.close() })
 

--- a/packages/app/universal-testing-utils/package.json
+++ b/packages/app/universal-testing-utils/package.json
@@ -57,7 +57,7 @@
         "@lokalise/tsconfig": "^3.1.0",
         "@vitest/coverage-v8": "^4.0.15",
         "mockttp": "^4.2.1",
-        "msw": "^2.11.1",
+        "msw": "^2.13.2",
         "rimraf": "^6.0.1",
         "typescript": "5.9.3",
         "vitest": "^4.0.15",

--- a/packages/app/universal-testing-utils/src/MswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.spec.ts
@@ -1,7 +1,7 @@
 import { mapRouteToPath } from '@lokalise/api-contracts'
 import { sendByContract } from '@lokalise/frontend-http-client'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import wretch from 'wretch'
 import {
   getContract,
@@ -25,7 +25,7 @@ describe('MswHelper', () => {
   const mswHelper = new MswHelper(BASE_URL)
   const wretchClient = wretch(BASE_URL)
 
-  beforeEach(() => {
+  beforeAll(() => {
     server.listen({ onUnhandledRequest: 'error' })
   })
   afterEach(() => {

--- a/packages/app/universal-testing-utils/src/MswHelper.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.ts
@@ -17,7 +17,7 @@ import {
   type JsonBodyType,
   type PathParams,
 } from 'msw'
-import type { SetupServerApi } from 'msw/node'
+import type { SetupServer } from 'msw/node'
 import type { ZodObject, z } from 'zod/v4'
 import { formatSseResponse, type SseMockEvent } from './MockttpHelper.ts'
 
@@ -96,7 +96,7 @@ function joinURL(base: string, path: string): string {
 }
 
 export type MockEndpointParams<PathParamsSchema extends z.Schema | undefined> = {
-  server: SetupServerApi
+  server: SetupServer
   contract:
     | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
     | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any, any>
@@ -213,7 +213,7 @@ export class MswHelper {
       any,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: PathParamsSchema extends z.Schema
       ? MswDualModeMockParams<
           InferSchemaInput<PathParamsSchema>,
@@ -243,7 +243,7 @@ export class MswHelper {
       Events,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: PathParamsSchema extends z.Schema
       ? MswSseMockParams<
           InferSchemaInput<PathParamsSchema>,
@@ -280,14 +280,14 @@ export class MswHelper {
           boolean,
           any
         >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: PathParamsSchema extends undefined
       ? MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>
       : MockParams<InferSchemaInput<PathParamsSchema>, InferSchemaInput<ResponseBodySchema>>,
   ): void
 
   // Implementation
-  mockValidResponse(contract: any, server: SetupServerApi, params: any): void {
+  mockValidResponse(contract: any, server: SetupServer, params: any): void {
     if ('isDualMode' in contract && contract.isDualMode) {
       const { resolvedPath, method } = this.resolveStreamingPath(contract, params.pathParams)
       const sseBody = formatSseResponse(params.events)
@@ -351,7 +351,7 @@ export class MswHelper {
       any,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: MswDualModeMockParamsNoPath<
       InferSchemaInput<RequestQuerySchema>,
       InferSchemaInput<ResponseBodySchema>,
@@ -373,7 +373,7 @@ export class MswHelper {
       Events,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: MswSseMockParamsNoPath<InferSchemaInput<RequestQuerySchema>, Events>,
   ): void
 
@@ -401,12 +401,12 @@ export class MswHelper {
           boolean,
           any
         >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>,
   ): void
 
   // Implementation
-  mockValidResponseWithAnyPath(contract: any, server: SetupServerApi, params: any): void {
+  mockValidResponseWithAnyPath(contract: any, server: SetupServer, params: any): void {
     const pathParams = contract.requestPathParamsSchema
       ? Object.keys((contract.requestPathParamsSchema as ZodObject<any>).shape).reduce(
           (acc, value) => {
@@ -438,7 +438,7 @@ export class MswHelper {
       any,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: (PathParamsSchema extends z.Schema
       ? MockWithImplementationParams<any, any, any>
       : MockWithImplementationParamsNoPath<any, any, any>) & {
@@ -476,14 +476,14 @@ export class MswHelper {
           boolean,
           any
         >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: PathParamsSchema extends undefined
       ? MockWithImplementationParamsNoPath<any, any, any>
       : MockWithImplementationParams<any, any, any>,
   ): void
 
   // Implementation
-  mockValidResponseWithImplementation(contract: any, server: SetupServerApi, params: any): void {
+  mockValidResponseWithImplementation(contract: any, server: SetupServer, params: any): void {
     if ('isDualMode' in contract && contract.isDualMode) {
       const { resolvedPath, method } = this.resolveStreamingPath(contract, params.pathParams)
       const sseBody = formatSseResponse(params.events)
@@ -539,7 +539,7 @@ export class MswHelper {
       any,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: PathParamsSchema extends z.Schema
       ? MswDualModeMockParams<
           InferSchemaInput<PathParamsSchema>,
@@ -555,14 +555,14 @@ export class MswHelper {
     contract:
       | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
       | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any, any>,
-    server: SetupServerApi,
+    server: SetupServer,
     params: PathParamsSchema extends undefined
       ? MockParamsNoPath<InferSchemaInput<any>>
       : MockParams<InferSchemaInput<PathParamsSchema>, InferSchemaInput<any>>,
   ): void
 
   // Implementation
-  mockAnyResponse(contract: any, server: SetupServerApi, params: any): void {
+  mockAnyResponse(contract: any, server: SetupServer, params: any): void {
     if ('isDualMode' in contract && contract.isDualMode) {
       const { resolvedPath, method } = this.resolveStreamingPath(contract, params.pathParams)
       const sseBody = formatSseResponse(params.events)
@@ -612,7 +612,7 @@ export class MswHelper {
       any,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params: (PathParamsSchema extends z.Schema
       ? { pathParams: InferSchemaInput<PathParamsSchema> }
       : { pathParams?: undefined }) & {
@@ -638,7 +638,7 @@ export class MswHelper {
       Events,
       any
     >,
-    server: SetupServerApi,
+    server: SetupServer,
     params?: (PathParamsSchema extends z.Schema
       ? { pathParams: InferSchemaInput<PathParamsSchema> }
       : { pathParams?: undefined }) &
@@ -649,7 +649,7 @@ export class MswHelper {
   ): SseEventController<Events>
 
   // Implementation
-  mockSseStream(contract: any, server: SetupServerApi, params?: any): SseEventController<any> {
+  mockSseStream(contract: any, server: SetupServer, params?: any): SseEventController<any> {
     const pathParams = params?.pathParams
     const { resolvedPath, method } = this.resolveStreamingPath(contract, pathParams)
     const encoder = new TextEncoder()


### PR DESCRIPTION
## Changes

We should not rely on implementation here, high level interface is more flexible

Additionally, fixed `universal-testing-utils` tests broken by MSW 2.13.x:
- MSW 2.13.x added an invariant that prevents calling `server.listen()` on an already-enabled server
- The test was calling `server.listen()` in `beforeEach`, which fails on the second test since the server is already listening
- Changed to `beforeAll` to match the standard MSW lifecycle pattern (`beforeAll`/`afterAll` for listen/close, `afterEach` for `resetHandlers`)
- Updated README example to reflect the corrected pattern

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**