### PR TITLE
Feat/api contracts response description

### DIFF
--- a/packages/app/api-contracts/README.md
+++ b/packages/app/api-contracts/README.md
@@ -12,7 +12,7 @@ This eliminates assumptions across the boundary and keeps documentation, validat
 ### REST routes
 
 ```ts
-import { defineApiContract, ContractNoBody } from '@lokalise/api-contracts'
+import { defineApiContract, noBodyResponse } from '@lokalise/api-contracts'
 import { z } from 'zod/v4'
 
 // GET with path params
@@ -41,7 +41,7 @@ const deleteUser = defineApiContract({
   requestPathParamsSchema: z.object({ userId: z.uuid() }),
   pathResolver: ({ userId }) => `/users/${userId}`,
   responsesByStatusCode: {
-    204: ContractNoBody,
+    204: noBodyResponse(),
   },
 })
 ```
@@ -121,6 +121,41 @@ const chatCompletion = defineApiContract({
 })
 ```
 
+### OpenAPI response descriptions
+
+All response factories accept an optional `ResponseOptions` object as their last argument.
+
+```ts
+import {
+  defineApiContract,
+  noBodyResponse,
+  textResponse,
+  blobResponse,
+  sseResponse,
+  anyOfResponses,
+} from '@lokalise/api-contracts'
+import { z } from 'zod/v4'
+
+const contract = defineApiContract({
+  method: 'post',
+  pathResolver: () => '/files',
+  requestBodySchema: z.object({ name: z.string() }),
+  responsesByStatusCode: {
+    201: z.object({ id: z.string() }).describe('Created resource'),
+    204: noBodyResponse({ description: 'Deleted — no content returned' }),
+    200: anyOfResponses(
+      [
+        z.object({ id: z.string() }).describe('JSON representation'),
+        textResponse('text/csv', { description: 'CSV export' }),
+        blobResponse('application/pdf', { description: 'PDF report' }),
+        sseResponse({ update: z.object({ id: z.string() }) }, { description: 'Live update stream' }),
+      ],
+      { description: 'Multiple response formats available' },
+    ),
+  },
+})
+```
+
 `getSseSchemaByEventName(contract)` extracts SSE event schemas from a contract:
 
 ```ts
