### PR TITLE
fix(fastify-bullboard-plugin): tighten QueueProConstructor opts to QueueOptions

### DIFF
--- a/packages/app/fastify-bullboard-plugin/src/bullBoard.spec.ts
+++ b/packages/app/fastify-bullboard-plugin/src/bullBoard.spec.ts
@@ -1,7 +1,8 @@
+import type { QueueProLike } from '@bull-board/api/bullMQProAdapter'
 import fastifySchedule from '@fastify/schedule'
-import { Queue } from 'bullmq'
+import { Queue, type QueueOptions } from 'bullmq'
 import fastify, { type FastifyInstance } from 'fastify'
-import { beforeAll, expect } from 'vitest'
+import { beforeAll, expect, expectTypeOf } from 'vitest'
 import {
   type BullBoardOptions,
   bullBoard,
@@ -113,6 +114,18 @@ describe('bull board', () => {
   })
 
   describe('pro queue support', () => {
+    it('QueueProConstructor accepts a real QueuePro-shaped ctor without a cast', () => {
+      // Type-only check. A constructor whose opts extend `QueueOptions` (the real
+      // `QueuePro` shape) must be assignable to `QueueProConstructor` directly —
+      // downstream consumers paid an `as unknown as` tax while opts was typed as
+      // `Record<string, unknown>`.
+      interface FakeQueueProOptions extends QueueOptions {
+        isPro?: boolean
+      }
+      type FakeQueueProCtor = new (name: string, opts?: FakeQueueProOptions) => QueueProLike
+      expectTypeOf<FakeQueueProCtor>().toMatchTypeOf<QueueProConstructor>()
+    })
+
     it('accepts registration with both queueConstructor and queueProConstructor provided', async () => {
       app = await initApp({
         queueConstructor: BullMqQueue,

--- a/packages/app/fastify-bullboard-plugin/src/bullBoard.ts
+++ b/packages/app/fastify-bullboard-plugin/src/bullBoard.ts
@@ -41,7 +41,7 @@ export type BullBoardOptions = {
 }
 
 export interface QueueProConstructor {
-  new (name: string, opts?: Record<string, unknown>): QueueProLike
+  new (name: string, opts?: QueueOptions): QueueProLike
 }
 
 export interface QueueConstructor {


### PR DESCRIPTION
## Summary

`QueueProConstructor` typed its `opts` parameter as `Record<string, unknown>`, which is wider than what the plugin actually passes (`{ connection, prefix }`) and wider than what real `QueuePro` constructors accept. By parameter contravariance, this made `typeof QueuePro` (from `@lokalise/bullmq-pro` / `@taskforcesh/bullmq-pro` — whose opts extend `QueueOptions` with a required `connection`) **unassignable** to the interface, forcing downstream consumers to write:

```ts
queueProConstructor: QueuePro as unknown as QueueProConstructor
```

at every registration. Sibling `QueueConstructor` already uses `QueueOptions` directly for this exact reason — `QueueProConstructor` was the outlier.

This PR tightens the opts parameter to `QueueOptions`, which:
- `QueueProOptions` already extends (`isPro` is optional), so `typeof QueuePro` becomes directly assignable.
- The plugin already imports from `bullmq` (`Queue`, `QueueOptions`, `RedisConnection`) — no new dependency.
- Matches the existing pattern in `QueueConstructor`.

After this change, consumers can drop the cast:

```ts
await app.register(bullBoard, {
  queueConstructor: Queue,
  queueProConstructor: QueuePro,   // no `as unknown as` needed
  redisConfigs: [...],
})
```

## Test plan

- [x] `tsc --noEmit` passes (only pre-existing unrelated errors in `errorReporterPlugin.spec.ts` remain)
- [x] `biome check` passes
- [x] `vitest run src/bullBoard.spec.ts` — 8/8 passing, including a new type-only assertion that fails to compile if the contract regresses
- [x] Validated downstream: `autopilot3/services/infra/bull-board` consumes `QueuePro` from `@lokalise/bullmq-pro` without a cast against this fix

## Checklist

- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)