### PR TITLE
fix(auth): cache JWKS lookups for empty-string kid tokens

### DIFF
--- a/.changeset/fluffy-stars-crash.md
+++ b/.changeset/fluffy-stars-crash.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/auth": patch
+---
+
+Fix JwksTokenDecoder bypassing the jwks-rsa cache for tokens with an empty-string `kid`.

--- a/packages/app/auth/src/token-decoders/JwksTokenDecoder.spec.ts
+++ b/packages/app/auth/src/token-decoders/JwksTokenDecoder.spec.ts
@@ -187,6 +187,67 @@ describe('JwksTokenDecoder', () => {
       })
     })
 
+    describe('empty string kid', () => {
+      let emptyKidContext: TestContext
+      let emptyKidServer: JwksServer
+      let client: ReturnType<typeof jwksClient>
+      let emptyKidDecoder: JwksTokenDecoder
+
+      beforeAll(async () => {
+        emptyKidContext = await createTestContext('')
+        emptyKidServer = new JwksServer()
+        await emptyKidServer.start(emptyKidContext)
+      })
+
+      afterAll(async () => {
+        await emptyKidServer.stop()
+      })
+
+      beforeEach(() => {
+        // Fresh client per test so the lru-memoizer cache starts empty.
+        client = jwksClient({
+          jwksUri: emptyKidServer.jwksUrl,
+          cache: true,
+        })
+        emptyKidDecoder = new JwksTokenDecoder(client, {
+          algorithms: ['RS256'],
+          clockTolerance: 30,
+          requiredClaims: ['exp'],
+        })
+      })
+
+      it('verifies the token and resolves the key with a normalized (undefined) kid', async () => {
+        // Given
+        const getSigningKeySpy = vi.spyOn(client, 'getSigningKey')
+        const token = await createToken(emptyKidContext, { foo: 'bar' })
+
+        // When
+        const result = await emptyKidDecoder.decode(reqContext, token)
+
+        // Then
+        expect(result).toEqual({
+          result: expect.objectContaining({ foo: 'bar' }),
+        })
+        expect(getSigningKeySpy).toHaveBeenCalledWith(undefined)
+      })
+
+      it('serves repeated decodes from cache instead of refetching the JWKS each time', async () => {
+        // Given
+        // getSigningKeys() performs the uncached network fetch of the JWKS. With the
+        // cached getSigningKey path it runs once; the buggy getSigningKeys() fallback ran
+        // it on every request.
+        const getSigningKeysSpy = vi.spyOn(client, 'getSigningKeys')
+        const token = await createToken(emptyKidContext, { foo: 'bar' })
+
+        // When
+        await emptyKidDecoder.decode(reqContext, token)
+        await emptyKidDecoder.decode(reqContext, token)
+
+        // Then
+        expect(getSigningKeysSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+
     describe('cryptographic verification', () => {
       it('rejects JWT signed with different key', async () => {
         // Given

--- a/packages/app/auth/src/token-decoders/JwksTokenDecoder.spec.ts
+++ b/packages/app/auth/src/token-decoders/JwksTokenDecoder.spec.ts
@@ -233,9 +233,6 @@ describe('JwksTokenDecoder', () => {
 
       it('serves repeated decodes from cache instead of refetching the JWKS each time', async () => {
         // Given
-        // getSigningKeys() performs the uncached network fetch of the JWKS. With the
-        // cached getSigningKey path it runs once; the buggy getSigningKeys() fallback ran
-        // it on every request.
         const getSigningKeysSpy = vi.spyOn(client, 'getSigningKeys')
         const token = await createToken(emptyKidContext, { foo: 'bar' })
 

--- a/packages/app/auth/src/token-decoders/JwksTokenDecoder.ts
+++ b/packages/app/auth/src/token-decoders/JwksTokenDecoder.ts
@@ -24,11 +24,12 @@ export class JwksTokenDecoder extends TokenDecoder {
     this.jwksClient = jwksClient
   }
 
-  private async getPublicKey(header: FreeformRecord): Promise<string> {
-    return 'kid' in header && typeof header.kid === 'string' ?
-        this.getKeyByKid(header.kid) :
-        // if kid is not present or string, fallback to the first available key
-        this.getFirstAvailableKey()
+  private getPublicKey(header: FreeformRecord): Promise<string> {
+    // Resolve through the cached getSigningKey(kid) path when a string kid is present;
+    // otherwise fall back to the first available key.
+    return 'kid' in header && typeof header.kid === 'string'
+      ? this.getKeyByKid(header.kid)
+      : this.getFirstAvailableKey()
   }
 
   private async getKeyByKid(kid: string): Promise<string> {

--- a/packages/app/auth/src/token-decoders/JwksTokenDecoder.ts
+++ b/packages/app/auth/src/token-decoders/JwksTokenDecoder.ts
@@ -24,8 +24,16 @@ export class JwksTokenDecoder extends TokenDecoder {
     this.jwksClient = jwksClient
   }
 
+  private async getPublicKey(header: FreeformRecord): Promise<string> {
+    return 'kid' in header && typeof header.kid === 'string' ?
+        this.getKeyByKid(header.kid) :
+        // if kid is not present or string, fallback to the first available key
+        this.getFirstAvailableKey()
+  }
+
   private async getKeyByKid(kid: string): Promise<string> {
-    const key = await this.jwksClient.getSigningKey(kid)
+    // An empty-string kid is normalized to undefined internally by jwksClient
+    const key = await this.jwksClient.getSigningKey(kid.length ? kid : undefined)
     return key.getPublicKey()
   }
 
@@ -36,9 +44,5 @@ export class JwksTokenDecoder extends TokenDecoder {
     /* v8 ignore stop */
 
     return keys[0].getPublicKey()
-  }
-
-  private getPublicKey(header: FreeformRecord): Promise<string> {
-    return header.kid ? this.getKeyByKid(header.kid) : this.getFirstAvailableKey()
   }
 }


### PR DESCRIPTION
## What

`JwksTokenDecoder.getPublicKey` selected the key-resolution path with a **truthy** check on `header.kid`:

```ts
return header.kid ? this.getKeyByKid(header.kid) : this.getFirstAvailableKey()
```

An empty string is falsy, so tokens whose JWT header carries `kid: ""` (e.g. Expert tokens — and the JWKS at `/.well-known/jwks` publishes its key with `kid: ""` too) fell through to `getFirstAvailableKey()` → `jwksClient.getSigningKeys()`.

jwks-rsa only memoizes `getSigningKey(kid)` (singular). `getSigningKeys()` / `getKeys()` are **uncached**, so every request reopened a TLS connection to the JWKS host and refetched the full key set.

## Fix

Route a string `kid` (including `""`) through the cached `getSigningKey()` path, normalizing **only** an empty-string `kid` to `undefined`:

```ts
private getPublicKey(header: FreeformRecord): Promise<string> {
  return 'kid' in header && typeof header.kid === 'string'
    ? this.getKeyByKid(header.kid)
    : this.getFirstAvailableKey()
}

private async getKeyByKid(kid: string): Promise<string> {
  const key = await this.jwksClient.getSigningKey(kid.length ? kid : undefined)
  return key.getPublicKey()
}
```

Why normalize `""` → `undefined`: jwks-rsa **strips empty-string kids** while parsing the JWKS (`utils.js`: `typeof jwk.kid === 'string' && jwk.kid ? ...`), so the stored key ends up with `kid: undefined`. Calling `getSigningKey("")` would therefore never match and throw `SigningKeyNotFoundError` (→ `INVALID_TOKEN`). `getSigningKey(undefined)` returns the single published key and is memoized under that cache key. Non-empty kids — including whitespace, which jwks-rsa **preserves** — are looked up verbatim; tokens with no `kid` property keep the first-available-key fallback.

## Impact

Every service using `@lokalise/auth` with empty-`kid` tokens was refetching the JWKS on every request. With the fix those lookups hit the 24h `getSigningKey` cache. Observed on TM `bulk-find-matches` (136 samples, last 24h):

- preHandler p50: **49ms → ~1ms** (matching `/records`, which already uses a cached/static-key path)
- preHandler p99: **401ms → low single digits**
- Long-tail spikes during upstream JWKS-host incidents (e.g. a 14s outlier) disappear, since healthy requests no longer depend on the JWKS host being reachable per request

## Tests

New `empty string kid` describe block in `JwksTokenDecoder.spec.ts`:
- verifies a `kid: ""` token decodes and resolves the key with a normalized (`undefined`) kid
- decoding the same empty-kid token twice fetches the JWKS **once** (cache hit on the second decode) — fails on the old `getSigningKeys()` path (2 fetches)

All 66 package tests pass, 100% coverage, lint clean.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**