### PR TITLE
feat(backend-http-client): add delay builders

### DIFF
--- a/.changeset/backend-http-client-delay-builders.md
+++ b/.changeset/backend-http-client-delay-builders.md
@@ -2,4 +2,4 @@
 "@lokalise/backend-http-client": minor
 ---
 
-Add createConstantDelay, createLinearDelay, and createExponentialDelay helpers for composing RetryConfig delay functions.
+Add constantDelay, linearDelay, and exponentialDelay helpers for composing RetryConfig delay functions.

--- a/.changeset/backend-http-client-delay-builders.md
+++ b/.changeset/backend-http-client-delay-builders.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/backend-http-client": minor
+---
+
+Add createConstantDelay, createLinearDelay, and createExponentialDelay helpers for composing RetryConfig delay functions.

--- a/packages/app/backend-http-client/README.md
+++ b/packages/app/backend-http-client/README.md
@@ -363,6 +363,28 @@ retry: { delay: () => 200 }
 retry: { delay: (n) => 300 * 2 ** (n - 1) }
 ```
 
+Three built-in delay builders are exported for common strategies:
+
+```ts
+import { constantDelay, linearDelay, exponentialDelay } from '@lokalise/backend-http-client'
+
+// constant — always 200 ms
+retry: { delay: constantDelay({ baseDelayMs: 200 }) }
+// attempt 1 → 200 ms, attempt 2 → 200 ms, …
+
+// linear — grows by baseDelayMs each attempt
+retry: { delay: linearDelay({ baseDelayMs: 100 }) }
+// attempt 1 → 100 ms, attempt 2 → 200 ms, attempt 3 → 300 ms, …
+
+// exponential — doubles by default (multiplier defaults to 2)
+retry: { delay: exponentialDelay({ baseDelayMs: 100 }) }
+// attempt 1 → 100 ms, attempt 2 → 200 ms, attempt 3 → 400 ms, …
+
+// exponential with custom multiplier
+retry: { delay: exponentialDelay({ baseDelayMs: 100, multiplier: 3 }) }
+// attempt 1 → 100 ms, attempt 2 → 300 ms, attempt 3 → 900 ms, …
+```
+
 `maxDelay` caps the final delay for any retry, including `Retry-After` values. Default: `30_000`.
 
 `maxJitter` adds up to this many milliseconds of random jitter on top of any delay, including `Retry-After` values, to spread out concurrent retries. Default: `100`.

--- a/packages/app/backend-http-client/src/api-contract/delayBuilders.spec.ts
+++ b/packages/app/backend-http-client/src/api-contract/delayBuilders.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { constantDelay, exponentialDelay, linearDelay } from './delayBuilders.ts'
+
+describe('delayBuilders', () => {
+  describe('constantDelay', () => {
+    it('always returns the base delay regardless of attempt number', () => {
+      const delay = constantDelay({ baseDelayMs: 200 })
+      expect(delay(1)).toBe(200)
+      expect(delay(2)).toBe(200)
+    })
+  })
+
+  describe('linearDelay', () => {
+    it('returns attempt * base delay', () => {
+      const delay = linearDelay({ baseDelayMs: 100 })
+      expect(delay(1)).toBe(100)
+      expect(delay(2)).toBe(200)
+      expect(delay(3)).toBe(300)
+    })
+  })
+
+  describe('exponentialDelay', () => {
+    it('returns base * 2^(attempt-1) by default', () => {
+      const delay = exponentialDelay({ baseDelayMs: 100 })
+      expect(delay(1)).toBe(100)
+      expect(delay(2)).toBe(200)
+      expect(delay(3)).toBe(400)
+    })
+
+    it('uses custom multiplier when provided', () => {
+      const delay = exponentialDelay({ baseDelayMs: 100, multiplier: 3 })
+      expect(delay(1)).toBe(100)
+      expect(delay(2)).toBe(300)
+      expect(delay(3)).toBe(900)
+    })
+  })
+})

--- a/packages/app/backend-http-client/src/api-contract/delayBuilders.ts
+++ b/packages/app/backend-http-client/src/api-contract/delayBuilders.ts
@@ -1,0 +1,40 @@
+import type { RetryDelay } from './retry.ts'
+
+export type ConstantDelayOptions = {
+  /** Fixed delay in milliseconds returned for every retry attempt. */
+  baseDelayMs: number
+}
+
+/** Returns a delay function that always returns the same fixed delay, regardless of the retry attempt number. */
+export const constantDelay =
+  ({ baseDelayMs }: ConstantDelayOptions): RetryDelay =>
+  (_attemptsMade) =>
+    baseDelayMs
+
+export type LinearDelayOptions = {
+  /** Base delay in milliseconds. The delay grows as `attempt * baseDelayMs`. */
+  baseDelayMs: number
+}
+
+/** Returns a delay function that grows linearly with the retry attempt number: `attempt * baseDelayMs`. */
+export const linearDelay =
+  ({ baseDelayMs }: LinearDelayOptions): RetryDelay =>
+  (attemptsMade) =>
+    attemptsMade * baseDelayMs
+
+export type ExponentialDelayOptions = {
+  /** Base delay in milliseconds. The delay grows as `baseDelayMs * multiplier^(attempt - 1)`. */
+  baseDelayMs: number
+  /**
+   * Growth rate of the backoff. Each retry multiplies the previous delay by this value.
+   *
+   * @default 2
+   */
+  multiplier?: number
+}
+
+/** Returns a delay function that grows exponentially with the retry attempt number: `baseDelayMs * multiplier^(attempt - 1)`. */
+export const exponentialDelay =
+  ({ baseDelayMs, multiplier = 2 }: ExponentialDelayOptions): RetryDelay =>
+  (attemptsMade) =>
+    baseDelayMs * multiplier ** (attemptsMade - 1)

--- a/packages/app/backend-http-client/src/api-contract/retry.ts
+++ b/packages/app/backend-http-client/src/api-contract/retry.ts
@@ -11,6 +11,8 @@
 import { setTimeout as setTimeoutPromise } from 'node:timers/promises'
 import type { Dispatcher } from 'undici'
 
+export type RetryDelay = (retryNumber: number) => number
+
 export type RetryConfig = {
   /**
    * Maximum number of retries after the initial attempt.
@@ -35,7 +37,7 @@ export type RetryConfig = {
    *
    * @default (n) => 100 * 2 ** (n - 1) — exponential backoff: 100 ms, 200 ms, 400 ms, …
    */
-  delay?: (retryNumber: number) => number
+  delay?: RetryDelay
 
   /**
    * Hard upper bound in milliseconds for any delay, including `Retry-After` values.

--- a/packages/app/backend-http-client/src/index.ts
+++ b/packages/app/backend-http-client/src/index.ts
@@ -1,4 +1,14 @@
-export type { RetryConfig } from './api-contract/retry.ts'
+export {
+  constantDelay,
+  exponentialDelay,
+  linearDelay,
+} from './api-contract/delayBuilders.ts'
+export type {
+  ConstantDelayOptions,
+  ExponentialDelayOptions,
+  LinearDelayOptions,
+} from './api-contract/delayBuilders.ts'
+export type { RetryConfig, RetryDelay } from './api-contract/retry.ts'
 export type { ContractRequestOptions } from './api-contract/sendByApiContract.ts'
 export { sendByApiContract } from './api-contract/sendByApiContract.ts'
 export { UnexpectedResponseError } from './api-contract/UnexpectedResponseError.ts'

--- a/packages/app/backend-http-client/src/index.ts
+++ b/packages/app/backend-http-client/src/index.ts
@@ -1,12 +1,12 @@
-export {
-  constantDelay,
-  exponentialDelay,
-  linearDelay,
-} from './api-contract/delayBuilders.ts'
 export type {
   ConstantDelayOptions,
   ExponentialDelayOptions,
   LinearDelayOptions,
+} from './api-contract/delayBuilders.ts'
+export {
+  constantDelay,
+  exponentialDelay,
+  linearDelay,
 } from './api-contract/delayBuilders.ts'
 export type { RetryConfig, RetryDelay } from './api-contract/retry.ts'
 export type { ContractRequestOptions } from './api-contract/sendByApiContract.ts'


### PR DESCRIPTION
## Changes

  - Add constantDelay, linearDelay, and exponentialDelay factory functions for composing RetryConfig.delay without writing the formula by hand
  - exponentialDelay accepts an optional multiplier (default 2) to control the growth rate
  - Export a shared RetryDelay type (renamed from RetryDelayFunction) used by all three builders and by RetryConfig.delay
  - Document all three builders with examples in the README under "Delay and backoff"

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
