### PR TITLE
Add support for wildcard status in testing utils

### DIFF
--- a/.changeset/universal-testing-utils-range-response-types.md
+++ b/.changeset/universal-testing-utils-range-response-types.md
@@ -1,0 +1,7 @@
+---
+"@lokalise/universal-testing-utils": minor
+---
+
+`MockResponseParams` now accepts any concrete numeric status code covered by a contract's range key ('2xx', '4xx', 'default', …). `ApiContractMockttpHelper.mockResponse` resolves the contract entry with exact → range → 'default' precedence, mirroring the runtime lookup in `api-contracts`. Also handles `NoBodyResponse` (new in `api-contracts@6.13.0`) alongside `ContractNoBody`.
+
+Bumps minimum peer dependency to `@lokalise/api-contracts@6.13.0`.

--- a/packages/app/universal-testing-utils/package.json
+++ b/packages/app/universal-testing-utils/package.json
@@ -45,14 +45,14 @@
         "postversion": "biome check --write package.json"
     },
     "peerDependencies": {
-        "@lokalise/api-contracts": ">=6.6.0",
+        "@lokalise/api-contracts": ">=6.13.0",
         "mockttp": ">=4.2.1",
         "msw": ">=2.7.0",
         "zod": ">=3.25.56"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.3.7",
-        "@lokalise/api-contracts": "^6.6.0",
+        "@lokalise/api-contracts": "^6.13.0",
         "@lokalise/biome-config": "^3.1.0",
         "@lokalise/frontend-http-client": "*",
         "@lokalise/tsconfig": "^4.0.0",

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
@@ -3,22 +3,29 @@ import { getLocal } from 'mockttp'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import wretch from 'wretch'
 import {
+  anyOfTextResponsesApiContract,
+  blobResponseApiContract,
   deleteApiContractWithNoBodyResponse,
   dualModeApiContract,
   dualModeApiContractWithPathParams,
   getApiContract,
   getApiContractWith2xxRange,
+  getApiContractWith4xxRange,
+  getApiContractWith5xxRange,
   getApiContractWithDefault,
   getApiContractWithExactAndRange,
   getApiContractWithPathAndQueryParams,
   getApiContractWithPathParams,
   getApiContractWithQueryParams,
   noBodyApiContract,
+  patchApiContract,
   postApiContract,
   postApiContractWithPathParams,
+  putApiContract,
   sseGetApiContract,
   sseGetApiContractWithPathParams,
   sseGetApiContractWithQueryParams,
+  textResponseApiContract,
 } from '../../test/testApiContracts.ts'
 import { ApiContractMockttpHelper } from './ApiContractMockttpHelper.ts'
 
@@ -262,6 +269,81 @@ describe('ApiContractMockttpHelper', () => {
       await helper.mockResponse(deleteApiContractWithNoBodyResponse, { responseStatus: 204 })
       const response = await client().url('/no-body').delete().res()
       expect(response.status).toBe(204)
+    })
+  })
+
+  describe('mockResponse — HTTP methods', () => {
+    it('mocks PATCH request', async () => {
+      await helper.mockResponse(patchApiContract, {
+        responseStatus: 200,
+        responseJson: { id: '1' },
+      })
+      const result = await sendByApiContract(client(), patchApiContract, { body: { name: 'test' } })
+      expect(result.result?.body).toEqual({ id: '1' })
+    })
+
+    it('mocks PUT request', async () => {
+      await helper.mockResponse(putApiContract, { responseStatus: 200, responseJson: { id: '2' } })
+      const result = await sendByApiContract(client(), putApiContract, { body: { name: 'test' } })
+      expect(result.result?.body).toEqual({ id: '2' })
+    })
+  })
+
+  describe('mockResponse — non-JSON response types', () => {
+    it('mocks text response', async () => {
+      await helper.mockResponse(textResponseApiContract, {
+        responseStatus: 200,
+        responseText: 'hello world',
+      })
+      const response = await client().url('/text').get().res()
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('text/plain')
+      expect(await response.text()).toBe('hello world')
+    })
+
+    it('mocks blob response', async () => {
+      await helper.mockResponse(blobResponseApiContract, {
+        responseStatus: 200,
+        responseBlob: 'binary-data',
+      })
+      const response = await client().url('/blob').get().res()
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe('application/octet-stream')
+    })
+
+    it('replies with status only when anyOfResponses has no SSE or JSON entry', async () => {
+      await helper.mockResponse(anyOfTextResponsesApiContract, { responseStatus: 200 })
+      const response = await client().url('/any-of-text').get().res()
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe('mockResponse — error handling', () => {
+    it('throws when responseStatus cannot be mapped with contract', async () => {
+      await expect(
+        // @ts-expect-error testing runtime error path with status code not in contract
+        helper.mockResponse(getApiContract, { responseStatus: 999, responseJson: { id: 'x' } }),
+      ).rejects.toThrow('Specified responseStatus cannot be mapped with contract')
+    })
+  })
+
+  describe('mockResponse — extended range / wildcard status key fallback', () => {
+    it('resolves response entry via 4xx range key', async () => {
+      await helper.mockResponse(getApiContractWith4xxRange, {
+        responseStatus: 404,
+        responseJson: { id: 'not-found' },
+      })
+      const response = await fetch(`${mockServer.url}/not-found`)
+      expect(response.status).toBe(404)
+    })
+
+    it('resolves response entry via 5xx range key', async () => {
+      await helper.mockResponse(getApiContractWith5xxRange, {
+        responseStatus: 503,
+        responseJson: { id: 'error' },
+      })
+      const response = await fetch(`${mockServer.url}/server-error`)
+      expect(response.status).toBe(503)
     })
   })
 })

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
@@ -3,9 +3,13 @@ import { getLocal } from 'mockttp'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import wretch from 'wretch'
 import {
+  deleteApiContractWithNoBodyResponse,
   dualModeApiContract,
   dualModeApiContractWithPathParams,
   getApiContract,
+  getApiContractWith2xxRange,
+  getApiContractWithDefault,
+  getApiContractWithExactAndRange,
   getApiContractWithPathAndQueryParams,
   getApiContractWithPathParams,
   getApiContractWithQueryParams,
@@ -212,6 +216,52 @@ describe('ApiContractMockttpHelper', () => {
         streaming: false,
       })
       expect(result.result?.body).toEqual({ id: '2' })
+    })
+  })
+
+  describe('mockResponse — range / wildcard status key fallback', () => {
+    it('resolves response entry via range key when exact code is absent', async () => {
+      await helper.mockResponse(getApiContractWith2xxRange, {
+        responseStatus: 201,
+        responseJson: { id: '42' },
+      })
+      const result = await sendByApiContract(client(), getApiContractWith2xxRange, {})
+      expect(result.result?.body).toEqual({ id: '42' })
+    })
+
+    it('resolves response entry via default key when no exact or range key matches', async () => {
+      await helper.mockResponse(getApiContractWithDefault, {
+        responseStatus: 200,
+        responseJson: { id: '7' },
+      })
+      const result = await sendByApiContract(client(), getApiContractWithDefault, {})
+      expect(result.result?.body).toEqual({ id: '7' })
+    })
+
+    it('exact key takes priority over range key', async () => {
+      await helper.mockResponse(getApiContractWithExactAndRange, {
+        responseStatus: 200,
+        responseJson: { id: 'exact' },
+      })
+      const result = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
+      expect(result.result?.body).toEqual({ id: 'exact' })
+    })
+
+    it('range key is used when exact code is absent but range matches', async () => {
+      await helper.mockResponse(getApiContractWithExactAndRange, {
+        responseStatus: 201,
+        responseJson: { id: 'range', created: true },
+      })
+      const result = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
+      expect(result.result?.body).toEqual({ id: 'range', created: true })
+    })
+  })
+
+  describe('mockResponse — NoBodyResponse', () => {
+    it('replies with no body for noBodyResponse() entry', async () => {
+      await helper.mockResponse(deleteApiContractWithNoBodyResponse, { responseStatus: 204 })
+      const response = await client().url('/no-body').delete().res()
+      expect(response.status).toBe(204)
     })
   })
 })

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -1,7 +1,8 @@
 import {
   type ApiContract,
   type ApiContractResponse,
-  ContractNoBody, type HttpStatusCode,
+  ContractNoBody,
+  type HttpStatusCode,
   isAnyOfResponses,
   isBlobResponse,
   isJsonResponse,
@@ -24,10 +25,17 @@ function getRangeKey(statusCode: HttpStatusCode) {
   if (statusCode >= 500 && statusCode < 600) return '5xx'
 }
 
-function resolveContractEntry(responsesByStatusCode: ResponsesByStatusCode, statusCode: HttpStatusCode): ApiContractResponse | undefined {
+function resolveContractEntry(
+  responsesByStatusCode: ResponsesByStatusCode,
+  statusCode: HttpStatusCode,
+): ApiContractResponse | undefined {
   const rangeKey = getRangeKey(statusCode)
 
-  return responsesByStatusCode[statusCode] ?? (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ?? responsesByStatusCode['default']
+  return (
+    responsesByStatusCode[statusCode] ??
+    (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ??
+    responsesByStatusCode['default']
+  )
 }
 
 export class ApiContractMockttpHelper {

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -1,17 +1,34 @@
 import {
   type ApiContract,
-  ContractNoBody,
+  type ApiContractResponse,
+  ContractNoBody, type HttpStatusCode,
   isAnyOfResponses,
   isBlobResponse,
   isJsonResponse,
+  isNoBodyResponse,
   isSseResponse,
   isTextResponse,
   mapApiContractToPath,
+  type ResponsesByStatusCode,
 } from '@lokalise/api-contracts'
 import type { Mockttp, RequestRuleBuilder } from 'mockttp'
 import { formatSseResponse, type MockResponseParams } from './types.ts'
 
 type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
+
+function getRangeKey(statusCode: HttpStatusCode) {
+  if (statusCode >= 100 && statusCode < 200) return '1xx'
+  if (statusCode >= 200 && statusCode < 300) return '2xx'
+  if (statusCode >= 300 && statusCode < 400) return '3xx'
+  if (statusCode >= 400 && statusCode < 500) return '4xx'
+  if (statusCode >= 500 && statusCode < 600) return '5xx'
+}
+
+function resolveContractEntry(responsesByStatusCode: ResponsesByStatusCode, statusCode: HttpStatusCode): ApiContractResponse | undefined {
+  const rangeKey = getRangeKey(statusCode)
+
+  return responsesByStatusCode[statusCode] ?? (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ?? responsesByStatusCode['default']
+}
 
 export class ApiContractMockttpHelper {
   private readonly mockServer: Mockttp
@@ -51,7 +68,7 @@ export class ApiContractMockttpHelper {
     const anyParams = params as any
     const path = this.resolvePath(contract, params.pathParams)
     const statusCode = params.responseStatus
-    const responseEntry = contract.responsesByStatusCode[params.responseStatus]
+    const responseEntry = resolveContractEntry(contract.responsesByStatusCode, statusCode)
 
     if (!responseEntry) {
       throw new Error('Specified responseStatus cannot be mapped with contract')
@@ -59,7 +76,7 @@ export class ApiContractMockttpHelper {
 
     const mockRule = this.resolveMethodBuilder(contract.method, path)
 
-    if (responseEntry === ContractNoBody) {
+    if (responseEntry === ContractNoBody || isNoBodyResponse(responseEntry)) {
       await mockRule.thenReply(statusCode)
       return
     }

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -34,7 +34,7 @@ function resolveContractEntry(
   return (
     responsesByStatusCode[statusCode] ??
     (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ??
-    responsesByStatusCode['default']
+    responsesByStatusCode.default
   )
 }
 

--- a/packages/app/universal-testing-utils/src/api-contracts/docs.md
+++ b/packages/app/universal-testing-utils/src/api-contracts/docs.md
@@ -17,7 +17,7 @@ afterEach(() => mockServer.stop())
 
 ## mockResponse
 
-Registers a mock rule for the given contract. The `responseStatus` field is required and must match a key in the contract's `responsesByStatusCode` — it drives both which schema to use for validation and which response type to return.
+Registers a mock rule for the given contract. `responseStatus` is the concrete numeric HTTP status code the mock will send (e.g. `201`, `404`). It also controls which schema is used: the helper looks up the contract entry with **exact → range → `'default'`** precedence, so a contract with only a `'2xx'` key accepts any `responseStatus` in 200–299.
 
 ```ts
 await helper.mockResponse(contract, params)
@@ -31,7 +31,7 @@ await helper.mockResponse(contract, params)
 | `sseResponse(schemas)` | `events: { event: string; data: unknown }[]` |
 | `textResponse(contentType)` | `responseText: string` |
 | `blobResponse(contentType)` | `responseBlob: string` |
-| `ContractNoBody` | *(none)* |
+| `ContractNoBody` / `noBodyResponse()` | *(none)* |
 | `anyOfResponses([sse, json])` | `responseJson` + `events` |
 
 Path params are required when the contract declares `requestPathParamsSchema`, and optional otherwise.
@@ -129,6 +129,63 @@ await helper.mockResponse(contract, {
 
 - Requests with `Accept: text/event-stream` receive the SSE stream.
 - All other requests receive the JSON body.
+
+### Range and wildcard status keys
+
+Contracts may use range keys (`'1xx'`–`'5xx'`) or `'default'` in `responsesByStatusCode` instead of exact codes. Pass any concrete numeric code covered by that range as `responseStatus`; the helper resolves the contract entry using the same **exact → range → `'default'`** precedence as the runtime client.
+
+**Range key only** — `responseStatus` accepts any code in 200–299:
+
+```ts
+const contract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/items',
+  responsesByStatusCode: { '2xx': z.object({ id: z.string() }) },
+})
+
+await helper.mockResponse(contract, {
+  responseStatus: 201,          // any 2xx code is valid
+  responseJson: { id: '1' },
+})
+```
+
+**`'default'` catch-all** — `responseStatus` accepts any `HttpStatusCode`:
+
+```ts
+const contract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/items',
+  responsesByStatusCode: { default: z.object({ id: z.string() }) },
+})
+
+await helper.mockResponse(contract, {
+  responseStatus: 200,
+  responseJson: { id: '1' },
+})
+```
+
+**Exact key takes priority** — when both `200` and `'2xx'` are defined, `responseStatus: 200` uses the exact entry and `responseStatus: 201` falls back to the range entry:
+
+```ts
+const contract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/items',
+  responsesByStatusCode: {
+    200: z.object({ id: z.string() }),
+    '2xx': z.object({ id: z.string(), created: z.literal(true) }),
+  },
+})
+
+await helper.mockResponse(contract, { responseStatus: 200, responseJson: { id: '1' } })
+await helper.mockResponse(contract, { responseStatus: 201, responseJson: { id: '2', created: true } })
+```
+
+### How `StatusCodeBodyPair` works (type-level)
+
+`MockResponseParams<TContract>` is a discriminated union on `responseStatus`. It has two branches:
+
+- **`ExactStatusCodePairs`** — one member per exact numeric key in `responsesByStatusCode`. `responseStatus` is that literal number and the body fields come from the entry at that key.
+- **`RangeStatusCodePairs`** — one member per wildcard key (`'1xx'`–`'5xx'`, `'default'`). `ExpandStatusRangeKey<K>` expands the key to its numeric union (e.g. `'2xx'` → `200|201|…|299`), then exact codes already covered by `ExactStatusCodePairs` are excluded via `Exclude` so the discriminated union stays unambiguous.
 
 ## Type safety
 

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -1,6 +1,7 @@
 import type {
   AnyOfResponses,
   ApiContract,
+  ExpandStatusRangeKey,
   HttpStatusCode,
   InferSchemaInput,
   RequestPathParamsSchema,
@@ -8,6 +9,7 @@ import type {
   TypedBlobResponse,
   TypedSseResponse,
   TypedTextResponse,
+  WildcardStatusCodeKey,
 } from '@lokalise/api-contracts'
 import type { z } from 'zod/v4'
 
@@ -49,13 +51,30 @@ type InferBodyParam<T> = T extends symbol
                   : object)
             : object
 
-// Discriminated union: each member pairs one response code with its typed body param.
-// responseStatus is required so the runtime always knows which schema entry to use.
-type StatusCodeBodyPair<TContract extends ApiContract> = {
+// responseStatus is always a concrete numeric code. Two sources contribute valid codes:
+//   1. Exact keys already present in responsesByStatusCode (e.g. 200, 404)
+//   2. Range/wildcard keys expanded to their constituent codes (e.g. '2xx' → 200–299),
+//      minus any exact keys that are already handled by source 1.
+// The runtime resolves the contract entry with exact → range → 'default' precedence.
+
+type ExactStatusCodePairs<TContract extends ApiContract> = {
   [K in keyof TContract['responsesByStatusCode'] & HttpStatusCode]: {
     responseStatus: K
   } & InferBodyParam<NonNullable<TContract['responsesByStatusCode'][K]>>
 }[keyof TContract['responsesByStatusCode'] & HttpStatusCode]
+
+type RangeStatusCodePairs<TContract extends ApiContract> = {
+  [K in keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]: {
+    responseStatus: Exclude<
+      ExpandStatusRangeKey<K>,
+      keyof TContract['responsesByStatusCode'] & HttpStatusCode
+    >
+  } & InferBodyParam<NonNullable<TContract['responsesByStatusCode'][K]>>
+}[keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]
+
+type StatusCodeBodyPair<TContract extends ApiContract> =
+  | ExactStatusCodePairs<TContract>
+  | RangeStatusCodePairs<TContract>
 
 type PathParamsField<TContract extends ApiContract> =
   TContract['requestPathParamsSchema'] extends RequestPathParamsSchema

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -4,6 +4,7 @@ import type {
   ExpandStatusRangeKey,
   HttpStatusCode,
   InferSchemaInput,
+  NoBodyResponse,
   RequestPathParamsSchema,
   SseSchemaByEventName,
   TypedBlobResponse,
@@ -25,6 +26,7 @@ export function formatSseResponse(events: { event: string; data: unknown }[]): s
 
 // Maps a single responsesByStatusCode entry to the body field(s) needed for mocking.
 // symbol (ContractNoBody) → no body field
+// NoBodyResponse         → no body field
 // ZodType              → { responseJson: z.input<T> }
 // TypedSseResponse     → { events: SseMockEventInput[] }
 // TypedTextResponse    → { responseText: string }
@@ -32,7 +34,9 @@ export function formatSseResponse(events: { event: string; data: unknown }[]): s
 // AnyOfResponses       → { responseJson: ...; events: ... } for dual-mode (SSE + JSON)
 type InferBodyParam<T> = T extends symbol
   ? { responseJson?: null }
-  : T extends z.ZodType
+  : T extends NoBodyResponse
+    ? { responseJson?: null }
+    : T extends z.ZodType
     ? { responseJson: z.input<T> }
     : T extends TypedSseResponse<infer S extends SseSchemaByEventName>
       ? { events: SseMockEventInput<S>[] }
@@ -50,12 +54,6 @@ type InferBodyParam<T> = T extends symbol
                   ? { events: SseMockEventInput<S>[] }
                   : object)
             : object
-
-// responseStatus is always a concrete numeric code. Two sources contribute valid codes:
-//   1. Exact keys already present in responsesByStatusCode (e.g. 200, 404)
-//   2. Range/wildcard keys expanded to their constituent codes (e.g. '2xx' → 200–299),
-//      minus any exact keys that are already handled by source 1.
-// The runtime resolves the contract entry with exact → range → 'default' precedence.
 
 type ExactStatusCodePairs<TContract extends ApiContract> = {
   [K in keyof TContract['responsesByStatusCode'] & HttpStatusCode]: {

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -37,23 +37,23 @@ type InferBodyParam<T> = T extends symbol
   : T extends NoBodyResponse
     ? { responseJson?: null }
     : T extends z.ZodType
-    ? { responseJson: z.input<T> }
-    : T extends TypedSseResponse<infer S extends SseSchemaByEventName>
-      ? { events: SseMockEventInput<S>[] }
-      : T extends TypedTextResponse
-        ? { responseText: string }
-        : T extends TypedBlobResponse
-          ? { responseBlob: string }
-          : T extends AnyOfResponses<infer Items>
-            ? (Extract<Items, z.ZodType> extends never
-                ? object
-                : { responseJson: z.input<Extract<Items, z.ZodType>> }) &
-                (Extract<Items, TypedSseResponse<any>> extends TypedSseResponse<
-                  infer S extends SseSchemaByEventName
-                >
-                  ? { events: SseMockEventInput<S>[] }
-                  : object)
-            : object
+      ? { responseJson: z.input<T> }
+      : T extends TypedSseResponse<infer S extends SseSchemaByEventName>
+        ? { events: SseMockEventInput<S>[] }
+        : T extends TypedTextResponse
+          ? { responseText: string }
+          : T extends TypedBlobResponse
+            ? { responseBlob: string }
+            : T extends AnyOfResponses<infer Items>
+              ? (Extract<Items, z.ZodType> extends never
+                  ? object
+                  : { responseJson: z.input<Extract<Items, z.ZodType>> }) &
+                  (Extract<Items, TypedSseResponse<any>> extends TypedSseResponse<
+                    infer S extends SseSchemaByEventName
+                  >
+                    ? { events: SseMockEventInput<S>[] }
+                    : object)
+              : object
 
 type ExactStatusCodePairs<TContract extends ApiContract> = {
   [K in keyof TContract['responsesByStatusCode'] & HttpStatusCode]: {

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -48,11 +48,13 @@ type InferBodyParam<T> = T extends symbol
               ? (Extract<Items, z.ZodType> extends never
                   ? object
                   : { responseJson: z.input<Extract<Items, z.ZodType>> }) &
-                  (Extract<Items, TypedSseResponse<any>> extends TypedSseResponse<
-                    infer S extends SseSchemaByEventName
-                  >
-                    ? { events: SseMockEventInput<S>[] }
-                    : object)
+                  ([Extract<Items, TypedSseResponse<any>>] extends [never]
+                    ? object
+                    : Extract<Items, TypedSseResponse<any>> extends TypedSseResponse<
+                          infer S extends SseSchemaByEventName
+                        >
+                      ? { events: SseMockEventInput<S>[] }
+                      : object)
               : object
 
 type ExactStatusCodePairs<TContract extends ApiContract> = {

--- a/packages/app/universal-testing-utils/test/testApiContracts.ts
+++ b/packages/app/universal-testing-utils/test/testApiContracts.ts
@@ -1,9 +1,11 @@
 import {
   anyOfResponses,
+  blobResponse,
   ContractNoBody,
   defineApiContract,
   noBodyResponse,
   sseResponse,
+  textResponse,
 } from '@lokalise/api-contracts'
 import { z } from 'zod/v4'
 
@@ -135,4 +137,48 @@ export const deleteApiContractWithNoBodyResponse = defineApiContract({
   method: 'delete',
   pathResolver: () => '/no-body',
   responsesByStatusCode: { 204: noBodyResponse() },
+})
+
+export const patchApiContract = defineApiContract({
+  method: 'patch',
+  requestBodySchema: REQUEST_BODY_SCHEMA,
+  pathResolver: () => '/patch',
+  responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+})
+
+export const putApiContract = defineApiContract({
+  method: 'put',
+  requestBodySchema: REQUEST_BODY_SCHEMA,
+  pathResolver: () => '/put',
+  responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+})
+
+export const textResponseApiContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/text',
+  responsesByStatusCode: { 200: textResponse('text/plain') },
+})
+
+export const blobResponseApiContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/blob',
+  responsesByStatusCode: { 200: blobResponse('application/octet-stream') },
+})
+
+export const anyOfTextResponsesApiContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/any-of-text',
+  responsesByStatusCode: { 200: anyOfResponses([textResponse('text/plain')]) },
+})
+
+export const getApiContractWith4xxRange = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/not-found',
+  responsesByStatusCode: { '4xx': RESPONSE_BODY_SCHEMA },
+})
+
+export const getApiContractWith5xxRange = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/server-error',
+  responsesByStatusCode: { '5xx': RESPONSE_BODY_SCHEMA },
 })

--- a/packages/app/universal-testing-utils/test/testApiContracts.ts
+++ b/packages/app/universal-testing-utils/test/testApiContracts.ts
@@ -2,6 +2,7 @@ import {
   anyOfResponses,
   ContractNoBody,
   defineApiContract,
+  noBodyResponse,
   sseResponse,
 } from '@lokalise/api-contracts'
 import { z } from 'zod/v4'
@@ -105,4 +106,33 @@ export const noBodyApiContract = defineApiContract({
   requestPathParamsSchema: PATH_PARAMS_SCHEMA,
   pathResolver: ({ userId }) => `/users/${userId}`,
   responsesByStatusCode: { 204: ContractNoBody },
+})
+
+export const getApiContractWith2xxRange = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/range',
+  responsesByStatusCode: { '2xx': RESPONSE_BODY_SCHEMA },
+})
+
+export const getApiContractWithDefault = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/default',
+  responsesByStatusCode: { default: RESPONSE_BODY_SCHEMA },
+})
+
+const CREATED_BODY_SCHEMA = z.object({ id: z.string(), created: z.literal(true) })
+
+export const getApiContractWithExactAndRange = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/exact-and-range',
+  responsesByStatusCode: {
+    200: RESPONSE_BODY_SCHEMA,
+    '2xx': CREATED_BODY_SCHEMA,
+  },
+})
+
+export const deleteApiContractWithNoBodyResponse = defineApiContract({
+  method: 'delete',
+  pathResolver: () => '/no-body',
+  responsesByStatusCode: { 204: noBodyResponse() },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 3.1.1
       '@lokalise/fastify-extras':
         specifier: ^31.0.0
-        version: 31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.11.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)
+        version: 31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.13.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.4.1
         version: 14.8.1(zod@4.4.3)
@@ -153,7 +153,7 @@ importers:
         version: 3.1.1
       '@lokalise/fastify-extras':
         specifier: ^31.0.0
-        version: 31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.11.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)
+        version: 31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.13.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.0.0
         version: 14.8.1(zod@4.4.3)
@@ -543,7 +543,7 @@ importers:
         version: 3.1.1
       '@lokalise/fastify-extras':
         specifier: ^31.0.0
-        version: 31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.11.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)
+        version: 31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.13.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.1.0
         version: 14.8.1(zod@4.4.3)
@@ -990,14 +990,14 @@ importers:
         specifier: ^2.3.7
         version: 2.4.15
       '@lokalise/api-contracts':
-        specifier: ^6.6.0
-        version: 6.11.0(zod@4.4.3)
+        specifier: ^6.13.0
+        version: 6.13.0(zod@4.4.3)
       '@lokalise/biome-config':
         specifier: ^3.1.0
         version: 3.1.1
       '@lokalise/frontend-http-client':
         specifier: '*'
-        version: 7.5.0(@lokalise/api-contracts@6.11.0(zod@4.4.3))(wretch@3.0.8)(zod@4.4.3)
+        version: 7.5.0(@lokalise/api-contracts@6.13.0(zod@4.4.3))(wretch@3.0.8)(zod@4.4.3)
       '@lokalise/tsconfig':
         specifier: ^4.0.0
         version: 4.0.0
@@ -1926,6 +1926,11 @@ packages:
 
   '@lokalise/api-contracts@6.11.0':
     resolution: {integrity: sha512-7n8l1J4hHXUrMry9msR95ecvNEPSyn8WHAnAhkTmVcxYKrT4jAUWrTQtvljQXtc9w+Vc1cMQ3bPKvKtjKr7K/A==}
+    peerDependencies:
+      zod: '>=3.25.56'
+
+  '@lokalise/api-contracts@6.13.0':
+    resolution: {integrity: sha512-cTAhdQjot7PPfxtI+4zKEj0KGwbj4rwpIBld8j9xGdGFO1c/gkD28RTuFMbVtqBYR2Huguc83aX85kmVrhK6rg==}
     peerDependencies:
       zod: '>=3.25.56'
 
@@ -8142,6 +8147,10 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@lokalise/api-contracts@6.13.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
   '@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3)':
     dependencies:
       '@lokalise/id-utils': 3.0.1
@@ -8184,12 +8193,12 @@ snapshots:
       - typescript
       - vitest
 
-  '@lokalise/fastify-extras@31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.11.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)':
+  '@lokalise/fastify-extras@31.0.0(@fastify/jwt@10.0.0)(@lokalise/api-contracts@6.13.0(zod@4.4.3))(@lokalise/background-jobs-common@14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.77.3)(dd-trace@5.104.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0)))(fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.8.5)(ioredis@5.10.1)(pino@10.3.1)(zod@4.4.3)':
     dependencies:
       '@amplitude/analytics-node': 1.5.57
       '@bugsnag/js': 8.9.0
       '@fastify/jwt': 10.0.0
-      '@lokalise/api-contracts': 6.11.0(zod@4.4.3)
+      '@lokalise/api-contracts': 6.13.0(zod@4.4.3)
       '@lokalise/background-jobs-common': 14.3.0(bullmq@5.77.3)(ioredis@5.10.1)(pino@10.3.1)(toad-scheduler@4.0.1)(zod@4.4.3)
       '@lokalise/error-utils': 3.0.0(@lokalise/node-core@14.8.1(zod@4.4.3))
       '@lokalise/node-core': 14.8.1(zod@4.4.3)
@@ -8212,9 +8221,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@lokalise/frontend-http-client@7.5.0(@lokalise/api-contracts@6.11.0(zod@4.4.3))(wretch@3.0.8)(zod@4.4.3)':
+  '@lokalise/frontend-http-client@7.5.0(@lokalise/api-contracts@6.13.0(zod@4.4.3))(wretch@3.0.8)(zod@4.4.3)':
     dependencies:
-      '@lokalise/api-contracts': 6.11.0(zod@4.4.3)
+      '@lokalise/api-contracts': 6.13.0(zod@4.4.3)
       fast-querystring: 1.1.2
       parse-sse: 0.1.0
       wretch: 3.0.8


### PR DESCRIPTION
## Changes

  - MockResponseParams now accepts any concrete numeric code covered by a range key ('2xx', 'default', …) — exact codes and range expansions are separate discriminants so the union stays unambiguous
  - resolveContractEntry replaces direct key lookup with exact → range → 'default' fallback, mirroring the runtime client
  - NoBodyResponse handled alongside ContractNoBody in both InferBodyParam and the no-body reply branch
  - Peer dep bumped to >=6.13.0; docs updated


## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
