### PR TITLE
fix: creating github tag and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           title: "Release Packages"
           commit: "chore: update versions"
-          publish: pnpm ci:publish
 
       - name: Auto-merge Changesets PR
         if: steps.changesets.outputs.hasChangesets == 'true'

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test:ci": "turbo run test:ci",
     "lint": "turbo run lint --continue=always",
     "lint:fix": "turbo run lint:fix --continue=always",
-    "changeset": "changeset",
-    "ci:publish": "pnpm publish -r"
+    "changeset": "changeset"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",


### PR DESCRIPTION
## Changes

The current setup was not creating git tag and GH release. We shouldn't use `pnpm publish -r` (even tho it is part of pnpm guide on introducing changesets). It seems that we'd have to combine it with `changeset tag` or just use `changeset release` (the default release command in changesets/action - this PR switches to this default one).

More context:
- https://github.com/changesets/changesets/blob/main/docs/command-line-options.md
- https://github.com/changesets/action/issues/196


## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [ ] **Yes, AI assisted with this PR**
- [x] **No, AI did not assist with this PR**