@@ -141,7 +176,7 @@ defineApiContract({
   method: 'get' | 'post' | 'put' | 'patch' | 'delete',
   pathResolver: (pathParams) => string,
   responsesByStatusCode: {
-    [statusCode]: z.ZodType | ContractNoBody | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
+    [statusCode]: z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
   },
 
   // Path params — links pathResolver parameter type to the schema
@@ -185,7 +220,7 @@ const contract = defineApiContract({
 
 ### Type utilities
 
-**`InferNonSseSuccessResponses<T>`** — TypeScript output type of all non-SSE 2xx responses. JSON schemas → `z.output<T>`, `textResponse` → `string`, `blobResponse` → `Blob`, `ContractNoBody` → `undefined`, `sseResponse` → `never` (excluded). `anyOfResponses` entries are unpacked before mapping.
+**`InferNonSseSuccessResponses<T>`** — TypeScript output type of all non-SSE 2xx responses. JSON schemas → `z.output<T>`, `textResponse` → `string`, `blobResponse` → `Blob`, `ContractNoBody`/`NoBodyResponse` → `undefined`, `sseResponse` → `never` (excluded). `anyOfResponses` entries are unpacked before mapping.
 
 ```ts
 import type { InferNonSseSuccessResponses } from '@lokalise/api-contracts'
@@ -207,7 +242,7 @@ type CsvResponse = InferNonSseSuccessResponses<typeof exportCsv['responsesByStat
 
 **`HasAnyNonSseSuccessResponse<T>`** — `true` if any 2xx entry is a non-SSE response (JSON, text, blob, or no-body).
 
-**`IsNoBodySuccessResponse<T>`** — `true` when all 2xx entries are `ContractNoBody` or no 2xx status codes are defined.
+**`IsNoBodySuccessResponse<T>`** — `true` when all 2xx entries are `ContractNoBody`/`NoBodyResponse` or no 2xx status codes are defined.
 
 **`ContractResponseMode<T>`** — classifies a contract into `'dual'` (SSE + non-SSE), `'sse'` (SSE-only), or `'non-sse'` (JSON/text/blob/no-body).
 
@@ -271,7 +306,7 @@ import { describeApiContract } from '@lokalise/api-contracts'
 describeApiContract(getUser) // "GET /users/:userId"
 ```
 
-**`getSuccessResponseSchema`** — merged Zod schema from all 2xx JSON entries. `ContractNoBody` and non-JSON entries are excluded. Returns `null` when no schema is present.
+**`getSuccessResponseSchema`** *(deprecated — no known consumers, will be removed in a future release)* — merged Zod schema from all 2xx JSON entries. `ContractNoBody`/`NoBodyResponse` and non-JSON entries are excluded. Returns `null` when no schema is present.
 
 ```ts
 import { getSuccessResponseSchema } from '@lokalise/api-contracts'
@@ -280,7 +315,7 @@ getSuccessResponseSchema(getUser)    // ZodObject
 getSuccessResponseSchema(deleteUser) // null
 ```
 
-**`getIsEmptyResponseExpected`** — `true` when no Zod schema exists among 2xx entries.
+**`getIsEmptyResponseExpected`** *(deprecated — no known consumers, will be removed in a future release)* — `true` when no Zod schema exists among 2xx entries.
 
 ```ts
 import { getIsEmptyResponseExpected } from '@lokalise/api-contracts'

--- a/packages/app/api-contracts/src/new/constants.ts
+++ b/packages/app/api-contracts/src/new/constants.ts
@@ -1,2 +1,1 @@
-/** @deprecated Use `noBodyResponse()` instead. */
 export const ContractNoBody = Symbol.for('ContractNoBody')

--- a/packages/app/api-contracts/src/new/constants.ts
+++ b/packages/app/api-contracts/src/new/constants.ts
@@ -1,1 +1,2 @@
+/** @deprecated Use `noBodyResponse()` instead. */
 export const ContractNoBody = Symbol.for('ContractNoBody')

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -5,6 +5,8 @@ import {
   anyOfResponses,
   blobResponse,
   isJsonResponse,
+  isNoBodyResponse,
+  noBodyResponse,
   resolveContractResponse,
   resolveResponseEntry,
   sseResponse,
@@ -37,6 +39,79 @@ describe('isJsonResponse', () => {
   })
 })
 
+describe('factory description option', () => {
+  it('textResponse includes description when provided', () => {
+    expect(textResponse('text/csv', { description: 'CSV export' })).toMatchObject({
+      description: 'CSV export',
+    })
+  })
+
+  it('textResponse omits description when not provided', () => {
+    expect(textResponse('text/csv')).not.toHaveProperty('description')
+  })
+
+  it('blobResponse includes description when provided', () => {
+    expect(blobResponse('image/png', { description: 'PNG image' })).toMatchObject({
+      description: 'PNG image',
+    })
+  })
+
+  it('blobResponse omits description when not provided', () => {
+    expect(blobResponse('image/png')).not.toHaveProperty('description')
+  })
+
+  it('sseResponse includes description when provided', () => {
+    expect(sseResponse({ update: z.string() }, { description: 'SSE stream' })).toMatchObject({
+      description: 'SSE stream',
+    })
+  })
+
+  it('sseResponse omits description when not provided', () => {
+    expect(sseResponse({ update: z.string() })).not.toHaveProperty('description')
+  })
+
+  it('anyOfResponses includes description when provided', () => {
+    expect(anyOfResponses([z.object({ id: z.string() })], { description: 'Multiple types' })).toMatchObject({
+      description: 'Multiple types',
+    })
+  })
+
+  it('anyOfResponses omits description when not provided', () => {
+    expect(anyOfResponses([z.object({ id: z.string() })])).not.toHaveProperty('description')
+  })
+
+  it('noBodyResponse includes description when provided', () => {
+    expect(noBodyResponse({ description: 'No content' })).toMatchObject({
+      description: 'No content',
+    })
+  })
+
+  it('noBodyResponse omits description when not provided', () => {
+    expect(noBodyResponse()).not.toHaveProperty('description')
+  })
+})
+
+describe('noBodyResponse / isNoBodyResponse', () => {
+  it('noBodyResponse returns correct tag', () => {
+    expect(noBodyResponse()).toEqual({ _tag: 'NoBodyResponse' })
+  })
+
+  it('isNoBodyResponse returns true for noBodyResponse()', () => {
+    expect(isNoBodyResponse(noBodyResponse())).toBe(true)
+  })
+
+  it('isNoBodyResponse returns false for ContractNoBody symbol', () => {
+    expect(isNoBodyResponse(ContractNoBody)).toBe(false)
+  })
+
+  it('isNoBodyResponse returns false for other tagged responses', () => {
+    expect(isNoBodyResponse(textResponse('text/csv'))).toBe(false)
+    expect(isNoBodyResponse(blobResponse('image/png'))).toBe(false)
+    expect(isNoBodyResponse(sseResponse({ update: z.string() }))).toBe(false)
+    expect(isNoBodyResponse(anyOfResponses([z.object({ id: z.string() })]))).toBe(false)
+  })
+})
+
 describe('resolveContractResponse', () => {
   describe('ContractNoBody', () => {
     it('returns noContent regardless of content-type', () => {
@@ -44,6 +119,15 @@ describe('resolveContractResponse', () => {
         kind: 'noContent',
       })
       expect(resolveContractResponse(ContractNoBody, undefined)).toEqual({ kind: 'noContent' })
+    })
+  })
+
+  describe('noBodyResponse', () => {
+    it('returns noContent regardless of content-type', () => {
+      expect(resolveContractResponse(noBodyResponse(), 'application/json')).toEqual({
+        kind: 'noContent',
+      })
+      expect(resolveContractResponse(noBodyResponse(), undefined)).toEqual({ kind: 'noContent' })
     })
   })
 

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -71,7 +71,9 @@ describe('factory description option', () => {
   })
 
   it('anyOfResponses includes description when provided', () => {
-    expect(anyOfResponses([z.object({ id: z.string() })], { description: 'Multiple types' })).toMatchObject({
+    expect(
+      anyOfResponses([z.object({ id: z.string() })], { description: 'Multiple types' }),
+    ).toMatchObject({
       description: 'Multiple types',
     })
   })

--- a/packages/app/api-contracts/src/new/contractResponse.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.ts
@@ -2,14 +2,23 @@ import type { z } from 'zod/v4'
 import type { HttpStatusCode } from '../HttpStatusCodes.ts'
 import { ContractNoBody } from './constants.ts'
 
+export type ResponseOptions = {
+  readonly description?: string
+}
+
 export type TypedTextResponse = {
   readonly _tag: 'TextResponse'
   readonly contentType: string
+  readonly description?: string
 }
 
-export const textResponse = (contentType: string): TypedTextResponse => ({
+export const textResponse = (
+  contentType: string,
+  options?: ResponseOptions,
+): TypedTextResponse => ({
   _tag: 'TextResponse',
   contentType,
+  ...(options?.description !== undefined && { description: options.description }),
 })
 
 export const isTextResponse = (value: ApiContractResponse): value is TypedTextResponse =>
@@ -18,11 +27,16 @@ export const isTextResponse = (value: ApiContractResponse): value is TypedTextRe
 export type TypedBlobResponse = {
   readonly _tag: 'BlobResponse'
   readonly contentType: string
+  readonly description?: string
 }
 
-export const blobResponse = (contentType: string): TypedBlobResponse => ({
+export const blobResponse = (
+  contentType: string,
+  options?: ResponseOptions,
+): TypedBlobResponse => ({
   _tag: 'BlobResponse',
   contentType,
+  ...(options?.description !== undefined && { description: options.description }),
 })
 
 export const isBlobResponse = (value: ApiContractResponse): value is TypedBlobResponse =>
@@ -33,13 +47,16 @@ export type SseSchemaByEventName = Record<string, z.ZodType>
 export type TypedSseResponse<T extends SseSchemaByEventName = SseSchemaByEventName> = {
   readonly _tag: 'SseResponse'
   readonly schemaByEventName: T
+  readonly description?: string
 }
 
 export const sseResponse = <T extends SseSchemaByEventName>(
   schemaByEventName: T,
+  options?: ResponseOptions,
 ): TypedSseResponse<T> => ({
   _tag: 'SseResponse',
   schemaByEventName,
+  ...(options?.description !== undefined && { description: options.description }),
 })
 
 export const isSseResponse = (value: ApiContractResponse): value is TypedSseResponse =>
@@ -59,19 +76,39 @@ export type TypedApiContractResponse =
 export type AnyOfResponses<T extends TypedApiContractResponse = TypedApiContractResponse> = {
   readonly _tag: 'AnyOfResponses'
   readonly responses: T[]
+  readonly description?: string
 }
 
 export const anyOfResponses = <T extends TypedApiContractResponse>(
   responses: T[],
+  options?: ResponseOptions,
 ): AnyOfResponses<T> => ({
   _tag: 'AnyOfResponses',
   responses,
+  ...(options?.description !== undefined && { description: options.description }),
 })
 
 export const isAnyOfResponses = (value: ApiContractResponse): value is AnyOfResponses =>
   typeof value === 'object' && value !== null && '_tag' in value && value._tag === 'AnyOfResponses'
 
-export type ApiContractResponse = typeof ContractNoBody | TypedApiContractResponse | AnyOfResponses
+export type NoBodyResponse = {
+  readonly _tag: 'NoBodyResponse'
+  readonly description?: string
+}
+
+export const noBodyResponse = (options?: ResponseOptions): NoBodyResponse => ({
+  _tag: 'NoBodyResponse',
+  ...(options?.description !== undefined && { description: options.description }),
+})
+
+export const isNoBodyResponse = (value: ApiContractResponse): value is NoBodyResponse =>
+  typeof value === 'object' && value !== null && '_tag' in value && value._tag === 'NoBodyResponse'
+
+export type ApiContractResponse =
+  | typeof ContractNoBody
+  | NoBodyResponse
+  | TypedApiContractResponse
+  | AnyOfResponses
 
 export type ResponsesByStatusCode = Partial<Record<HttpStatusCode, ApiContractResponse>>
 
@@ -141,7 +178,7 @@ export const resolveContractResponse = (
   contentType: string | undefined,
   strict = true,
 ): ResponseKind | null => {
-  if (schemaEntry === ContractNoBody) {
+  if (schemaEntry === ContractNoBody || isNoBodyResponse(schemaEntry)) {
     return { kind: 'noContent' }
   }
 

--- a/packages/app/api-contracts/src/new/defineApiContract.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.ts
@@ -10,6 +10,7 @@ import { ContractNoBody } from './constants.ts'
 import {
   isAnyOfResponses,
   isBlobResponse,
+  isNoBodyResponse,
   isSseResponse,
   isTextResponse,
   type ResponsesByStatusCode,
@@ -130,6 +131,7 @@ export const hasAnySuccessSseResponse = (apiContract: ApiContract): boolean => {
   return false
 }
 
+/** @deprecated No known consumers — will be removed in a future release. */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: it is acceptable
 export const getSuccessResponseSchema = (routeConfig: ApiContract): z.ZodType | null => {
   const schemas: z.ZodType[] = []
@@ -150,6 +152,7 @@ export const getSuccessResponseSchema = (routeConfig: ApiContract): z.ZodType | 
       }
     } else if (
       value === ContractNoBody ||
+      isNoBodyResponse(value) ||
       isSseResponse(value) ||
       isTextResponse(value) ||
       isBlobResponse(value)
@@ -172,13 +175,14 @@ export const getSuccessResponseSchema = (routeConfig: ApiContract): z.ZodType | 
   return hasDirectNonJsonEntry ? z.never() : null
 }
 
+/** @deprecated No known consumers — will be removed in a future release. */
 export const getIsEmptyResponseExpected = (routeConfig: ApiContract): boolean => {
   let isEmptyResponseExpected = true
 
   for (const code of SUCCESSFUL_HTTP_STATUS_CODES) {
     const value = routeConfig.responsesByStatusCode[code]
 
-    if (value && value !== ContractNoBody) {
+    if (value && value !== ContractNoBody && !isNoBodyResponse(value)) {
       isEmptyResponseExpected = false
       break
     }


### PR DESCRIPTION
## Changes
 
Adds an optional `description` field to all response contract types in `@lokalise/api-contracts`, so it can be passed down to the OpenAPI spec.

## Changes
  
  - New shared `ResponseOptions` type `{ description?: string }` used across all factory functions
  - New `NoBodyResponse` tagged-object type + `noBodyResponse(options?)` factory + `isNoBodyResponse()` guard — replaces the raw `ContractNoBody` symbol in `responsesByStatusCode`
  - `description?` added to `TypedTextResponse`, `TypedBlobResponse`, `TypedSseResponse`, `AnyOfResponses` — factories updated to accept `options?: ResponseOptions`
  - `getSuccessResponseSchema` and `getIsEmptyResponseExpected` marked `@deprecated` (no known consumers)

  ## Usage
  
  ```ts
  responsesByStatusCode: {
    204: noBodyResponse({ description: 'Resource deleted' }),
    200: anyOfResponses([schema, textResponse('text/csv')], { description: 'Returns data' }),
  }
```

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
