### PR TITLE
feat(fastify-api-contracts): add injectByApiContract for defineApiContract

### DIFF
--- a/.changeset/inject-by-api-contract.md
+++ b/.changeset/inject-by-api-contract.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/fastify-api-contracts": minor
+---
+
+Add `injectByApiContract`, a test-request injector for contracts created with `defineApiContract` (the current `@lokalise/api-contracts` API). It mirrors `injectByContract` but resolves its params (`pathParams`/`body`/`queryParams`/`headers`/`pathPrefix`) directly from the `defineApiContract` contract, including `ContractNoBody` handling and an optional `pathPrefix` that is prepended to the resolved path. The resolved params type is exported as `InjectByApiContractParams`.

--- a/packages/app/fastify-api-contracts/README.md
+++ b/packages/app/fastify-api-contracts/README.md
@@ -11,6 +11,7 @@ This package adds support for generating fastify routes using universal API cont
   - [Accessing the contract](#accessing-the-contract)
   - [Adding extra route options from contract metadata](#adding-extra-route-options-from-contract-metadata)
 - [Test helpers](#test-helpers)
+  - [`injectByApiContract`](#injectbyapicontract)
   - [`injectByContract`](#injectbycontract)
 - [Deprecated APIs](#deprecated-apis)
 
@@ -161,9 +162,61 @@ const route = buildFastifyRoute(
 
 Test helpers let you dispatch requests against a Fastify instance directly from a contract, without spinning up a real HTTP server. They are intended for tests — in production code, prefer a real HTTP client such as `@lokalise/frontend-http-client`.
 
+Pick the helper that matches how the contract was created:
+
+- [`injectByApiContract`](#injectbyapicontract) — for contracts created with `defineApiContract` (the current `@lokalise/api-contracts` API).
+- [`injectByContract`](#injectbycontract) — for contracts created with the deprecated `buildRestContract`/`buildGetRoute`/`buildPayloadRoute` builders.
+
+Both share the same core parameter shape (`pathParams`, `body`, `queryParams`, `headers`) and runtime behavior — only the contract type they accept differs. `injectByApiContract` additionally accepts an optional `pathPrefix`.
+
+### `injectByApiContract`
+
+`injectByApiContract` dispatches a request through Fastify's [`inject`](https://fastify.dev/docs/latest/Guides/Testing/) for contracts created with `defineApiContract`, automatically determining the HTTP method from the contract.
+
+The params type is resolved directly from the contract (the same way the contract client's request params are), so each field is required only when the corresponding request schema is present:
+
+- `pathParams` — required when `requestPathParamsSchema` is defined
+- `body` — required when `requestBodySchema` is a schema (omitted for GET/DELETE and for `ContractNoBody`)
+- `queryParams` — required when `requestQuerySchema` is defined
+- `headers` — required when `requestHeaderSchema` is defined; accepts a plain object or a (sync or async) function
+- `pathPrefix` — always optional; when provided, it is prepended to the path resolved from the contract (e.g. to hit a route mounted under a Fastify prefix)
+
+```ts
+import { injectByApiContract } from '@lokalise/fastify-api-contracts'
+import { ContractNoBody, defineApiContract } from '@lokalise/api-contracts'
+
+const createUserContract = defineApiContract({
+    method: 'post',
+    requestBodySchema: REQUEST_BODY_SCHEMA,
+    requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+    pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+    responsesByStatusCode: { 201: RESPONSE_BODY_SCHEMA },
+})
+
+// POST request — body is required and typed from the contract
+const postResponse = await injectByApiContract(app, createUserContract, {
+    pathParams: { userId: '1' },
+    body: { id: '2' },
+    headers: async () => ({ authorization: 'some-value' }), // plain object or (a)sync function
+})
+
+const pingContract = defineApiContract({
+    method: 'get',
+    pathResolver: () => '/ping',
+    responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+})
+
+// A contract with no request schemas needs no input fields
+const pingResponse = await injectByApiContract(app, pingContract, {})
+```
+
+The resolved params type is also exported as `InjectByApiContractParams<typeof contract>`, which is handy for building typed request factories in tests.
+
 ### `injectByContract`
 
 `injectByContract` dispatches a request through Fastify's [`inject`](https://fastify.dev/docs/latest/Guides/Testing/) and automatically determines the HTTP method from the contract. It replaces the per-method `injectGet`/`injectDelete`/`injectPost`/`injectPut`/`injectPatch` helpers.
+
+> It targets the deprecated `buildRestContract`/`buildGetRoute`/`buildPayloadRoute` contracts. For contracts created with `defineApiContract`, use [`injectByApiContract`](#injectbyapicontract) instead.
 
 The params type is automatically resolved from the contract:
 

--- a/packages/app/fastify-api-contracts/README.md
+++ b/packages/app/fastify-api-contracts/README.md
@@ -189,11 +189,13 @@ const createUserContract = defineApiContract({
     method: 'post',
     requestBodySchema: REQUEST_BODY_SCHEMA,
     requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+    requestHeaderSchema: HEADERS_SCHEMA,
     pathResolver: (pathParams) => `/users/${pathParams.userId}`,
     responsesByStatusCode: { 201: RESPONSE_BODY_SCHEMA },
 })
 
-// POST request — body is required and typed from the contract
+// POST request — body is required and typed from the contract; headers are required
+// because the contract declares requestHeaderSchema
 const postResponse = await injectByApiContract(app, createUserContract, {
     pathParams: { userId: '1' },
     body: { id: '2' },

--- a/packages/app/fastify-api-contracts/src/index.ts
+++ b/packages/app/fastify-api-contracts/src/index.ts
@@ -12,5 +12,6 @@ export {
   injectPut,
 } from './fastifyApiRequestInjector.ts'
 export { buildFastifyRoute, buildFastifyRouteHandler } from './fastifyRouteBuilder.ts'
+export { type InjectByApiContractParams, injectByApiContract } from './injectByApiContract.ts'
 export { injectByContract } from './injectByContract.ts'
 export * from './types.ts'

--- a/packages/app/fastify-api-contracts/src/injectByApiContract.spec.ts
+++ b/packages/app/fastify-api-contracts/src/injectByApiContract.spec.ts
@@ -186,6 +186,60 @@ describe('injectByApiContract', () => {
 
       expect(response.statusCode).toBe(200)
     })
+
+    it('normalizes a pathPrefix with a trailing slash without doubling the separator', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(
+        contract,
+        (req) => {
+          expect(req.params).toEqual({ userId: '1' })
+          return Promise.resolve({})
+        },
+        '/api/v1',
+      )
+
+      // a trailing slash on the prefix must not produce `/api/v1//users/1`
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        pathPrefix: '/api/v1/',
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('normalizes a pathPrefix without a leading slash', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(
+        contract,
+        (req) => {
+          expect(req.params).toEqual({ userId: '1' })
+          return Promise.resolve({})
+        },
+        '/api/v1',
+      )
+
+      // a missing leading slash must still resolve to `/api/v1/users/1`
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        pathPrefix: 'api/v1',
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
   })
 
   describe('DELETE', () => {

--- a/packages/app/fastify-api-contracts/src/injectByApiContract.spec.ts
+++ b/packages/app/fastify-api-contracts/src/injectByApiContract.spec.ts
@@ -317,6 +317,35 @@ describe('injectByApiContract', () => {
       expect(response.statusCode).toBe(201)
     })
 
+    it('prepends pathPrefix to the resolved path for a payload route', async () => {
+      expect.assertions(3)
+      const contract = defineApiContract({
+        method: 'post',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 201: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(
+        contract,
+        (req, reply) => {
+          expect(req.params).toEqual({ userId: '1' })
+          expect(req.body).toEqual({ id: '2' })
+          return reply.code(201).send({})
+        },
+        '/api/v1',
+      )
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        body: { id: '2' },
+        pathPrefix: '/api/v1',
+      })
+
+      expect(response.statusCode).toBe(201)
+    })
+
     it('injects a POST request for a contract with a ContractNoBody request body', async () => {
       expect.assertions(2)
       const contract = defineApiContract({

--- a/packages/app/fastify-api-contracts/src/injectByApiContract.spec.ts
+++ b/packages/app/fastify-api-contracts/src/injectByApiContract.spec.ts
@@ -1,0 +1,397 @@
+import {
+  type ApiContract,
+  ContractNoBody,
+  defineApiContract,
+  mapApiContractToPath,
+} from '@lokalise/api-contracts'
+import { copyWithoutUndefined } from '@lokalise/node-core'
+import { type FastifyInstance, fastify, type RouteHandlerMethod } from 'fastify'
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
+import { describe, expect, expectTypeOf, it, onTestFinished } from 'vitest'
+import { z } from 'zod/v4'
+import { type InjectByApiContractParams, injectByApiContract } from './injectByApiContract.ts'
+
+const REQUEST_BODY_SCHEMA = z.object({
+  id: z.string(),
+})
+const RESPONSE_BODY_SCHEMA = z.object({})
+const PATH_PARAMS_SCHEMA = z.object({
+  userId: z.string(),
+})
+const HEADERS_SCHEMA = z.object({
+  authorization: z.string(),
+})
+const arrayPreprocessor = (value: unknown) => (Array.isArray(value) ? value : [value])
+
+const REQUEST_QUERY_SCHEMA = z.object({
+  testIds: z.preprocess(arrayPreprocessor, z.array(z.string())).optional(),
+  limit: z.coerce.number().gt(0).default(10),
+})
+
+/**
+ * Registers a single route derived from a `defineApiContract` contract, so the injected request has
+ * something to hit. Mirrors how `buildFastifyRoute` would wire schemas, but works with the newer
+ * contract shape directly.
+ */
+async function initAppForContract(
+  contract: ApiContract,
+  handler: RouteHandlerMethod,
+  urlPrefix = '',
+): Promise<FastifyInstance> {
+  const app = fastify({
+    logger: false,
+    disableRequestLogging: true,
+  })
+
+  app.setValidatorCompiler(validatorCompiler)
+  app.setSerializerCompiler(serializerCompiler)
+
+  const schema = copyWithoutUndefined({
+    params: contract.requestPathParamsSchema,
+    querystring: contract.requestQuerySchema,
+    headers: contract.requestHeaderSchema,
+    body: contract.requestBodySchema === ContractNoBody ? undefined : contract.requestBodySchema,
+  })
+
+  app.route({
+    method: contract.method,
+    url: `${urlPrefix}${mapApiContractToPath(contract)}`,
+    schema,
+    handler,
+  })
+
+  await app.ready()
+  onTestFinished(() => app.close())
+  return app
+}
+
+describe('injectByApiContract', () => {
+  describe('GET', () => {
+    it('injects a GET request with path and query params', async () => {
+      expect.assertions(4)
+      const contract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestQuerySchema: REQUEST_QUERY_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req) => {
+        expect(req.params).toEqual({ userId: '1' })
+        // the query schema coerces and applies the default, which fastify parses on the way in
+        expect(req.query).toEqual({ limit: 10 })
+        return Promise.resolve({})
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        queryParams: { limit: 10 },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toMatchInlineSnapshot(`"{}"`)
+    })
+
+    it('injects a GET request with a header object', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestHeaderSchema: HEADERS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req) => {
+        expect(req.headers.authorization).toBe('dummy')
+        return Promise.resolve({})
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        headers: { authorization: 'dummy' },
+        pathParams: { userId: '1' },
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('injects a GET request with a sync and async header factory', async () => {
+      expect.assertions(4)
+      const contract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestHeaderSchema: HEADERS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req) => {
+        expect(req.headers.authorization).toBe('dummy')
+        return Promise.resolve({})
+      })
+
+      const syncResponse = await injectByApiContract(app, contract, {
+        headers: () => ({ authorization: 'dummy' }),
+        pathParams: { userId: '1' },
+      })
+      expect(syncResponse.statusCode).toBe(200)
+
+      const asyncResponse = await injectByApiContract(app, contract, {
+        headers: () => Promise.resolve({ authorization: 'dummy' }),
+        pathParams: { userId: '1' },
+      })
+      expect(asyncResponse.statusCode).toBe(200)
+    })
+
+    it('injects a GET request for a contract without any request schemas', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/ping',
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, () => Promise.resolve({}))
+
+      const response = await injectByApiContract(app, contract, {})
+
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toMatchInlineSnapshot(`"{}"`)
+    })
+
+    it('prepends pathPrefix to the resolved path', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      // the route is mounted under a prefix the contract itself is unaware of
+      const app = await initAppForContract(
+        contract,
+        (req) => {
+          expect(req.params).toEqual({ userId: '1' })
+          return Promise.resolve({})
+        },
+        '/api/v1',
+      )
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        pathPrefix: '/api/v1',
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('DELETE', () => {
+    it('injects a DELETE request returning no body', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'delete',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 204: ContractNoBody },
+      })
+
+      const app = await initAppForContract(contract, (req, reply) => {
+        expect(req.params).toEqual({ userId: '1' })
+        return reply.code(204).send()
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+      })
+
+      expect(response.statusCode).toBe(204)
+    })
+  })
+
+  describe('POST', () => {
+    it('injects a POST request with a body', async () => {
+      expect.assertions(3)
+      const contract = defineApiContract({
+        method: 'post',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 201: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req, reply) => {
+        expect(req.params).toEqual({ userId: '1' })
+        expect(req.body).toEqual({ id: '2' })
+        return reply.code(201).send({})
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        body: { id: '2' },
+      })
+
+      expect(response.statusCode).toBe(201)
+    })
+
+    it('injects a POST request with a body and an async header factory', async () => {
+      expect.assertions(4)
+      const contract = defineApiContract({
+        method: 'post',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestHeaderSchema: HEADERS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 201: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req, reply) => {
+        expect(req.params).toEqual({ userId: '1' })
+        expect(req.body).toEqual({ id: '2' })
+        expect(req.headers.authorization).toBe('dummy')
+        return reply.code(201).send({})
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        headers: () => Promise.resolve({ authorization: 'dummy' }),
+        pathParams: { userId: '1' },
+        body: { id: '2' },
+      })
+
+      expect(response.statusCode).toBe(201)
+    })
+
+    it('injects a POST request for a contract with a ContractNoBody request body', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'post',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestBodySchema: ContractNoBody,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}/activate`,
+        responsesByStatusCode: { 204: ContractNoBody },
+      })
+
+      const app = await initAppForContract(contract, (req, reply) => {
+        expect(req.params).toEqual({ userId: '1' })
+        return reply.code(204).send()
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+      })
+
+      expect(response.statusCode).toBe(204)
+    })
+  })
+
+  describe('PUT', () => {
+    it('injects a PUT request with a body', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'put',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req) => {
+        expect(req.body).toEqual({ id: '2' })
+        return Promise.resolve({})
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        body: { id: '2' },
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('PATCH', () => {
+    it('injects a PATCH request with a body', async () => {
+      expect.assertions(2)
+      const contract = defineApiContract({
+        method: 'patch',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+
+      const app = await initAppForContract(contract, (req) => {
+        expect(req.body).toEqual({ id: '2' })
+        return Promise.resolve({})
+      })
+
+      const response = await injectByApiContract(app, contract, {
+        pathParams: { userId: '1' },
+        body: { id: '2' },
+      })
+
+      expect(response.statusCode).toBe(200)
+    })
+  })
+
+  describe('type-level params resolution', () => {
+    it('requires pathParams and body for a payload contract, and forbids body for a GET', () => {
+      const postContract = defineApiContract({
+        method: 'post',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 201: RESPONSE_BODY_SCHEMA },
+      })
+      expectTypeOf<InjectByApiContractParams<typeof postContract>>().toEqualTypeOf<{
+        pathParams: { userId: string }
+        body: { id: string }
+        queryParams?: undefined
+        headers?: undefined
+        pathPrefix?: string
+      }>()
+
+      const getContract = defineApiContract({
+        method: 'get',
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        requestQuerySchema: REQUEST_QUERY_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+      expectTypeOf<
+        InjectByApiContractParams<typeof getContract>['body']
+      >().toEqualTypeOf<undefined>()
+      expectTypeOf<InjectByApiContractParams<typeof getContract>['queryParams']>().toEqualTypeOf<
+        z.input<typeof REQUEST_QUERY_SCHEMA>
+      >()
+    })
+
+    it('produces an all-optional params type for a contract without request schemas', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/ping',
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+      expectTypeOf<InjectByApiContractParams<typeof contract>>().toEqualTypeOf<{
+        pathParams?: undefined
+        body?: undefined
+        queryParams?: undefined
+        headers?: undefined
+        pathPrefix?: string
+      }>()
+    })
+
+    it('always exposes an optional pathPrefix', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/ping',
+        responsesByStatusCode: { 200: RESPONSE_BODY_SCHEMA },
+      })
+      expectTypeOf<InjectByApiContractParams<typeof contract>['pathPrefix']>().toEqualTypeOf<
+        string | undefined
+      >()
+    })
+  })
+})

--- a/packages/app/fastify-api-contracts/src/injectByApiContract.ts
+++ b/packages/app/fastify-api-contracts/src/injectByApiContract.ts
@@ -1,0 +1,53 @@
+import type { ApiContract, ClientRequestParams } from '@lokalise/api-contracts'
+import type { Response as LightMyRequestResponse } from 'light-my-request'
+
+import { type AnyFastifyInstance, dispatchInjectByMethod } from './injectRequestDispatcher.ts'
+
+/**
+ * Request params for {@link injectByApiContract}, derived directly from a `defineApiContract`
+ * contract.
+ *
+ * This mirrors the contract client's `ClientRequestParams`, minus the `streaming` field, which is
+ * not relevant when injecting requests against a Fastify instance:
+ * - `pathParams`, `body`, `queryParams` and `headers` are each required only when the matching
+ *   request schema is defined on the contract, and omitted otherwise.
+ * - `headers` accepts either a plain object or a (sync or async) function producing it.
+ * - `pathPrefix` is always optional and, when provided, is prepended to the resolved path.
+ */
+export type InjectByApiContractParams<TApiContract extends ApiContract> = Omit<
+  ClientRequestParams<TApiContract, false>,
+  'streaming'
+>
+
+/**
+ * Unified request injector for contracts created with `defineApiContract` (the newer API of
+ * `@lokalise/api-contracts`). It dispatches a request through Fastify's
+ * [`inject`](https://fastify.dev/docs/latest/Guides/Testing/) and automatically determines the HTTP
+ * method from the contract.
+ *
+ * This is the `defineApiContract` counterpart of {@link injectByContract}, which targets the
+ * deprecated `buildRestContract`/`buildGetRoute`/`buildPayloadRoute` route definitions. The params
+ * type is resolved directly from the contract:
+ * - GET/DELETE contracts → params without a request body
+ * - POST/PUT/PATCH contracts → params with a request body (omitted when `ContractNoBody`)
+ *
+ * An optional `pathPrefix` is prepended to the path resolved from the contract, matching the
+ * behavior of the contract client.
+ */
+export function injectByApiContract<const TApiContract extends ApiContract>(
+  app: AnyFastifyInstance,
+  apiContract: TApiContract,
+  params: InjectByApiContractParams<TApiContract>,
+): Promise<LightMyRequestResponse>
+
+// Implementation
+export function injectByApiContract(
+  app: AnyFastifyInstance,
+  apiContract: ApiContract,
+  // biome-ignore lint/suspicious/noExplicitAny: params shape depends on the contract
+  params: any,
+): Promise<LightMyRequestResponse> {
+  const path = `${params.pathPrefix ?? ''}${apiContract.pathResolver(params.pathParams)}`
+
+  return dispatchInjectByMethod(app, apiContract.method, path, params)
+}

--- a/packages/app/fastify-api-contracts/src/injectByApiContract.ts
+++ b/packages/app/fastify-api-contracts/src/injectByApiContract.ts
@@ -1,4 +1,8 @@
-import type { ApiContract, ClientRequestParams } from '@lokalise/api-contracts'
+import {
+  type ApiContract,
+  buildRequestPath,
+  type ClientRequestParams,
+} from '@lokalise/api-contracts'
 import type { Response as LightMyRequestResponse } from 'light-my-request'
 
 import { type AnyFastifyInstance, dispatchInjectByMethod } from './injectRequestDispatcher.ts'
@@ -47,7 +51,7 @@ export function injectByApiContract(
   // biome-ignore lint/suspicious/noExplicitAny: params shape depends on the contract
   params: any,
 ): Promise<LightMyRequestResponse> {
-  const path = `${params.pathPrefix ?? ''}${apiContract.pathResolver(params.pathParams)}`
+  const path = buildRequestPath(apiContract.pathResolver(params.pathParams), params.pathPrefix)
 
   return dispatchInjectByMethod(app, apiContract.method, path, params)
 }

--- a/packages/app/fastify-api-contracts/src/injectByContract.ts
+++ b/packages/app/fastify-api-contracts/src/injectByContract.ts
@@ -22,7 +22,7 @@ import { type AnyFastifyInstance, dispatchInjectByMethod } from './injectRequest
  */
 
 // Overload 1: GET route
-export async function injectByContract<
+export function injectByContract<
   ResponseBodySchema extends z.Schema | undefined = undefined,
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
@@ -53,7 +53,7 @@ export async function injectByContract<
 ): Promise<LightMyRequestResponse>
 
 // Overload 2: DELETE route
-export async function injectByContract<
+export function injectByContract<
   ResponseBodySchema extends z.Schema | undefined = undefined,
   PathParamsSchema extends z.Schema | undefined = undefined,
   RequestQuerySchema extends z.Schema | undefined = undefined,
@@ -84,7 +84,7 @@ export async function injectByContract<
 ): Promise<LightMyRequestResponse>
 
 // Overload 3: Payload route (POST/PUT/PATCH)
-export async function injectByContract<
+export function injectByContract<
   ResponseBodySchema extends z.Schema | undefined = undefined,
   RequestBodySchema extends z.Schema | undefined = undefined,
   PathParamsSchema extends z.Schema | undefined = undefined,

--- a/packages/app/fastify-api-contracts/src/injectByContract.ts
+++ b/packages/app/fastify-api-contracts/src/injectByContract.ts
@@ -6,14 +6,11 @@ import type {
   InferSchemaOutput,
   PayloadRouteDefinition,
 } from '@lokalise/api-contracts'
-import type { FastifyInstance } from 'fastify'
 import type { Response as LightMyRequestResponse } from 'light-my-request'
 import type { z } from 'zod/v4'
 
 import type { PayloadRouteRequestParams, RouteRequestParams } from './fastifyApiRequestInjector.ts'
-
-// biome-ignore lint/suspicious/noExplicitAny: we don't care about what kind of app instance we get here
-type AnyFastifyInstance = FastifyInstance<any, any, any, any>
+import { type AnyFastifyInstance, dispatchInjectByMethod } from './injectRequestDispatcher.ts'
 
 /**
  * Unified request injector that automatically determines the HTTP method from the contract.
@@ -121,49 +118,14 @@ export async function injectByContract<
 ): Promise<LightMyRequestResponse>
 
 // Implementation
-export async function injectByContract(
+export function injectByContract(
   app: AnyFastifyInstance,
   // biome-ignore lint/suspicious/noExplicitAny: Union of all contract types
   apiContract: any,
   // biome-ignore lint/suspicious/noExplicitAny: Params type depends on overload
   params: any,
 ): Promise<LightMyRequestResponse> {
-  const resolvedHeaders =
-    typeof params.headers === 'function' ? await params.headers() : params.headers
-
   const path = apiContract.pathResolver(params.pathParams)
-  const { method } = apiContract
 
-  switch (method) {
-    case 'get':
-      return app.inject().get(path).headers(resolvedHeaders).query(params.queryParams).end()
-    case 'delete':
-      return app.inject().delete(path).headers(resolvedHeaders).query(params.queryParams).end()
-    case 'post':
-      return app
-        .inject()
-        .post(path)
-        .body(params.body)
-        .headers(resolvedHeaders)
-        .query(params.queryParams)
-        .end()
-    case 'put':
-      return app
-        .inject()
-        .put(path)
-        .body(params.body)
-        .headers(resolvedHeaders)
-        .query(params.queryParams)
-        .end()
-    case 'patch':
-      return app
-        .inject()
-        .patch(path)
-        .body(params.body)
-        .headers(resolvedHeaders)
-        .query(params.queryParams)
-        .end()
-    default:
-      throw new Error(`Unsupported HTTP method: ${method}`)
-  }
+  return dispatchInjectByMethod(app, apiContract.method, path, params)
 }

--- a/packages/app/fastify-api-contracts/src/injectRequestDispatcher.ts
+++ b/packages/app/fastify-api-contracts/src/injectRequestDispatcher.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from 'fastify'
+import type { Response as LightMyRequestResponse } from 'light-my-request'
+
+// biome-ignore lint/suspicious/noExplicitAny: we don't care about what kind of app instance we get here
+export type AnyFastifyInstance = FastifyInstance<any, any, any, any>
+
+type DispatchParams = {
+  // biome-ignore lint/suspicious/noExplicitAny: headers shape depends on the contract
+  headers?: any
+  // biome-ignore lint/suspicious/noExplicitAny: body shape depends on the contract
+  body?: any
+  // biome-ignore lint/suspicious/noExplicitAny: query shape depends on the contract
+  queryParams?: any
+}
+
+/**
+ * Shared runtime dispatch for the contract-based request injectors.
+ *
+ * The HTTP method and resolved path are derived from the contract by the caller; this helper only
+ * turns them into a `light-my-request` injection. `headers` may be a plain object or a (sync or
+ * async) factory, which is resolved here before dispatching.
+ */
+export async function dispatchInjectByMethod(
+  app: AnyFastifyInstance,
+  method: string,
+  path: string,
+  params: DispatchParams,
+): Promise<LightMyRequestResponse> {
+  const resolvedHeaders =
+    typeof params.headers === 'function' ? await params.headers() : params.headers
+
+  switch (method) {
+    case 'get':
+      return app.inject().get(path).headers(resolvedHeaders).query(params.queryParams).end()
+    case 'delete':
+      return app.inject().delete(path).headers(resolvedHeaders).query(params.queryParams).end()
+    case 'post':
+      return app
+        .inject()
+        .post(path)
+        .body(params.body)
+        .headers(resolvedHeaders)
+        .query(params.queryParams)
+        .end()
+    case 'put':
+      return app
+        .inject()
+        .put(path)
+        .body(params.body)
+        .headers(resolvedHeaders)
+        .query(params.queryParams)
+        .end()
+    case 'patch':
+      return app
+        .inject()
+        .patch(path)
+        .body(params.body)
+        .headers(resolvedHeaders)
+        .query(params.queryParams)
+        .end()
+    default:
+      throw new Error(`Unsupported HTTP method: ${method}`)
+  }
+}


### PR DESCRIPTION
## What

Adds **`injectByApiContract`** to `@lokalise/fastify-api-contracts` — a test-request injector for contracts created with the current `defineApiContract` API of `@lokalise/api-contracts`. It is the `defineApiContract` counterpart to the existing `injectByContract` (which targets the deprecated `buildRestContract`/`buildGetRoute`/`buildPayloadRoute` definitions).

## Why a parallel function instead of extending `injectByContract`

The two contract systems are structurally distinct:

- The old definitions (`GetRouteDefinition`/`DeleteRouteDefinition`/`PayloadRouteDefinition`) require `successResponseBodySchema` and rely on generic-slot extraction.
- `defineApiContract` produces a discriminated `ApiContract` union built around `responsesByStatusCode` and a `ContractNoBody` sentinel.

Adding three more overloads to `injectByContract`'s existing three-overload set would mix two fundamentally different generic-inference strategies in one overload group — fragile resolution and worse error messages. The new API also already ships a clean, well-tested param-derivation type (`ClientRequestParams`), so the parallel function is both simpler and more type-safe. Naming mirrors the contract side: `defineApiContract` ↔ `injectByApiContract`.

## Details

- Params (`pathParams` / `body` / `queryParams` / `headers` / `pathPrefix`) are resolved directly from the contract via `ClientRequestParams`, so each field is required only when its request schema is present.
- `ContractNoBody` request bodies correctly drop the `body` field.
- `headers` accepts a plain object or a (sync or async) factory.
- `pathPrefix` is optional and, when provided, is prepended to the resolved path (matching the contract client's behavior) — useful for hitting routes mounted under a Fastify prefix.
- The resolved params type is exported as `InjectByApiContractParams<typeof contract>`.
- The shared runtime dispatch (header resolution + per-method `light-my-request` injection) is extracted into an internal `injectRequestDispatcher`, so `injectByContract` and `injectByApiContract` share one code path. `injectByContract`'s behavior is unchanged.
- README updated with a new section + ToC entry and cross-references; changeset added (minor).

## Testing

- New `injectByApiContract.spec.ts`: GET/DELETE/POST/PUT/PATCH, header object + sync/async factories, no-schema contract, `pathPrefix`, `ContractNoBody` request/response, plus `expectTypeOf` checks for required-vs-optional param resolution.
- Full package suite: **146 tests pass**, `tsc` clean, no type errors. `injectByContract`'s existing tests pass unchanged after the dispatch extraction.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
