### PR TITLE
Fix case-insensitive Content-Type header handling in HTTP clients

### DIFF
--- a/packages/app/backend-http-client/src/api-contract/sendByApiContract.spec.ts
+++ b/packages/app/backend-http-client/src/api-contract/sendByApiContract.spec.ts
@@ -275,6 +275,92 @@ describe('sendByApiContract', () => {
     })
   })
 
+  describe('content-type request header', () => {
+    it('sets content-type: application/json automatically when body is present', async () => {
+      const contract = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/items',
+        requestBodySchema: z.object({ name: z.string() }),
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forPost('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(client, contract, { body: { name: 'test' } })
+
+      expect(contentTypeHeader).toBe('application/json')
+    })
+
+    it('does not set content-type when no body is present', async () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/items',
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forGet('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(client, contract, {})
+
+      expect(contentTypeHeader).toBeUndefined()
+    })
+
+    it('preserves user-provided content-type (lowercase)', async () => {
+      const contract = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/items',
+        requestBodySchema: z.object({ name: z.string() }),
+        requestHeaderSchema: z.object({ 'content-type': z.string().optional() }),
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forPost('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(client, contract, {
+        body: { name: 'test' },
+        headers: { 'content-type': 'text/plain' },
+      })
+
+      expect(contentTypeHeader).toBe('text/plain')
+    })
+
+    it('preserves user-provided content-type (Title-Case)', async () => {
+      const contract = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/items',
+        requestBodySchema: z.object({ name: z.string() }),
+        requestHeaderSchema: z.object({ 'Content-Type': z.string().optional() }),
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forPost('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      // biome-ignore lint/suspicious/noExplicitAny: intentionally testing runtime case-insensitivity
+      await sendByApiContract(client, contract, {
+        body: { name: 'test' },
+        headers: { 'Content-Type': 'text/plain' },
+      })
+
+      expect(contentTypeHeader).toBe('text/plain')
+    })
+  })
+
   describe('PUT', () => {
     it('sends PUT request', async () => {
       const contract = defineApiContract({

--- a/packages/app/backend-http-client/src/api-contract/sendByApiContract.ts
+++ b/packages/app/backend-http-client/src/api-contract/sendByApiContract.ts
@@ -228,21 +228,26 @@ export async function sendByApiContract<
 
   const userHeaders = (await resolveRequestHeaders(params.headers)) ?? {}
 
-  const requestHeaders: Record<string, string> = {
-    ...(params.reqContext ? { [REQUEST_ID_HEADER]: params.reqContext.reqId } : {}),
-    ...userHeaders,
+  const requestHeaders = new Headers(userHeaders)
+
+  if (params.reqContext && !requestHeaders.has(REQUEST_ID_HEADER)) {
+    requestHeaders.set(REQUEST_ID_HEADER, params.reqContext.reqId)
+  }
+
+  if (params.body !== undefined && !requestHeaders.has('content-type')) {
+    requestHeaders.set('content-type', 'application/json')
   }
 
   if (useStreaming) {
-    if (requestHeaders.accept && requestHeaders.accept !== 'text/event-stream') {
+    const existingAccept = requestHeaders.get('accept')
+
+    if (existingAccept && existingAccept !== 'text/event-stream') {
       throw new Error(
-        `Cannot use SSE streaming with a custom Accept header ("${requestHeaders.accept}"). Remove the header or set it to "text/event-stream".`,
+        `Cannot use SSE streaming with a custom Accept header ("${existingAccept}"). Remove the header or set it to "text/event-stream".`,
       )
     }
-    requestHeaders.accept = 'text/event-stream'
-  }
-  if (params.body !== undefined && !requestHeaders['content-type']) {
-    requestHeaders['content-type'] = 'application/json'
+
+    requestHeaders.set('accept', 'text/event-stream')
   }
 
   const baseRequest = {

--- a/packages/app/frontend-http-client/src/api-contract/sendByApiContract.spec.ts
+++ b/packages/app/frontend-http-client/src/api-contract/sendByApiContract.spec.ts
@@ -586,4 +586,89 @@ describe('sendByApiContract', () => {
       expect(result.result?.body.size).toBe(4)
     })
   })
+
+  describe('content-type request header', () => {
+    it('sets content-type: application/json automatically when body is present', async () => {
+      const contract = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/items',
+        requestBodySchema: z.object({ name: z.string() }),
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forPost('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(buildClient(), contract, { body: { name: 'test' } })
+
+      expect(contentTypeHeader).toBe('application/json')
+    })
+
+    it('does not set content-type when no body is present', async () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/items',
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forGet('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(buildClient(), contract, {})
+
+      expect(contentTypeHeader).toBeUndefined()
+    })
+
+    it('preserves user-provided content-type (lowercase)', async () => {
+      const contract = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/items',
+        requestBodySchema: z.object({ name: z.string() }),
+        requestHeaderSchema: z.object({ 'content-type': z.string().optional() }),
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forPost('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(buildClient(), contract, {
+        body: { name: 'test' },
+        headers: { 'content-type': 'text/plain' },
+      })
+
+      expect(contentTypeHeader).toBe('text/plain')
+    })
+
+    it('preserves user-provided content-type (Title-Case)', async () => {
+      const contract = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/items',
+        requestBodySchema: z.object({ name: z.string() }),
+        requestHeaderSchema: z.object({ 'Content-Type': z.string().optional() }),
+        responsesByStatusCode: { 200: z.object({ id: z.number() }) },
+      })
+
+      let contentTypeHeader: string | undefined
+      await mockServer.forPost('/items').thenCallback((req) => {
+        contentTypeHeader = req.headers['content-type']
+        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ id: 1 }) }
+      })
+
+      await sendByApiContract(buildClient(), contract, {
+        body: { name: 'test' },
+        headers: { 'Content-Type': 'text/plain' },
+      })
+
+      expect(contentTypeHeader).toBe('text/plain')
+    })
+  })
 })

--- a/packages/app/frontend-http-client/src/api-contract/sendByApiContract.ts
+++ b/packages/app/frontend-http-client/src/api-contract/sendByApiContract.ts
@@ -171,18 +171,20 @@ export async function sendByApiContract<
   const captureAsError = params.captureAsError ?? true
   const strictContentType = params.strictContentType ?? true
 
-  const requestHeaders: Record<string, string> = (await resolveRequestHeaders(params.headers)) ?? {}
+  const requestHeaders = new Headers((await resolveRequestHeaders(params.headers)) ?? {})
+
+  if (params.body !== undefined && !requestHeaders.has('content-type')) {
+    requestHeaders.set('content-type', 'application/json')
+  }
 
   if (useStreaming) {
-    if (requestHeaders.accept && requestHeaders.accept !== 'text/event-stream') {
+    const existingAccept = requestHeaders.get('accept')
+    if (existingAccept && existingAccept !== 'text/event-stream') {
       throw new Error(
-        `Cannot use SSE streaming with a custom Accept header ("${requestHeaders.accept}"). Remove the header or set it to "text/event-stream".`,
+        `Cannot use SSE streaming with a custom Accept header ("${existingAccept}"). Remove the header or set it to "text/event-stream".`,
       )
     }
-    requestHeaders.accept = 'text/event-stream'
-  }
-  if (params.body !== undefined && !requestHeaders['content-type']) {
-    requestHeaders['content-type'] = 'application/json'
+    requestHeaders.set('accept', 'text/event-stream')
   }
 
   const path = buildRequestPath(apiContract.pathResolver(params.pathParams), params.pathPrefix)
@@ -205,7 +207,7 @@ export async function sendByApiContract<
   const wretchInstance = wretch
     .middlewares([cloneErrorResponseMiddleware])
     .url(fullUrl)
-    .headers(requestHeaders)
+    .headers(Object.fromEntries(requestHeaders))
     .options({ signal: params.signal })
 
   let response: Response


### PR DESCRIPTION
## Changes

Both `backend-http-client` and `frontend-http-client` now use `new Headers()` (the Web API) to manage request headers, which provides correct case-insensitive deduplication. Previously, a user-supplied Content-Type header could silently collide with or be overwritten by the auto-set content-type: application/json.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
