### PR TITLE
feat(api-contracts): add wildcard status code keys to api contract responses

### DIFF
--- a/.changeset/api-contracts-wildcard-status-codes.md
+++ b/.changeset/api-contracts-wildcard-status-codes.md
@@ -1,6 +1,5 @@
 ---
 "@lokalise/api-contracts": minor
-"@lokalise/fastify-api-contracts": minor
 ---
 
 Add support for wildcard status code keys (`'1xx'`–`'5xx'`) and `'default'` in `responsesByStatusCode`, aligning with OpenAPI and Fastify conventions.

--- a/.changeset/api-contracts-wildcard-status-codes.md
+++ b/.changeset/api-contracts-wildcard-status-codes.md
@@ -1,0 +1,8 @@
+---
+"@lokalise/api-contracts": minor
+"@lokalise/fastify-api-contracts": minor
+---
+
+Add support for wildcard status code keys (`'1xx'`–`'5xx'`) and `'default'` in `responsesByStatusCode`, aligning with OpenAPI and Fastify conventions.
+
+Lookup precedence: exact code → range key → `'default'`. The `'2xx'` range participates in SSE-mode detection and success/error type narrowing the same way explicit 2xx codes do.

--- a/packages/app/api-contracts/README.md
+++ b/packages/app/api-contracts/README.md
@@ -217,34 +217,36 @@ getSseSchemaByEventName(chatCompletion)
 ### All fields
 
 ```ts
-defineApiContract({
+type ApiContractOptions = {
   // Required
-  method: 'get' | 'post' | 'put' | 'patch' | 'delete',
-  pathResolver: (pathParams) => string,
-  responsesByStatusCode: {
-    // exact status codes
-    [statusCode: HttpStatusCode]: z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
-    // range keys (OpenAPI-style): '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default'
-    [rangeKey: WildcardStatusCodeKey]: z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
-  },
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete'
+  pathResolver: (pathParams: Record<string, string>) => string
+  // Accepts exact codes, OpenAPI-style range keys ('1xx'–'5xx'), and a catch-all 'default'.
+  // Lookup precedence at runtime: exact code → range key → 'default'.
+  responsesByStatusCode: Partial<
+    Record<
+      HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default',
+      z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
+    >
+  >
 
   // Path params — links pathResolver parameter type to the schema
-  requestPathParamsSchema: z.ZodObject,
+  requestPathParamsSchema?: z.ZodObject<z.ZodRawShape>
 
   // Request
-  requestBodySchema: z.ZodType | ContractNoBody, // required for POST / PUT / PATCH, forbidden otherwise
-  requestQuerySchema: z.ZodObject,
-  requestHeaderSchema: z.ZodObject,
+  requestBodySchema?: z.ZodType | ContractNoBody  // required for POST / PUT / PATCH, forbidden otherwise
+  requestQuerySchema?: z.ZodObject<z.ZodRawShape>
+  requestHeaderSchema?: z.ZodObject<z.ZodRawShape>
 
   // Response
-  responseHeaderSchema: z.ZodObject,
+  responseHeaderSchema?: z.ZodObject<z.ZodRawShape>
 
   // Documentation
-  summary: string,
-  description: string,
-  tags: readonly string[],
-  metadata: Record<string, unknown>,
-})
+  summary?: string
+  description?: string
+  tags?: readonly string[]
+  metadata?: Record<string, unknown>
+}
 ```
 
 ### Header schemas

--- a/packages/app/api-contracts/README.md
+++ b/packages/app/api-contracts/README.md
@@ -121,6 +121,52 @@ const chatCompletion = defineApiContract({
 })
 ```
 
+### Wildcard and default response keys
+
+In addition to exact status codes, `responsesByStatusCode` accepts OpenAPI-style range keys (`'1xx'`–`'5xx'`) and `'default'` as fallbacks.
+
+Lookup precedence at runtime: **exact code → range key → `'default'`**.
+
+```ts
+import { defineApiContract } from '@lokalise/api-contracts'
+import { z } from 'zod/v4'
+
+// '2xx' covers all 200–299 responses
+const listItems = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/items',
+  responsesByStatusCode: {
+    '2xx': z.object({ items: z.array(z.string()) }),
+    '4xx': z.object({ message: z.string() }),
+  },
+})
+
+// exact code takes precedence over the range key
+const createItem = defineApiContract({
+  method: 'post',
+  pathResolver: () => '/items',
+  requestBodySchema: z.object({ name: z.string() }),
+  responsesByStatusCode: {
+    201: z.object({ id: z.string() }),
+    '4xx': z.object({ message: z.string() }),
+  },
+})
+
+// 'default' matches any status code not covered by a more specific entry
+const flexible = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/data',
+  responsesByStatusCode: {
+    200: z.object({ data: z.unknown() }),
+    default: z.object({ error: z.string() }),
+  },
+})
+```
+
+The `'2xx'` range key participates in SSE detection and success/error type narrowing exactly like explicit 2xx codes: `InferNonSseClientResponse` maps it to `SuccessfulHttpStatusCode`, and `hasAnySuccessSseResponse` returns `true` when it holds an SSE schema.
+
+`'default'` is split into a success half (`SuccessfulHttpStatusCode`) and a non-success half in `InferSseClientResponse` / `InferNonSseClientResponse` so that `captureAsError` type narrowing stays correct regardless of the actual status code.
+
 ### OpenAPI response descriptions
 
 All response factories accept an optional `ResponseOptions` object as their last argument.
@@ -176,7 +222,10 @@ defineApiContract({
   method: 'get' | 'post' | 'put' | 'patch' | 'delete',
   pathResolver: (pathParams) => string,
   responsesByStatusCode: {
-    [statusCode]: z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
+    // exact status codes
+    [statusCode: HttpStatusCode]: z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
+    // range keys (OpenAPI-style): '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default'
+    [rangeKey: WildcardStatusCodeKey]: z.ZodType | NoBodyResponse | TypedTextResponse | TypedBlobResponse | TypedSseResponse | AnyOfResponses
   },
 
   // Path params — links pathResolver parameter type to the schema
@@ -236,7 +285,7 @@ type CsvResponse = InferNonSseSuccessResponses<typeof exportCsv['responsesByStat
 
 **`InferSseSuccessResponses<T>`** — extracts the SSE event schema map type from a `responsesByStatusCode` map. Returns `never` when no SSE schemas are present.
 
-**`HasAnySseSuccessResponse<T>`** — `true` if any 2xx entry is a `TypedSseResponse` or an `AnyOfResponses` containing one.
+**`HasAnySseSuccessResponse<T>`** — `true` if any 2xx entry (exact code or `'2xx'` range key) is a `TypedSseResponse` or an `AnyOfResponses` containing one.
 
 **`HasAnyJsonSuccessResponse<T>`** — `true` if any 2xx entry is a JSON Zod schema or an `AnyOfResponses` containing one.
 
@@ -264,9 +313,9 @@ These types are primarily consumed by HTTP client implementations.
 
 **`ClientRequestParams<TApiContract, TIsStreaming>`** — infers the request parameter object for a contract. Includes `pathParams`, `body`, `queryParams`, `headers` (required when the corresponding schema is defined), `pathPrefix` (always optional), and `streaming` (required for dual-mode contracts, forbidden otherwise).
 
-**`InferSseClientResponse<TApiContract>`** — discriminated union of `{ statusCode, headers, body }` for SSE mode. Success status codes yield `AsyncIterable<SseEventOf<...>>`; error codes yield the declared body type.
+**`InferSseClientResponse<TApiContract>`** — discriminated union of `{ statusCode, headers, body }` for SSE mode. Exact 2xx codes and the `'2xx'` range key yield `AsyncIterable<SseEventOf<...>>`; error codes, other range keys, and `'default'` yield the declared body type. `'default'` is split into a `SuccessfulHttpStatusCode` half and a non-success half.
 
-**`InferNonSseClientResponse<TApiContract>`** — same shape as above for non-SSE mode. Success status codes yield JSON / `string` / `Blob` / `null`; SSE entries are excluded (`never`).
+**`InferNonSseClientResponse<TApiContract>`** — same shape as above for non-SSE mode. Exact 2xx codes and the `'2xx'` range key yield JSON / `string` / `Blob` / `null` (SSE excluded); error codes, other range keys, and `'default'` yield the declared body type as-is. `'default'` is split the same way.
 
 **`DefaultStreaming<T>`** — `true` for SSE-only contracts, `false` for everything else.
 
@@ -324,7 +373,7 @@ getIsEmptyResponseExpected(deleteUser) // true
 getIsEmptyResponseExpected(getUser)    // false
 ```
 
