### PR TITLE
feat(frontend-http-client): add onClose callback to SseCallbacks

### DIFF
--- a/packages/app/frontend-http-client/src/sse.spec.ts
+++ b/packages/app/frontend-http-client/src/sse.spec.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import { buildSseContract } from '@lokalise/api-contracts'
 import { getLocal, type Mockttp } from 'mockttp'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
@@ -363,6 +364,110 @@ describe('connectSseByContract', () => {
     await vi.waitFor(() => expect(onDone).toHaveBeenCalled())
 
     expect(onOpen).toHaveBeenCalledOnce()
+    connection.close()
+  })
+
+  it('calls onClose when the server closes the stream naturally', async () => {
+    await mockServer.forGet('/events/stream').thenCallback(() => ({
+      statusCode: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+      body: sseResponse([
+        { event: 'item.updated', data: JSON.stringify({ items: [{ id: '1' }] }) },
+        { event: 'done', data: JSON.stringify({ total: 1 }) },
+      ]),
+    }))
+
+    const onDone = vi.fn()
+    const onClose = vi.fn()
+    const onError = vi.fn()
+
+    const client = wretch(mockServer.url)
+    const connection = connectSseByContract(
+      client,
+      getSseContract,
+      {},
+      {
+        onEvent: {
+          'item.updated': vi.fn(),
+          done: onDone,
+        },
+        onClose,
+        onError,
+      },
+    )
+
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalled())
+
+    expect(onDone).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onError).not.toHaveBeenCalled()
+    connection.close()
+  })
+
+  it('does not call onClose when the caller aborts the connection', async () => {
+    // Use a streaming response that emits one event and then stays open, so we can
+    // deterministically abort mid-stream (a `thenCallback` response would deliver
+    // its full body before we get a chance to call `close()`, racing the assertion).
+    const responseStream = new Readable({ read() {} })
+    responseStream.push(
+      `event: item.updated\ndata: ${JSON.stringify({ items: [{ id: '1' }] })}\n\n`,
+    )
+    await mockServer
+      .forGet('/events/stream')
+      .thenStream(200, responseStream, { 'Content-Type': 'text/event-stream' })
+
+    const onItemUpdated = vi.fn()
+    const onClose = vi.fn()
+
+    const client = wretch(mockServer.url)
+    const connection = connectSseByContract(
+      client,
+      getSseContract,
+      {},
+      {
+        onEvent: {
+          'item.updated': onItemUpdated,
+          done: vi.fn(),
+        },
+        onClose,
+      },
+    )
+
+    await vi.waitFor(() => expect(onItemUpdated).toHaveBeenCalled())
+    connection.close()
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(onClose).not.toHaveBeenCalled()
+    responseStream.push(null)
+  })
+
+  it('does not call onClose when the stream errors', async () => {
+    await mockServer.forGet('/events/stream').thenCallback(() => ({
+      statusCode: 500,
+      body: 'Server error',
+    }))
+
+    const onClose = vi.fn()
+    const onError = vi.fn()
+
+    const client = wretch(mockServer.url)
+    const connection = connectSseByContract(
+      client,
+      getSseContract,
+      {},
+      {
+        onEvent: {
+          'item.updated': vi.fn(),
+          done: vi.fn(),
+        },
+        onClose,
+        onError,
+      },
+    )
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled())
+
+    expect(onClose).not.toHaveBeenCalled()
     connection.close()
   })
 

--- a/packages/app/frontend-http-client/src/sse.ts
+++ b/packages/app/frontend-http-client/src/sse.ts
@@ -174,8 +174,12 @@ async function runSseConnection(
       handleSseEvent(event, data, contract, callbacks)
     }
 
-    // Natural end of stream — server closed without error and we weren't aborted.
+    // Natural end of stream — server closed without error. The aborted-here
+    // branch is only reachable if abort is signaled between reader.read() calls
+    // (otherwise reader.read() throws and we go to catch), so coverage skips it.
+    /* v8 ignore start */
     if (!abortController.signal.aborted) callbacks.onClose?.()
+    /* v8 ignore stop */
   } catch (err) {
     /* v8 ignore start */
     if (!abortController.signal.aborted) {

--- a/packages/app/frontend-http-client/src/sse.ts
+++ b/packages/app/frontend-http-client/src/sse.ts
@@ -22,6 +22,13 @@ export type SseCallbacks<Events extends SSEEventSchemas> = {
   }
   onError?: (error: Error) => void
   onOpen?: () => void
+  /**
+   * Fires once the server closes the stream naturally (i.e. without an error and
+   * without the caller invoking `close()`). Use this to react to end-of-stream
+   * without inferring it from event content. Not called on aborted streams or
+   * errors — `onError` is the signal for those.
+   */
+  onClose?: () => void
 }
 
 type AnyContract = AnyDualModeContractDefinition | AnySSEContractDefinition
@@ -166,6 +173,9 @@ async function runSseConnection(
       /* v8 ignore stop */
       handleSseEvent(event, data, contract, callbacks)
     }
+
+    // Natural end of stream — server closed without error and we weren't aborted.
+    if (!abortController.signal.aborted) callbacks.onClose?.()
   } catch (err) {
     /* v8 ignore start */
     if (!abortController.signal.aborted) {


### PR DESCRIPTION
Fires once the server closes the stream naturally (no error, no caller abort). Lets consumers react to end-of-stream without inferring it from event content — e.g. an SSE producing a variable number of events can now flip a `isStreaming` flag on stream close instead of guessing from the last event's payload.

Optional, backwards-compatible. Not called on aborted streams or errors; those keep the existing onError / silent semantics.

## Changes

Please describe

## Checklist

- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [ ] I've updated the documentation, or no changes were necessary
- [ ] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
