### PR TITLE
fix: release workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Please describe
 
 ## Checklist
 
-- [ ] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
+- [ ] I've added a changeset, or no published packages were changed
 - [ ] I've updated the documentation, or no changes were necessary
 - [ ] I've updated the tests, or no changes were necessary
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+  repository_dispatch:
+    types:
+      - release
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-
   repository_dispatch:
     types:
       - release


### PR DESCRIPTION
## Changes

The release pipeline was not publishing packages after the changesets PR was auto-merged.

Root cause — two compounding issues:

1. GITHUB_TOKEN pushes don't re-trigger workflows. When the auto-merge step merged the changesets PR via GITHUB_TOKEN, the resulting commit on main was silently ignored by GitHub Actions (by design, to prevent infinite loops). The publish step in changesets/action never ran.

2. The repository_dispatch workaround had no listener. The workflow already attempted to work around this by dispatching a release event after the merge, but the workflow's on: block only declared a push trigger — repository_dispatch was never listed, so the event was fired and immediately dropped.

Fix: Added repository_dispatch: types: [release] to the workflow triggers. Now, after the auto-merge fires the dispatch, a second workflow run starts, changesets/action finds no pending changesets, and proceeds directly to pnpm ci:publish.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
