### PR TITLE
fix(background-jobs-common): demote bullmq control-flow errors to debug

### DIFF
--- a/.changeset/bullmq-control-flow-error-log.md
+++ b/.changeset/bullmq-control-flow-error-log.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/background-jobs-common": patch
+---
+
+Stop logging BullMQ control-flow errors (`DelayedError`, `WaitingChildrenError`, `RateLimitError`) as job attempt failures. These errors are cooperative signals a processor throws after `moveToDelayed`/`moveToWaitingChildren`/`rateLimit` to hand the job back to BullMQ, not real failures. They now emit a `"<jobName> deferred via <ErrorName>"` debug log instead of the `"<jobName> try failed"` error log.

--- a/packages/app/background-jobs-common/src/background-job-processor/errors/utils.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/errors/utils.ts
@@ -1,5 +1,5 @@
 import { isError } from '@lokalise/node-core'
-import { UnrecoverableError } from 'bullmq'
+import { DelayedError, RateLimitError, UnrecoverableError, WaitingChildrenError } from 'bullmq'
 import {
   MUTED_UNRECOVERABLE_ERROR_SYMBOL,
   type MutedUnrecoverableError,
@@ -17,3 +17,15 @@ export const isStalledJobError = (error: Error): boolean =>
 
 export const isJobMissingError = (error: unknown): boolean =>
   isError(error) && error.message.startsWith('Missing key for job')
+
+const BULLMQ_CONTROL_FLOW_ERROR_NAMES: ReadonlySet<string> = new Set([
+  DelayedError.name,
+  WaitingChildrenError.name,
+  RateLimitError.name,
+])
+
+// BullMQ uses these errors as cooperative signals from a processor to move a job
+// to a different state (delayed, waiting-children, rate-limited). They are control
+// flow, not failures, so they should not be reported as job errors.
+export const isBullmqControlFlowError = (error: unknown): boolean =>
+  isError(error) && BULLMQ_CONTROL_FLOW_ERROR_NAMES.has(error.name)

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.spec.ts
@@ -1,4 +1,5 @@
 import { generateMonotonicUuid } from '@lokalise/id-utils'
+import { DelayedError, RateLimitError, WaitingChildrenError } from 'bullmq'
 import pino from 'pino'
 import {
   afterAll,
@@ -247,6 +248,36 @@ describe('BackgroundJobProcessorMonitor', () => {
           }),
         }),
         'name_test-correlation-id_job try failed',
+      ])
+    })
+
+    it.each([
+      ['DelayedError', () => new DelayedError()],
+      ['WaitingChildrenError', () => new WaitingChildrenError()],
+      ['RateLimitError', () => new RateLimitError()],
+    ])('should log %s at debug level as bullmq control flow', (name, makeError) => {
+      const job = createFakeJob('test-correlation-id', 30)
+      const requestContext = {
+        reqId: 'test-req-id',
+        logger: {
+          debug: (_obj: unknown, _msg: unknown) => undefined,
+          error: (_obj: unknown, _msg: unknown) => undefined,
+        },
+      } as unknown as RequestContext
+      const errorSpy = vi.spyOn(requestContext.logger, 'error')
+      const debugSpy = vi.spyOn(requestContext.logger, 'debug')
+
+      monitor.jobAttemptError(job, makeError(), requestContext)
+
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(debugSpy).toHaveBeenCalledOnce()
+      expect(debugSpy.mock.calls[0]).toMatchObject([
+        expect.objectContaining({
+          jobProgress: 30,
+          origin: 'BackgroundJobProcessorMonitor tests',
+          error: expect.objectContaining({ type: name }),
+        }),
+        `name_test-correlation-id_job deferred via ${name}`,
       ])
     })
   })

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.ts
@@ -4,6 +4,7 @@ import {
   resolveGlobalErrorLogObject,
   type TransactionObservabilityManager,
 } from '@lokalise/node-core'
+import { isBullmqControlFlowError } from '../errors/utils.ts'
 import { BackgroundJobProcessorLogger } from '../logger/BackgroundJobProcessorLogger.ts'
 import type { BackgroundJobProcessorDependencies } from '../processors/types.ts'
 import type { BaseJobPayload, RequestContext, SafeJob } from '../types.ts'
@@ -98,6 +99,16 @@ export class BackgroundJobProcessorMonitor<
   }
 
   public jobAttemptError(job: JobType, error: unknown, requestContext: RequestContext): void {
+    // BullMQ control-flow errors (DelayedError, WaitingChildrenError, RateLimitError) are
+    // cooperative state-transition signals, not failures. Log them at debug level so they're
+    // visible when investigating but don't pollute prod logs at info+.
+    if (isBullmqControlFlowError(error)) {
+      requestContext.logger.debug(
+        this.buildLogParams(job, error),
+        `${job.name} deferred via ${(error as Error).name}`,
+      )
+      return
+    }
     requestContext.logger.error(this.buildLogParams(job, error), `${job.name} try failed`)
   }
 


### PR DESCRIPTION
  ## Summary

`BackgroundJobProcessorMonitor.jobAttemptError` was treating every error thrown from `processInternal` as a job failure and logging it at `error` level with `"<jobName> try failed"`. This included BullMQ's cooperative control-flow errors - `DelayedError`, `WaitingChildrenError`, `RateLimitError` - which a processor throws after `moveToDelayed` / `moveToWaitingChildren` / `rateLimit` to hand the job back to BullMQ.

These aren't failures, so logging them at `error` level was misleading (the package itself does this in its own barrier path, so any barrier-driven delay was producing a noisy error log in prod).

  ## Changes

  - Added `isBullmqControlFlowError` helper in `errors/utils.ts` (matches the existing `error.name === X.name` pattern used by `isUnrecoverableJobError`).
  - `BackgroundJobProcessorMonitor.jobAttemptError` now detects control-flow errors and logs `"<jobName> deferred via <ErrorName>"` at `debug` level instead of the `error` log. Real failures still log at `error` unchanged.

  ### Why `debug` and not silent / `warn` / `info`?

  - Silent is hard to debug later when investigating "why is this job stuck in delayed?".
  - `warn` would cry wolf - these are normal control flow.
  - `info` would add steady noise on healthy rate-limit / retry-heavy workers.
  - `debug` matches the existing precedent in `AbstractBackgroundJobProcessor.barrier` (`"Did not pass the barrier"` is also debug).

  ## Test plan

  - [x] New unit tests in `BackgroundJobProcessorMonitor.spec.ts` asserting `logger.error` is NOT called and `logger.debug` IS called with the expected payload for each of
  `DelayedError`, `WaitingChildrenError`, `RateLimitError`.
  - [x] Existing `jobAttemptError` "should log error" test still passes (real errors still log at `error`).
  - [x] Full package suite green (211 tests passing).
  - [x] Barrier integration specs run clean - no more `"try failed"` error logs for delayed jobs.
  - [x] `pnpm run lint` (biome + tsc) clean.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
