### PR TITLE
fix: add missing publush command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
+          publish: pnpm run ci:publish
           title: "Release Packages"
           commit: "chore: update versions"
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:ci": "turbo run test:ci",
     "lint": "turbo run lint --continue=always",
     "lint:fix": "turbo run lint:fix --continue=always",
-    "changeset": "changeset"
+    "changeset": "changeset",
+    "ci:publish": "turbo run build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",


### PR DESCRIPTION
## Changes

This PR adds missing changeset publish command.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [ ] **Yes, AI assisted with this PR**
- [x] **No, AI did not assist with this PR**
