### PR TITLE
chore: add missing changeset for drizzle-utils schema snapshotting (#949)

### DIFF
--- a/.changeset/drizzle-utils-schema-snapshotting.md
+++ b/.changeset/drizzle-utils-schema-snapshotting.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/drizzle-utils": minor
+---
+
+Add DB schema snapshotting and diffing utilities (`snapshotSchema`, `diffSchemaSnapshots`) for PostgreSQL and MySQL, to support comparing schemas before and after Drizzle migrations.


### PR DESCRIPTION
## Summary
- Adds a missing changeset for #949, which introduced DB schema snapshotting and diffing utilities in `@lokalise/drizzle-utils` after the repo migrated to Changesets in #948.
- Bumps `@lokalise/drizzle-utils` as a `minor` release (new public API: `snapshotSchema`, `diffSchemaSnapshots`, and supporting types).

## Test plan
- [ ] CI passes (changeset validation)

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**