-**`hasAnySuccessSseResponse`** — `true` when any 2xx entry is an SSE response (including inside `anyOfResponses`).
+**`hasAnySuccessSseResponse`** — `true` when any 2xx entry (exact code or `'2xx'` range key) is an SSE response (including inside `anyOfResponses`).
 
 ```ts
 import { hasAnySuccessSseResponse } from '@lokalise/api-contracts'

--- a/packages/app/api-contracts/src/HttpStatusCodes.ts
+++ b/packages/app/api-contracts/src/HttpStatusCodes.ts
@@ -6,9 +6,7 @@ export const SUCCESSFUL_HTTP_STATUS_CODES = [
 ] as const
 export type SuccessfulHttpStatusCode = (typeof SUCCESSFUL_HTTP_STATUS_CODES)[number]
 
-export const REDIRECTION_HTTP_STATUS_CODES = [
-  300, 301, 302, 303, 304, 305, 306, 307, 308,
-] as const
+export const REDIRECTION_HTTP_STATUS_CODES = [300, 301, 302, 303, 304, 305, 306, 307, 308] as const
 export type RedirectionHttpStatusCode = (typeof REDIRECTION_HTTP_STATUS_CODES)[number]
 
 export const CLIENT_ERROR_HTTP_STATUS_CODES = [
@@ -33,15 +31,14 @@ export type HttpStatusCodeRange = '1xx' | '2xx' | '3xx' | '4xx' | '5xx'
 
 export type WildcardStatusCodeKey = HttpStatusCodeRange | 'default'
 
-export type ExpandStatusRangeKey<K extends WildcardStatusCodeKey> =
-  K extends '1xx'
-    ? InformationalHttpStatusCode
-    : K extends '2xx'
-      ? SuccessfulHttpStatusCode
-      : K extends '3xx'
-        ? RedirectionHttpStatusCode
-        : K extends '4xx'
-          ? ClientErrorHttpStatusCode
-          : K extends '5xx'
-            ? ServerErrorHttpStatusCode
-            : HttpStatusCode // 'default'
+export type ExpandStatusRangeKey<K extends WildcardStatusCodeKey> = K extends '1xx'
+  ? InformationalHttpStatusCode
+  : K extends '2xx'
+    ? SuccessfulHttpStatusCode
+    : K extends '3xx'
+      ? RedirectionHttpStatusCode
+      : K extends '4xx'
+        ? ClientErrorHttpStatusCode
+        : K extends '5xx'
+          ? ServerErrorHttpStatusCode
+          : HttpStatusCode // 'default'

--- a/packages/app/api-contracts/src/HttpStatusCodes.ts
+++ b/packages/app/api-contracts/src/HttpStatusCodes.ts
@@ -1,25 +1,36 @@
+/** Tuple of all 1xx informational HTTP status codes. */
 export const INFORMATIONAL_HTTP_STATUS_CODES = [100, 101, 102, 103] as const
+/** Union of all 1xx informational HTTP status codes. */
 export type InformationalHttpStatusCode = (typeof INFORMATIONAL_HTTP_STATUS_CODES)[number]
 
+/** Tuple of all 2xx successful HTTP status codes. */
 export const SUCCESSFUL_HTTP_STATUS_CODES = [
   200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
 ] as const
+/** Union of all 2xx successful HTTP status codes. */
 export type SuccessfulHttpStatusCode = (typeof SUCCESSFUL_HTTP_STATUS_CODES)[number]
 
+/** Tuple of all 3xx redirection HTTP status codes. */
 export const REDIRECTION_HTTP_STATUS_CODES = [300, 301, 302, 303, 304, 305, 306, 307, 308] as const
+/** Union of all 3xx redirection HTTP status codes. */
 export type RedirectionHttpStatusCode = (typeof REDIRECTION_HTTP_STATUS_CODES)[number]
 
+/** Tuple of all 4xx client-error HTTP status codes. */
 export const CLIENT_ERROR_HTTP_STATUS_CODES = [
   400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418,
   421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
 ] as const
+/** Union of all 4xx client-error HTTP status codes. */
 export type ClientErrorHttpStatusCode = (typeof CLIENT_ERROR_HTTP_STATUS_CODES)[number]
 
+/** Tuple of all 5xx server-error HTTP status codes. */
 export const SERVER_ERROR_HTTP_STATUS_CODES = [
   500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
 ] as const
+/** Union of all 5xx server-error HTTP status codes. */
 export type ServerErrorHttpStatusCode = (typeof SERVER_ERROR_HTTP_STATUS_CODES)[number]
 
+/** Union of every standard HTTP status code across all classes (1xx–5xx). */
 export type HttpStatusCode =
   | InformationalHttpStatusCode
   | SuccessfulHttpStatusCode
@@ -27,18 +38,23 @@ export type HttpStatusCode =
   | ClientErrorHttpStatusCode
   | ServerErrorHttpStatusCode
 
+/** String representation of an HTTP status class. */
 export type HttpStatusCodeRange = '1xx' | '2xx' | '3xx' | '4xx' | '5xx'
 
+/** Range key or catch-all fallback. */
 export type WildcardStatusCodeKey = HttpStatusCodeRange | 'default'
 
-export type ExpandStatusRangeKey<K extends WildcardStatusCodeKey> = K extends '1xx'
-  ? InformationalHttpStatusCode
-  : K extends '2xx'
-    ? SuccessfulHttpStatusCode
-    : K extends '3xx'
-      ? RedirectionHttpStatusCode
-      : K extends '4xx'
-        ? ClientErrorHttpStatusCode
-        : K extends '5xx'
-          ? ServerErrorHttpStatusCode
-          : HttpStatusCode // 'default'
+type RangeExpansion = {
+  '1xx': InformationalHttpStatusCode
+  '2xx': SuccessfulHttpStatusCode
+  '3xx': RedirectionHttpStatusCode
+  '4xx': ClientErrorHttpStatusCode
+  '5xx': ServerErrorHttpStatusCode
+  default: HttpStatusCode
+}
+
+/**
+ * Maps a `WildcardStatusCodeKey` to its concrete `HttpStatusCode` union.
+ * `'default'` expands to the full `HttpStatusCode` union.
+ */
+export type ExpandStatusRangeKey<K extends WildcardStatusCodeKey> = RangeExpansion[K]

--- a/packages/app/api-contracts/src/HttpStatusCodes.ts
+++ b/packages/app/api-contracts/src/HttpStatusCodes.ts
@@ -1,70 +1,47 @@
-export type HttpStatusCode =
-  | 100
-  | 101
-  | 102
-  | 103
-  | 200
-  | 201
-  | 202
-  | 203
-  | 204
-  | 205
-  | 206
-  | 207
-  | 208
-  | 226
-  | 300
-  | 301
-  | 302
-  | 303
-  | 304
-  | 305
-  | 306
-  | 307
-  | 308
-  | 400
-  | 401
-  | 402
-  | 403
-  | 404
-  | 405
-  | 406
-  | 407
-  | 408
-  | 409
-  | 410
-  | 411
-  | 412
-  | 413
-  | 414
-  | 415
-  | 416
-  | 417
-  | 418
-  | 421
-  | 422
-  | 423
-  | 424
-  | 425
-  | 426
-  | 428
-  | 429
-  | 431
-  | 451
-  | 500
-  | 501
-  | 502
-  | 503
-  | 504
-  | 505
-  | 506
-  | 507
-  | 508
-  | 510
-  | 511
+export const INFORMATIONAL_HTTP_STATUS_CODES = [100, 101, 102, 103] as const
+export type InformationalHttpStatusCode = (typeof INFORMATIONAL_HTTP_STATUS_CODES)[number]
 
 export const SUCCESSFUL_HTTP_STATUS_CODES = [
   200, 201, 202, 203, 204, 205, 206, 207, 208, 226,
 ] as const
-
 export type SuccessfulHttpStatusCode = (typeof SUCCESSFUL_HTTP_STATUS_CODES)[number]
+
+export const REDIRECTION_HTTP_STATUS_CODES = [
+  300, 301, 302, 303, 304, 305, 306, 307, 308,
+] as const
+export type RedirectionHttpStatusCode = (typeof REDIRECTION_HTTP_STATUS_CODES)[number]
+
+export const CLIENT_ERROR_HTTP_STATUS_CODES = [
+  400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418,
+  421, 422, 423, 424, 425, 426, 428, 429, 431, 451,
+] as const
+export type ClientErrorHttpStatusCode = (typeof CLIENT_ERROR_HTTP_STATUS_CODES)[number]
+
+export const SERVER_ERROR_HTTP_STATUS_CODES = [
+  500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511,
+] as const
+export type ServerErrorHttpStatusCode = (typeof SERVER_ERROR_HTTP_STATUS_CODES)[number]
+
+export type HttpStatusCode =
+  | InformationalHttpStatusCode
+  | SuccessfulHttpStatusCode
+  | RedirectionHttpStatusCode
+  | ClientErrorHttpStatusCode
+  | ServerErrorHttpStatusCode
+
+export type HttpStatusCodeRange = '1xx' | '2xx' | '3xx' | '4xx' | '5xx'
+
+export type WildcardStatusCodeKey = HttpStatusCodeRange | 'default'
+
+export type ExpandStatusRangeKey<K extends WildcardStatusCodeKey> =
+  K extends '1xx'
+    ? InformationalHttpStatusCode
+    : K extends '2xx'
+      ? SuccessfulHttpStatusCode
+      : K extends '3xx'
+        ? RedirectionHttpStatusCode
+        : K extends '4xx'
+          ? ClientErrorHttpStatusCode
+          : K extends '5xx'
+            ? ServerErrorHttpStatusCode
+            : HttpStatusCode // 'default'

--- a/packages/app/api-contracts/src/new/clientTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.spec.ts
@@ -402,7 +402,11 @@ describe('clientTypes', () => {
       })
       type Result = InferNonSseClientResponse<typeof contract>
       expectTypeOf<Result>().toEqualTypeOf<
-        | { statusCode: SuccessfulHttpStatusCode; headers: DefaultHeaders; body: { message: string } }
+        | {
+            statusCode: SuccessfulHttpStatusCode
+            headers: DefaultHeaders
+            body: { message: string }
+          }
         | {
             statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
             headers: DefaultHeaders

--- a/packages/app/api-contracts/src/new/clientTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod/v4'
 import type {
+  ExpandStatusRangeKey,
+  HttpStatusCode,
+  SuccessfulHttpStatusCode,
+} from '../HttpStatusCodes.ts'
+import type {
   ClientRequestParams,
   HeadersParam,
   InferNonSseClientResponse,
@@ -352,6 +357,105 @@ describe('clientTypes', () => {
           'x-retry-count': number
         }
         body: { id: number }
+      }>()
+    })
+
+    it('maps 2xx range key to SuccessfulHttpStatusCode with non-SSE body', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ id: z.number() }) },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      expectTypeOf<Result>().toEqualTypeOf<{
+        statusCode: SuccessfulHttpStatusCode
+        headers: DefaultHeaders
+        body: { id: number }
+      }>()
+    })
+
+    it('maps 4xx range key to 4xx status codes with as-is body', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          200: z.object({ id: z.number() }),
+          '4xx': z.object({ message: z.string() }),
+        },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      expectTypeOf<Result>().toEqualTypeOf<
+        | { statusCode: 200; headers: DefaultHeaders; body: { id: number } }
+        | {
+            statusCode: ExpandStatusRangeKey<'4xx'>
+            headers: DefaultHeaders
+            body: { message: string }
+          }
+      >()
+    })
+
+    it('maps default key to split success/non-success statusCode entries', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { default: z.object({ message: z.string() }) },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      expectTypeOf<Result>().toEqualTypeOf<
+        | { statusCode: SuccessfulHttpStatusCode; headers: DefaultHeaders; body: { message: string } }
+        | {
+            statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+            headers: DefaultHeaders
+            body: { message: string }
+          }
+      >()
+    })
+  })
+
+  describe('InferNonSseClientResponse with range keys and captureAsError', () => {
+    it('2xx range response ends up in result type (extends SuccessfulHttpStatusCode)', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ ok: z.boolean() }) },
+      })
+      type Response = InferNonSseClientResponse<typeof contract>
+      // The statusCode must be SuccessfulHttpStatusCode so Extract works with captureAsError
+      type SuccessPart = Extract<Response, { statusCode: SuccessfulHttpStatusCode }>
+      expectTypeOf<SuccessPart>().not.toEqualTypeOf<never>()
+    })
+
+    it('4xx range response ends up in error type (not SuccessfulHttpStatusCode)', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '4xx': z.object({ error: z.string() }) },
+      })
+      type Response = InferNonSseClientResponse<typeof contract>
+      type SuccessPart = Extract<Response, { statusCode: SuccessfulHttpStatusCode }>
+      expectTypeOf<SuccessPart>().toEqualTypeOf<never>()
+    })
+  })
+
+  describe('InferSseClientResponse with range keys', () => {
+    it('maps 2xx SSE range to AsyncIterable body for success codes', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/events',
+        responsesByStatusCode: {
+          '2xx': sseResponse({ tick: z.object({ count: z.number() }) }),
+        },
+      })
+      type Result = InferSseClientResponse<typeof contract>
+      expectTypeOf<Result>().toEqualTypeOf<{
+        statusCode: SuccessfulHttpStatusCode
+        headers: DefaultHeaders
+        body: AsyncIterable<{
+          type: 'tick'
+          data: { count: number }
+          lastEventId: string
+          retry: number | undefined
+        }>
       }>()
     })
   })

--- a/packages/app/api-contracts/src/new/clientTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod/v4'
 import type {
+  ClientErrorHttpStatusCode,
   ExpandStatusRangeKey,
   HttpStatusCode,
   SuccessfulHttpStatusCode,
@@ -360,6 +361,32 @@ describe('clientTypes', () => {
       }>()
     })
 
+    it('exact code takes precedence over 2xx range: narrowing by exact statusCode resolves only the exact body', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          '2xx': z.object({ id: z.number() }),
+          201: z.object({ name: z.string() }),
+        },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      // Narrowing to 201 must yield only the exact entry's body, not the range body
+      type At201 = Extract<Result, { statusCode: 201 }>
+      expectTypeOf<At201>().toEqualTypeOf<{
+        statusCode: 201
+        headers: DefaultHeaders
+        body: { name: string }
+      }>()
+      // The range entry must not include 201 in its statusCode union
+      type RangeEntry = Extract<Result, { statusCode: Exclude<SuccessfulHttpStatusCode, 201> }>
+      expectTypeOf<RangeEntry>().toEqualTypeOf<{
+        statusCode: Exclude<SuccessfulHttpStatusCode, 201>
+        headers: DefaultHeaders
+        body: { id: number }
+      }>()
+    })
+
     it('maps 2xx range key to SuccessfulHttpStatusCode with non-SSE body', () => {
       const contract = defineApiContract({
         method: 'get',
@@ -413,6 +440,51 @@ describe('clientTypes', () => {
             body: { message: string }
           }
       >()
+    })
+
+    it('range key takes precedence over default: range codes excluded from default statusCode', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          '4xx': z.object({ error: z.string() }),
+          default: z.object({ message: z.string() }),
+        },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      // The 4xx range entry covers all ClientErrorHttpStatusCode codes
+      type RangeEntry = Extract<Result, { body: { error: string } }>
+      expectTypeOf<RangeEntry['statusCode']>().toEqualTypeOf<ClientErrorHttpStatusCode>()
+      // The default entry's statusCode must not include any 4xx code
+      type DefaultEntry = Extract<Result, { body: { message: string } }>
+      expectTypeOf<404 extends DefaultEntry['statusCode'] ? true : false>().toEqualTypeOf<false>()
+    })
+
+    it('exact code takes precedence over both range and default', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          404: z.object({ notFound: z.boolean() }),
+          '4xx': z.object({ error: z.string() }),
+          default: z.object({ message: z.string() }),
+        },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      // Exact 404 entry is a literal statusCode — Extract works correctly here
+      type At404 = Extract<Result, { statusCode: 404 }>
+      expectTypeOf<At404>().toEqualTypeOf<{
+        statusCode: 404
+        headers: DefaultHeaders
+        body: { notFound: boolean }
+      }>()
+      // The 4xx range entry excludes 404
+      type RangeEntry = Extract<Result, { body: { error: string } }>
+      expectTypeOf<404 extends RangeEntry['statusCode'] ? true : false>().toEqualTypeOf<false>()
+      // The default entry excludes all 4xx codes (covered by range) and 404 (exact)
+      type DefaultEntry = Extract<Result, { body: { message: string } }>
+      expectTypeOf<400 extends DefaultEntry['statusCode'] ? true : false>().toEqualTypeOf<false>()
+      expectTypeOf<404 extends DefaultEntry['statusCode'] ? true : false>().toEqualTypeOf<false>()
     })
   })
 

--- a/packages/app/api-contracts/src/new/clientTypes.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.ts
@@ -91,8 +91,8 @@ type WildcardNonSseBody<V, K extends WildcardStatusCodeKey> = K extends '2xx'
   : InferClientResponseBody<V>
 
 // Exact status codes explicitly defined in the contract — these take precedence over range keys.
-type ExactStatusCodes<TApiContract extends ApiContract> = keyof TApiContract['responsesByStatusCode'] &
-  HttpStatusCode
+type ExactStatusCodes<TApiContract extends ApiContract> =
+  keyof TApiContract['responsesByStatusCode'] & HttpStatusCode
 
 // Status codes covered by any range key (e.g. '2xx', '4xx') present in the contract.
 // These take precedence over 'default'.

--- a/packages/app/api-contracts/src/new/clientTypes.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.ts
@@ -91,43 +91,47 @@ type WildcardNonSseBody<V, K extends WildcardStatusCodeKey> = K extends '2xx'
 
 // 'default' is split into success and non-success parts so captureAsError typing stays accurate:
 // the success part ends up in Either.result, the non-success part in Either.error.
-type WildcardSseEntry<TApiContract extends ApiContract, K extends WildcardStatusCodeKey> =
-  K extends 'default'
-    ?
-        | {
-            statusCode: SuccessfulHttpStatusCode
-            headers: InferClientResponseHeaders<TApiContract>
-            body: SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-          }
-        | {
-            statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
-            headers: InferClientResponseHeaders<TApiContract>
-            body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-          }
-    : {
-        statusCode: ExpandStatusRangeKey<K>
-        headers: InferClientResponseHeaders<TApiContract>
-        body: WildcardSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
-      }
+type WildcardSseEntry<
+  TApiContract extends ApiContract,
+  K extends WildcardStatusCodeKey,
+> = K extends 'default'
+  ?
+      | {
+          statusCode: SuccessfulHttpStatusCode
+          headers: InferClientResponseHeaders<TApiContract>
+          body: SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+        }
+      | {
+          statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+          headers: InferClientResponseHeaders<TApiContract>
+          body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+        }
+  : {
+      statusCode: ExpandStatusRangeKey<K>
+      headers: InferClientResponseHeaders<TApiContract>
+      body: WildcardSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
+    }
 
-type WildcardNonSseEntry<TApiContract extends ApiContract, K extends WildcardStatusCodeKey> =
-  K extends 'default'
-    ?
-        | {
-            statusCode: SuccessfulHttpStatusCode
-            headers: InferClientResponseHeaders<TApiContract>
-            body: NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-          }
-        | {
-            statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
-            headers: InferClientResponseHeaders<TApiContract>
-            body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-          }
-    : {
-        statusCode: ExpandStatusRangeKey<K>
-        headers: InferClientResponseHeaders<TApiContract>
-        body: WildcardNonSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
-      }
+type WildcardNonSseEntry<
+  TApiContract extends ApiContract,
+  K extends WildcardStatusCodeKey,
+> = K extends 'default'
+  ?
+      | {
+          statusCode: SuccessfulHttpStatusCode
+          headers: InferClientResponseHeaders<TApiContract>
+          body: NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+        }
+      | {
+          statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+          headers: InferClientResponseHeaders<TApiContract>
+          body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+        }
+  : {
+      statusCode: ExpandStatusRangeKey<K>
+      headers: InferClientResponseHeaders<TApiContract>
+      body: WildcardNonSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
+    }
 
 /**
  * Infers a discriminated union of `{ statusCode, headers, body }` for SSE mode:
@@ -151,8 +155,10 @@ export type InferSseClientResponse<TApiContract extends ApiContract> =
       }
     }[keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]
   | {
-      [K in keyof TApiContract['responsesByStatusCode'] &
-        WildcardStatusCodeKey]: WildcardSseEntry<TApiContract, K>
+      [K in keyof TApiContract['responsesByStatusCode'] & WildcardStatusCodeKey]: WildcardSseEntry<
+        TApiContract,
+        K
+      >
     }[keyof TApiContract['responsesByStatusCode'] & WildcardStatusCodeKey]
 
 /**

--- a/packages/app/api-contracts/src/new/clientTypes.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.ts
@@ -1,6 +1,11 @@
 import type { z } from 'zod/v4'
 import type { InferSchemaInput, InferSchemaOutput } from '../apiContracts.ts'
-import type { HttpStatusCode, SuccessfulHttpStatusCode } from '../HttpStatusCodes.ts'
+import type {
+  ExpandStatusRangeKey,
+  HttpStatusCode,
+  SuccessfulHttpStatusCode,
+  WildcardStatusCodeKey,
+} from '../HttpStatusCodes.ts'
 import type { Prettify } from '../typeUtils.ts'
 import type { ContractNoBody } from './constants.ts'
 import type { ResponsesByStatusCode, SseSchemaByEventName } from './contractResponse.ts'
@@ -73,38 +78,105 @@ type SseInferClientResponseBody<T> = Extract<InferClientResponseBody<T>, AsyncIt
  */
 type NonSseInferClientResponseBody<T> = Exclude<InferClientResponseBody<T>, AsyncIterable<unknown>>
 
+// Body helpers for wildcard response keys.
+// '2xx' maps to success mode (SSE-filtered or non-SSE-filtered); all other ranges and 'default' use
+// the full body union since those entries are always on the error side of captureAsError.
+type WildcardSseBody<V, K extends WildcardStatusCodeKey> = K extends '2xx'
+  ? SseInferClientResponseBody<V>
+  : InferClientResponseBody<V>
+
+type WildcardNonSseBody<V, K extends WildcardStatusCodeKey> = K extends '2xx'
+  ? NonSseInferClientResponseBody<V>
+  : InferClientResponseBody<V>
+
+// 'default' is split into success and non-success parts so captureAsError typing stays accurate:
+// the success part ends up in Either.result, the non-success part in Either.error.
+type WildcardSseEntry<TApiContract extends ApiContract, K extends WildcardStatusCodeKey> =
+  K extends 'default'
+    ?
+        | {
+            statusCode: SuccessfulHttpStatusCode
+            headers: InferClientResponseHeaders<TApiContract>
+            body: SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+          }
+        | {
+            statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+            headers: InferClientResponseHeaders<TApiContract>
+            body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+          }
+    : {
+        statusCode: ExpandStatusRangeKey<K>
+        headers: InferClientResponseHeaders<TApiContract>
+        body: WildcardSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
+      }
+
+type WildcardNonSseEntry<TApiContract extends ApiContract, K extends WildcardStatusCodeKey> =
+  K extends 'default'
+    ?
+        | {
+            statusCode: SuccessfulHttpStatusCode
+            headers: InferClientResponseHeaders<TApiContract>
+            body: NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+          }
+        | {
+            statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+            headers: InferClientResponseHeaders<TApiContract>
+            body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+          }
+    : {
+        statusCode: ExpandStatusRangeKey<K>
+        headers: InferClientResponseHeaders<TApiContract>
+        body: WildcardNonSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
+      }
+
 /**
  * Infers a discriminated union of `{ statusCode, headers, body }` for SSE mode:
- * - success status codes → SSE body only (AsyncIterable)
- * - error status codes  → body as-is (all kinds)
+ * - exact success status codes and `'2xx'` range → SSE body only (AsyncIterable)
+ * - error status codes, other ranges, and `'default'` → body as-is (all kinds)
+ *
+ * `'default'` is split into a success half (`SuccessfulHttpStatusCode`) and a non-success half
+ * so that `captureAsError` type narrowing stays correct regardless of the actual status code.
  *
  * Headers are typed via `InferClientResponseHeaders`: known headers from `responseHeaderSchema`
  * are strongly typed; all other headers remain accessible as `string | undefined`.
  */
-export type InferSseClientResponse<TApiContract extends ApiContract> = {
-  [K in keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]: {
-    statusCode: K
-    headers: InferClientResponseHeaders<TApiContract>
-    body: K extends SuccessfulHttpStatusCode
-      ? SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-      : InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-  }
-}[keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]
+export type InferSseClientResponse<TApiContract extends ApiContract> =
+  | {
+      [K in keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]: {
+        statusCode: K
+        headers: InferClientResponseHeaders<TApiContract>
+        body: K extends SuccessfulHttpStatusCode
+          ? SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+          : InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+      }
+    }[keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]
+  | {
+      [K in keyof TApiContract['responsesByStatusCode'] &
+        WildcardStatusCodeKey]: WildcardSseEntry<TApiContract, K>
+    }[keyof TApiContract['responsesByStatusCode'] & WildcardStatusCodeKey]
 
 /**
  * Infers a discriminated union of `{ statusCode, headers, body }` for non-SSE mode:
- * - success status codes → non-SSE body only (JSON / text / blob / null)
- * - error status codes  → body as-is (all kinds)
+ * - exact success status codes and `'2xx'` range → non-SSE body only (JSON / text / blob / null)
+ * - error status codes, other ranges, and `'default'` → body as-is (all kinds)
+ *
+ * `'default'` is split into a success half (`SuccessfulHttpStatusCode`) and a non-success half
+ * so that `captureAsError` type narrowing stays correct regardless of the actual status code.
  *
  * Headers are typed via `InferClientResponseHeaders`: known headers from `responseHeaderSchema`
  * are strongly typed; all other headers remain accessible as `string | undefined`.
  */
-export type InferNonSseClientResponse<TApiContract extends ApiContract> = {
-  [K in keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]: {
-    statusCode: K
-    headers: InferClientResponseHeaders<TApiContract>
-    body: K extends SuccessfulHttpStatusCode
-      ? NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-      : InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
-  }
-}[keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]
+export type InferNonSseClientResponse<TApiContract extends ApiContract> =
+  | {
+      [K in keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]: {
+        statusCode: K
+        headers: InferClientResponseHeaders<TApiContract>
+        body: K extends SuccessfulHttpStatusCode
+          ? NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+          : InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
+      }
+    }[keyof TApiContract['responsesByStatusCode'] & HttpStatusCode]
+  | {
+      [K in keyof TApiContract['responsesByStatusCode'] &
+        WildcardStatusCodeKey]: WildcardNonSseEntry<TApiContract, K>
+    }[keyof TApiContract['responsesByStatusCode'] & WildcardStatusCodeKey]

--- a/packages/app/api-contracts/src/new/clientTypes.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.ts
@@ -79,9 +79,12 @@ type SseInferClientResponseBody<T> = Extract<InferClientResponseBody<T>, AsyncIt
  */
 type NonSseInferClientResponseBody<T> = Exclude<InferClientResponseBody<T>, AsyncIterable<unknown>>
 
-// Body helpers for wildcard response keys.
-// '2xx' maps to success mode (SSE-filtered or non-SSE-filtered); all other ranges and 'default' use
-// the full body union since those entries are always on the error side of captureAsError.
+// Body helpers for non-'default' wildcard range keys (e.g. '2xx', '4xx', '5xx').
+// '2xx' maps to success mode (SSE-filtered or non-SSE-filtered); all other ranges use the full body
+// union because non-2xx range entries always land on the error side of captureAsError.
+// 'default' does not use these helpers — it inlines its own body logic in WildcardSseEntry /
+// WildcardNonSseEntry, where the success half is still SSE/non-SSE filtered and the non-success
+// half uses the full body union.
 type WildcardSseBody<V, K extends WildcardStatusCodeKey> = K extends '2xx'
   ? SseInferClientResponseBody<V>
   : InferClientResponseBody<V>
@@ -100,28 +103,30 @@ type RangeStatusCodes<TApiContract extends ApiContract> = {
   [K in keyof TApiContract['responsesByStatusCode'] & HttpStatusCodeRange]: ExpandStatusRangeKey<K>
 }[keyof TApiContract['responsesByStatusCode'] & HttpStatusCodeRange]
 
-// 'default' is split into success and non-success parts so captureAsError typing stays accurate:
-// the success part ends up in Either.result, the non-success part in Either.error.
-// Exact codes are excluded from range/default statusCode unions so narrowing by an exact code
-// resolves only to the exact entry's body, not the range entry's body.
+// Status codes that fall through to 'default' — not claimed by any exact code or range key.
+// Split into success/non-success so captureAsError typing stays accurate: success lands in
+// Either.result, non-success lands in Either.error.
+type DefaultSuccessStatusCodes<TApiContract extends ApiContract> = Exclude<
+  SuccessfulHttpStatusCode,
+  ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
+>
+type DefaultNonSuccessStatusCodes<TApiContract extends ApiContract> = Exclude<
+  Exclude<HttpStatusCode, SuccessfulHttpStatusCode>,
+  ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
+>
+
 type WildcardSseEntry<
   TApiContract extends ApiContract,
   K extends WildcardStatusCodeKey,
 > = K extends 'default'
   ?
       | {
-          statusCode: Exclude<
-            SuccessfulHttpStatusCode,
-            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
-          >
+          statusCode: DefaultSuccessStatusCodes<TApiContract>
           headers: InferClientResponseHeaders<TApiContract>
           body: SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
       | {
-          statusCode: Exclude<
-            Exclude<HttpStatusCode, SuccessfulHttpStatusCode>,
-            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
-          >
+          statusCode: DefaultNonSuccessStatusCodes<TApiContract>
           headers: InferClientResponseHeaders<TApiContract>
           body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
@@ -137,18 +142,12 @@ type WildcardNonSseEntry<
 > = K extends 'default'
   ?
       | {
-          statusCode: Exclude<
-            SuccessfulHttpStatusCode,
-            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
-          >
+          statusCode: DefaultSuccessStatusCodes<TApiContract>
           headers: InferClientResponseHeaders<TApiContract>
           body: NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
       | {
-          statusCode: Exclude<
-            Exclude<HttpStatusCode, SuccessfulHttpStatusCode>,
-            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
-          >
+          statusCode: DefaultNonSuccessStatusCodes<TApiContract>
           headers: InferClientResponseHeaders<TApiContract>
           body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }

--- a/packages/app/api-contracts/src/new/clientTypes.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.ts
@@ -3,6 +3,7 @@ import type { InferSchemaInput, InferSchemaOutput } from '../apiContracts.ts'
 import type {
   ExpandStatusRangeKey,
   HttpStatusCode,
+  HttpStatusCodeRange,
   SuccessfulHttpStatusCode,
   WildcardStatusCodeKey,
 } from '../HttpStatusCodes.ts'
@@ -89,25 +90,43 @@ type WildcardNonSseBody<V, K extends WildcardStatusCodeKey> = K extends '2xx'
   ? NonSseInferClientResponseBody<V>
   : InferClientResponseBody<V>
 
+// Exact status codes explicitly defined in the contract — these take precedence over range keys.
+type ExactStatusCodes<TApiContract extends ApiContract> = keyof TApiContract['responsesByStatusCode'] &
+  HttpStatusCode
+
+// Status codes covered by any range key (e.g. '2xx', '4xx') present in the contract.
+// These take precedence over 'default'.
+type RangeStatusCodes<TApiContract extends ApiContract> = {
+  [K in keyof TApiContract['responsesByStatusCode'] & HttpStatusCodeRange]: ExpandStatusRangeKey<K>
+}[keyof TApiContract['responsesByStatusCode'] & HttpStatusCodeRange]
+
 // 'default' is split into success and non-success parts so captureAsError typing stays accurate:
 // the success part ends up in Either.result, the non-success part in Either.error.
+// Exact codes are excluded from range/default statusCode unions so narrowing by an exact code
+// resolves only to the exact entry's body, not the range entry's body.
 type WildcardSseEntry<
   TApiContract extends ApiContract,
   K extends WildcardStatusCodeKey,
 > = K extends 'default'
   ?
       | {
-          statusCode: SuccessfulHttpStatusCode
+          statusCode: Exclude<
+            SuccessfulHttpStatusCode,
+            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
+          >
           headers: InferClientResponseHeaders<TApiContract>
           body: SseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
       | {
-          statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+          statusCode: Exclude<
+            Exclude<HttpStatusCode, SuccessfulHttpStatusCode>,
+            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
+          >
           headers: InferClientResponseHeaders<TApiContract>
           body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
   : {
-      statusCode: ExpandStatusRangeKey<K>
+      statusCode: Exclude<ExpandStatusRangeKey<K>, ExactStatusCodes<TApiContract>>
       headers: InferClientResponseHeaders<TApiContract>
       body: WildcardSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
     }
@@ -118,17 +137,23 @@ type WildcardNonSseEntry<
 > = K extends 'default'
   ?
       | {
-          statusCode: SuccessfulHttpStatusCode
+          statusCode: Exclude<
+            SuccessfulHttpStatusCode,
+            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
+          >
           headers: InferClientResponseHeaders<TApiContract>
           body: NonSseInferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
       | {
-          statusCode: Exclude<HttpStatusCode, SuccessfulHttpStatusCode>
+          statusCode: Exclude<
+            Exclude<HttpStatusCode, SuccessfulHttpStatusCode>,
+            ExactStatusCodes<TApiContract> | RangeStatusCodes<TApiContract>
+          >
           headers: InferClientResponseHeaders<TApiContract>
           body: InferClientResponseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>>
         }
   : {
-      statusCode: ExpandStatusRangeKey<K>
+      statusCode: Exclude<ExpandStatusRangeKey<K>, ExactStatusCodes<TApiContract>>
       headers: InferClientResponseHeaders<TApiContract>
       body: WildcardNonSseBody<NonNullable<TApiContract['responsesByStatusCode'][K]>, K>
     }

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -349,6 +349,31 @@ describe('resolveResponseEntry', () => {
       ).toEqual({ kind: 'json', schema: exact })
     })
 
+    it('exact match is absolute: content-type mismatch on exact entry returns null without falling through to range', () => {
+      // The exact entry is a text/csv response; the server returns application/json.
+      // resolveContractResponse returns null for the exact entry, and the function must NOT
+      // fall through to the '2xx' range entry — exact match wins absolutely.
+      expect(
+        resolveResponseEntry(
+          { 200: textResponse('text/csv'), '2xx': z.object({ id: z.string() }) },
+          200,
+          'application/json',
+          true,
+        ),
+      ).toBeNull()
+    })
+
+    it('exact match is absolute: content-type mismatch on exact entry returns null without falling through to default', () => {
+      expect(
+        resolveResponseEntry(
+          { 200: textResponse('text/csv'), default: z.object({ id: z.string() }) },
+          200,
+          'application/json',
+          true,
+        ),
+      ).toBeNull()
+    })
+
     it('range key takes precedence over default', () => {
       const range = z.object({ message: z.string() })
       const def = z.object({ error: z.string() })

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -342,7 +342,9 @@ describe('resolveResponseEntry', () => {
     })
 
     it('returns null when range does not cover the status code', () => {
-      expect(resolveResponseEntry({ '2xx': z.object({}) }, 404, 'application/json', true)).toBeNull()
+      expect(
+        resolveResponseEntry({ '2xx': z.object({}) }, 404, 'application/json', true),
+      ).toBeNull()
     })
   })
 

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -408,6 +408,41 @@ describe('resolveResponseEntry', () => {
       ).toEqual({ kind: 'json', schema: range })
     })
 
+    it('multiple range keys each route correctly and default is not invoked for covered codes', () => {
+      const s4xx = z.object({ clientError: z.string() })
+      const s5xx = z.object({ serverError: z.string() })
+      const def = z.object({ fallback: z.string() })
+      const contract = { '4xx': s4xx, '5xx': s5xx, default: def }
+      // 4xx code → 4xx range
+      expect(resolveResponseEntry(contract, 404, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema: s4xx,
+      })
+      // 5xx code → 5xx range
+      expect(resolveResponseEntry(contract, 503, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema: s5xx,
+      })
+      // code not covered by either range → default
+      expect(resolveResponseEntry(contract, 304, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema: def,
+      })
+    })
+
+    it('2xx range takes precedence over default for success codes', () => {
+      const s2xx = z.object({ data: z.string() })
+      const def = z.object({ fallback: z.string() })
+      // success code → 2xx range, not default
+      expect(
+        resolveResponseEntry({ '2xx': s2xx, default: def }, 201, 'application/json', true),
+      ).toEqual({ kind: 'json', schema: s2xx })
+      // non-2xx code with no range → default
+      expect(
+        resolveResponseEntry({ '2xx': s2xx, default: def }, 404, 'application/json', true),
+      ).toEqual({ kind: 'json', schema: def })
+    })
+
     it('returns null when range does not cover the status code', () => {
       expect(
         resolveResponseEntry({ '2xx': z.object({}) }, 404, 'application/json', true),
@@ -450,6 +485,23 @@ describe('resolveResponseEntry', () => {
       expect(
         resolveResponseEntry({ 200: exact, default: def }, 200, 'application/json', true),
       ).toEqual({ kind: 'json', schema: exact })
+    })
+
+    it('resolves the correct kind from a composite default anyOfResponses entry by content-type', () => {
+      const jsonSchema = z.object({ id: z.string() })
+      const contract = {
+        default: anyOfResponses([sseResponse({ event: z.object({ id: z.string() }) }), jsonSchema]),
+      }
+      // application/json → JSON kind
+      expect(resolveResponseEntry(contract, 500, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema: jsonSchema,
+      })
+      // text/event-stream → SSE kind
+      expect(resolveResponseEntry(contract, 500, 'text/event-stream', true)).toEqual({
+        kind: 'sse',
+        schemaByEventName: { event: expect.any(Object) },
+      })
     })
   })
 })

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -287,4 +287,92 @@ describe('resolveResponseEntry', () => {
       kind: 'noContent',
     })
   })
+
+  describe('range key fallback', () => {
+    it('resolves via 2xx range for any success code', () => {
+      const schema = z.object({ id: z.string() })
+      expect(resolveResponseEntry({ '2xx': schema }, 200, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+      expect(resolveResponseEntry({ '2xx': schema }, 201, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
+    it('resolves via 4xx range for any client-error code', () => {
+      const schema = z.object({ message: z.string() })
+      expect(resolveResponseEntry({ '4xx': schema }, 404, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+      expect(resolveResponseEntry({ '4xx': schema }, 400, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
+    it('resolves via 5xx range for any server-error code', () => {
+      const schema = z.object({ error: z.string() })
+      expect(resolveResponseEntry({ '5xx': schema }, 500, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+      expect(resolveResponseEntry({ '5xx': schema }, 503, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
+    it('exact code takes precedence over range key', () => {
+      const exact = z.object({ id: z.string() })
+      const range = z.object({ message: z.string() })
+      expect(
+        resolveResponseEntry({ 200: exact, '2xx': range }, 200, 'application/json', true),
+      ).toEqual({ kind: 'json', schema: exact })
+    })
+
+    it('range key takes precedence over default', () => {
+      const range = z.object({ message: z.string() })
+      const def = z.object({ error: z.string() })
+      expect(
+        resolveResponseEntry({ '5xx': range, default: def }, 500, 'application/json', true),
+      ).toEqual({ kind: 'json', schema: range })
+    })
+
+    it('returns null when range does not cover the status code', () => {
+      expect(resolveResponseEntry({ '2xx': z.object({}) }, 404, 'application/json', true)).toBeNull()
+    })
+  })
+
+  describe('default fallback', () => {
+    it('resolves via default when no exact or range match', () => {
+      const schema = z.object({ error: z.string() })
+      expect(resolveResponseEntry({ default: schema }, 503, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
+    it('resolves via default for any status code when it is the only entry', () => {
+      const schema = z.object({ message: z.string() })
+      expect(resolveResponseEntry({ default: schema }, 200, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+      expect(resolveResponseEntry({ default: schema }, 404, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
+    it('exact code takes precedence over default', () => {
+      const exact = z.object({ id: z.string() })
+      const def = z.object({ error: z.string() })
+      expect(
+        resolveResponseEntry({ 200: exact, default: def }, 200, 'application/json', true),
+      ).toEqual({ kind: 'json', schema: exact })
+    })
+  })
 })

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -288,6 +288,32 @@ describe('resolveResponseEntry', () => {
     })
   })
 
+  describe('getRangeKey boundaries', () => {
+    const schema = z.object({ x: z.string() })
+    // Use a contract with all five range keys so a mismatch (null from getRangeKey) falls to null,
+    // and a match resolves to the schema with kind 'json'.
+    const allRanges = {
+      '1xx': schema,
+      '2xx': schema,
+      '3xx': schema,
+      '4xx': schema,
+      '5xx': schema,
+    }
+
+    it.each([
+      [99, null],
+      [100, { kind: 'json', schema }],
+      [199, { kind: 'json', schema }],
+      [200, { kind: 'json', schema }],
+      [299, { kind: 'json', schema }],
+      [300, { kind: 'json', schema }],
+      [599, { kind: 'json', schema }],
+      [600, null],
+    ])('status %i → %s', (statusCode, expected) => {
+      expect(resolveResponseEntry(allRanges, statusCode, 'application/json', true)).toEqual(expected)
+    })
+  })
+
   describe('range key fallback', () => {
     it('resolves via 2xx range for any success code', () => {
       const schema = z.object({ id: z.string() })

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -310,7 +310,9 @@ describe('resolveResponseEntry', () => {
       [599, { kind: 'json', schema }],
       [600, null],
     ])('status %i → %s', (statusCode, expected) => {
-      expect(resolveResponseEntry(allRanges, statusCode, 'application/json', true)).toEqual(expected)
+      expect(resolveResponseEntry(allRanges, statusCode, 'application/json', true)).toEqual(
+        expected,
+      )
     })
   })
 

--- a/packages/app/api-contracts/src/new/contractResponse.spec.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.spec.ts
@@ -301,6 +301,22 @@ describe('resolveResponseEntry', () => {
       })
     })
 
+    it('resolves via 1xx range for any informational code', () => {
+      const schema = z.object({ info: z.string() })
+      expect(resolveResponseEntry({ '1xx': schema }, 100, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
+    it('resolves via 3xx range for any redirect code', () => {
+      const schema = z.object({ location: z.string() })
+      expect(resolveResponseEntry({ '3xx': schema }, 301, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
+    })
+
     it('resolves via 4xx range for any client-error code', () => {
       const schema = z.object({ message: z.string() })
       expect(resolveResponseEntry({ '4xx': schema }, 404, 'application/json', true)).toEqual({
@@ -345,6 +361,14 @@ describe('resolveResponseEntry', () => {
       expect(
         resolveResponseEntry({ '2xx': z.object({}) }, 404, 'application/json', true),
       ).toBeNull()
+    })
+
+    it('falls through to default when status code is outside all ranges', () => {
+      const schema = z.object({ error: z.string() })
+      expect(resolveResponseEntry({ default: schema }, 0, 'application/json', true)).toEqual({
+        kind: 'json',
+        schema,
+      })
     })
   })
 

--- a/packages/app/api-contracts/src/new/contractResponse.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.ts
@@ -1,5 +1,9 @@
 import type { z } from 'zod/v4'
-import type { HttpStatusCode, HttpStatusCodeRange, WildcardStatusCodeKey } from '../HttpStatusCodes.ts'
+import type {
+  HttpStatusCode,
+  HttpStatusCodeRange,
+  WildcardStatusCodeKey,
+} from '../HttpStatusCodes.ts'
 import { ContractNoBody } from './constants.ts'
 
 export type ResponseOptions = {

--- a/packages/app/api-contracts/src/new/contractResponse.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.ts
@@ -1,5 +1,5 @@
 import type { z } from 'zod/v4'
-import type { HttpStatusCode } from '../HttpStatusCodes.ts'
+import type { HttpStatusCode, HttpStatusCodeRange, WildcardStatusCodeKey } from '../HttpStatusCodes.ts'
 import { ContractNoBody } from './constants.ts'
 
 export type ResponseOptions = {
@@ -110,7 +110,9 @@ export type ApiContractResponse =
   | TypedApiContractResponse
   | AnyOfResponses
 
-export type ResponsesByStatusCode = Partial<Record<HttpStatusCode, ApiContractResponse>>
+export type ResponsesByStatusCode = Partial<
+  Record<HttpStatusCode | WildcardStatusCodeKey, ApiContractResponse>
+>
 
 export type ResponseKind =
   | { kind: 'noContent' }
@@ -206,9 +208,19 @@ export const resolveContractResponse = (
   return matched ?? (strict ? null : resolveByKind(schemaEntry))
 }
 
+function getRangeKey(statusCode: number): HttpStatusCodeRange | null {
+  if (statusCode >= 100 && statusCode < 200) return '1xx'
+  if (statusCode >= 200 && statusCode < 300) return '2xx'
+  if (statusCode >= 300 && statusCode < 400) return '3xx'
+  if (statusCode >= 400 && statusCode < 500) return '4xx'
+  if (statusCode >= 500 && statusCode < 600) return '5xx'
+  return null
+}
+
 /**
  * Combines status-code lookup and content-type resolution into a single call.
- * Returns `null` when the status code is not in the contract or the content-type cannot be matched.
+ * Lookup precedence: exact code → range key (e.g. `'4xx'`) → `'default'`.
+ * Returns `null` when no entry matches or the content-type cannot be matched.
  */
 export function resolveResponseEntry(
   responsesByStatusCode: ResponsesByStatusCode,
@@ -216,11 +228,23 @@ export function resolveResponseEntry(
   contentType: string | undefined,
   strictContentType: boolean,
 ): ResponseKind | null {
-  const schemaEntry = responsesByStatusCode[statusCode as HttpStatusCode]
-
-  if (!schemaEntry) {
-    return null
+  const exactEntry = responsesByStatusCode[statusCode as HttpStatusCode]
+  if (exactEntry) {
+    return resolveContractResponse(exactEntry, contentType, strictContentType)
   }
 
-  return resolveContractResponse(schemaEntry, contentType, strictContentType)
+  const rangeKey = getRangeKey(statusCode)
+  if (rangeKey) {
+    const rangeEntry = responsesByStatusCode[rangeKey]
+    if (rangeEntry) {
+      return resolveContractResponse(rangeEntry, contentType, strictContentType)
+    }
+  }
+
+  const defaultEntry = responsesByStatusCode['default']
+  if (defaultEntry) {
+    return resolveContractResponse(defaultEntry, contentType, strictContentType)
+  }
+
+  return null
 }

--- a/packages/app/api-contracts/src/new/defineApiContract.spec.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.spec.ts
@@ -548,6 +548,28 @@ describe('hasAnySuccessSseResponse', () => {
 
     expect(hasAnySuccessSseResponse(route)).toBe(false)
   })
+
+  it('returns true for sseResponse under the default key', () => {
+    const route = defineApiContract({
+      method: 'get',
+      pathResolver: () => '/stream',
+      responsesByStatusCode: {
+        default: sseResponse({ chunk: z.object({ delta: z.string() }) }),
+      },
+    })
+
+    expect(hasAnySuccessSseResponse(route)).toBe(true)
+  })
+
+  it('returns false for non-SSE response under the default key', () => {
+    const route = defineApiContract({
+      method: 'get',
+      pathResolver: () => '/users',
+      responsesByStatusCode: { default: z.object({ message: z.string() }) },
+    })
+
+    expect(hasAnySuccessSseResponse(route)).toBe(false)
+  })
 })
 
 describe('getIsEmptyResponseExpected with SSE', () => {

--- a/packages/app/api-contracts/src/new/defineApiContract.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.ts
@@ -110,7 +110,7 @@ export const getSseSchemaByEventName = (routeConfig: ApiContract): SseSchemaByEv
 }
 
 export const hasAnySuccessSseResponse = (apiContract: ApiContract): boolean => {
-  for (const code of SUCCESSFUL_HTTP_STATUS_CODES) {
+  for (const code of [...SUCCESSFUL_HTTP_STATUS_CODES, '2xx' as const]) {
     const value = apiContract.responsesByStatusCode[code]
 
     if (!value) {

--- a/packages/app/api-contracts/src/new/defineApiContract.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.ts
@@ -110,7 +110,7 @@ export const getSseSchemaByEventName = (routeConfig: ApiContract): SseSchemaByEv
 }
 
 export const hasAnySuccessSseResponse = (apiContract: ApiContract): boolean => {
-  for (const code of [...SUCCESSFUL_HTTP_STATUS_CODES, '2xx' as const]) {
+  for (const code of [...SUCCESSFUL_HTTP_STATUS_CODES, '2xx' as const, 'default' as const]) {
     const value = apiContract.responsesByStatusCode[code]
 
     if (!value) {

--- a/packages/app/api-contracts/src/new/inferTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.spec.ts
@@ -189,6 +189,28 @@ describe('inferTypes', () => {
       type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<Result>().toEqualTypeOf<false>()
     })
+
+    it('returns true for sseResponse under the default key', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          default: sseResponse({ chunk: z.object({ delta: z.string() }) }),
+        },
+      })
+      type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns false for non-SSE response under the default key', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { default: z.object({ message: z.string() }) },
+      })
+      type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
   })
 
   describe('InferSseSuccessResponses', () => {

--- a/packages/app/api-contracts/src/new/inferTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.spec.ts
@@ -165,6 +165,30 @@ describe('inferTypes', () => {
       type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<Result>().toEqualTypeOf<false>()
     })
+
+    it('returns true for sseResponse under the 2xx range key', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          '2xx': sseResponse({ chunk: z.object({ delta: z.string() }) }),
+        },
+      })
+      type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns false for sseResponse under a non-success range key', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          '4xx': sseResponse({ chunk: z.object({ delta: z.string() }) }),
+        },
+      })
+      type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
   })
 
   describe('InferSseSuccessResponses', () => {

--- a/packages/app/api-contracts/src/new/inferTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.spec.ts
@@ -4,9 +4,14 @@ import { ContractNoBody } from './constants.ts'
 import { anyOfResponses, blobResponse, sseResponse, textResponse } from './contractResponse.ts'
 import { defineApiContract } from './defineApiContract.ts'
 import type {
+  AvailableResponseModes,
+  ContractResponseMode,
+  HasAnyJsonSuccessResponse,
   HasAnySseSuccessResponse,
   InferJsonSuccessResponses,
+  InferNonSseSuccessResponses,
   InferSseSuccessResponses,
+  IsNoBodySuccessResponse,
 } from './inferTypes.ts'
 
 describe('inferTypes', () => {
@@ -93,6 +98,17 @@ describe('inferTypes', () => {
       })
       type Result = InferJsonSuccessResponses<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<Result>().toEqualTypeOf<typeof jsonSchema>()
+    })
+
+    it('extracts JSON schema from the 2xx range key', () => {
+      const schema = z.object({ id: z.string() })
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': schema },
+      })
+      type Result = InferJsonSuccessResponses<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<typeof schema>()
     })
   })
 
@@ -210,6 +226,231 @@ describe('inferTypes', () => {
       })
       type Result = HasAnySseSuccessResponse<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
+  })
+
+  describe('IsNoBodySuccessResponse', () => {
+    it('returns true when all success responses are ContractNoBody', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 204: ContractNoBody },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns false when a success response has a JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
+
+    it('returns true for 2xx: ContractNoBody', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': ContractNoBody },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns false for 2xx: JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ id: z.string() }) },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
+  })
+
+  describe('HasAnyJsonSuccessResponse', () => {
+    it('returns true for a JSON schema at an exact success code', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+      })
+      type Result = HasAnyJsonSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns false for SSE-only response', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = HasAnyJsonSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
+
+    it('returns true for 2xx: JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ id: z.string() }) },
+      })
+      type Result = HasAnyJsonSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns false for 2xx: sseResponse', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = HasAnyJsonSuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
+  })
+
+  describe('InferNonSseSuccessResponses', () => {
+    it('returns the output type of a JSON success schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+      })
+      type Result = InferNonSseSuccessResponses<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<{ id: string }>()
+    })
+
+    it('returns never for SSE-only response', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = InferNonSseSuccessResponses<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<never>()
+    })
+
+    it('returns the output type for 2xx: JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ id: z.string() }) },
+      })
+      type Result = InferNonSseSuccessResponses<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<{ id: string }>()
+    })
+
+    it('returns never for 2xx: sseResponse', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = InferNonSseSuccessResponses<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<never>()
+    })
+  })
+
+  describe('ContractResponseMode', () => {
+    it('returns non-sse for a JSON-only contract', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+      })
+      type Result = ContractResponseMode<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'non-sse'>()
+    })
+
+    it('returns sse for an SSE-only contract', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = ContractResponseMode<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'sse'>()
+    })
+
+    it('returns sse for 2xx: sseResponse', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = ContractResponseMode<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'sse'>()
+    })
+
+    it('returns non-sse for 2xx: JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ id: z.string() }) },
+      })
+      type Result = ContractResponseMode<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'non-sse'>()
+    })
+
+    it('returns dual for 2xx: anyOfResponses with SSE and JSON', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          '2xx': anyOfResponses([
+            sseResponse({ chunk: z.object({ delta: z.string() }) }),
+            z.object({ id: z.string() }),
+          ]),
+        },
+      })
+      type Result = ContractResponseMode<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'dual'>()
+    })
+  })
+
+  describe('AvailableResponseModes', () => {
+    it('includes json for a JSON success response', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+      })
+      type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'json'>()
+    })
+
+    it('includes sse for an SSE-only response', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'sse'>()
+    })
+
+    it('includes json for 2xx: JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': z.object({ id: z.string() }) },
+      })
+      type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'json'>()
+    })
+
+    it('includes sse for 2xx: sseResponse', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { '2xx': sseResponse({ chunk: z.object({ delta: z.string() }) }) },
+      })
+      type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'sse'>()
     })
   })
 

--- a/packages/app/api-contracts/src/new/inferTypes.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.ts
@@ -6,7 +6,7 @@ import type { ResponsesByStatusCode } from './contractResponse.ts'
 
 type ExtractSuccessResponses<T extends ResponsesByStatusCode> = ValueOf<
   T,
-  Extract<keyof T, SuccessfulHttpStatusCode | '2xx'>
+  Extract<keyof T, SuccessfulHttpStatusCode | '2xx' | 'default'>
 >
 
 /**

--- a/packages/app/api-contracts/src/new/inferTypes.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.ts
@@ -6,7 +6,7 @@ import type { ResponsesByStatusCode } from './contractResponse.ts'
 
 type ExtractSuccessResponses<T extends ResponsesByStatusCode> = ValueOf<
   T,
-  Extract<keyof T, SuccessfulHttpStatusCode>
+  Extract<keyof T, SuccessfulHttpStatusCode | '2xx'>
 >
 
 /**

--- a/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.ts
@@ -38,7 +38,7 @@ export function buildFastifyRouteHandler<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
+    | Partial<Record<HttpStatusCode, z.Schema>>
     | undefined = undefined,
 >(
   apiContract: GetRouteDefinition<
@@ -67,7 +67,7 @@ export function buildFastifyRouteHandler<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
+    | Partial<Record<HttpStatusCode, z.Schema>>
     | undefined = undefined,
 >(
   apiContract: DeleteRouteDefinition<
@@ -99,7 +99,7 @@ export function buildFastifyRouteHandler<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
+    | Partial<Record<HttpStatusCode, z.Schema>>
     | undefined = undefined,
 >(
   apiContract: PayloadRouteDefinition<
@@ -151,7 +151,7 @@ export function buildFastifyRoute<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
+    | Partial<Record<HttpStatusCode, z.Schema>>
     | undefined = undefined,
 >(
   apiContract: GetRouteDefinition<
@@ -187,7 +187,7 @@ export function buildFastifyRoute<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
+    | Partial<Record<HttpStatusCode, z.Schema>>
     | undefined = undefined,
 >(
   apiContract: DeleteRouteDefinition<
@@ -226,7 +226,7 @@ export function buildFastifyRoute<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
+    | Partial<Record<HttpStatusCode, z.Schema>>
     | undefined = undefined,
 >(
   apiContract: PayloadRouteDefinition<

--- a/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.ts
@@ -38,7 +38,7 @@ export function buildFastifyRouteHandler<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
+    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
     | undefined = undefined,
 >(
   apiContract: GetRouteDefinition<
@@ -67,7 +67,7 @@ export function buildFastifyRouteHandler<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
+    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
     | undefined = undefined,
 >(
   apiContract: DeleteRouteDefinition<
@@ -99,7 +99,7 @@ export function buildFastifyRouteHandler<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
+    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
     | undefined = undefined,
 >(
   apiContract: PayloadRouteDefinition<
@@ -151,7 +151,7 @@ export function buildFastifyRoute<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
+    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
     | undefined = undefined,
 >(
   apiContract: GetRouteDefinition<
@@ -187,7 +187,7 @@ export function buildFastifyRoute<
   RequestHeaderSchema extends OptionalZodSchema = undefined,
   ResponseHeaderSchema extends OptionalZodSchema = undefined,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
+    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
     | undefined = undefined,
 >(
   apiContract: DeleteRouteDefinition<
@@ -226,7 +226,7 @@ export function buildFastifyRoute<
   IsNonJSONResponseExpected extends boolean = false,
   IsEmptyResponseExpected extends boolean = false,
   ResponseSchemasByStatusCode extends
-    | Partial<Record<HttpStatusCode, z.Schema>>
+    | Partial<Record<HttpStatusCode | '1xx' | '2xx' | '3xx' | '4xx' | '5xx' | 'default', z.Schema>>
     | undefined = undefined,
 >(
   apiContract: PayloadRouteDefinition<


### PR DESCRIPTION
## Changes

  - Add `WildcardStatusCodeKey` (`'1xx'`–`'5xx'` and `'default'`) as valid keys in `responsesByStatusCode`, matching OpenAPI / Fastify conventions
  - `resolveResponseEntry` now resolves with precedence: exact code → range key → `'default'`
  - `'2xx'` range participates in SSE-mode detection (`hasAnySuccessSseResponse`) and in `InferSseClientResponse` / `InferNonSseClientResponse` success-side type narrowing the same way explicit 2xx
  codes do
  - `'default'` is split into a `SuccessfulHttpStatusCode` half and a `Exclude<HttpStatusCode, SuccessfulHttpStatusCode>` half so `captureAsError` type narrowing stays accurate

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
