### PR TITLE
Fix api contract path types

### DIFF
--- a/.changeset/deprecate-is-no-body-success-response.md
+++ b/.changeset/deprecate-is-no-body-success-response.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/api-contracts": patch
+---
+
+Deprecate `IsNoBodySuccessResponse` — no known consumers; will be removed in a future release.

--- a/.changeset/fix-define-api-contract-method-body-enforcement.md
+++ b/.changeset/fix-define-api-contract-method-body-enforcement.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/api-contracts": patch
+---
+
+Fix `defineApiContract` not enforcing method/body rules: a non-distributive `Omit` collapsed the `ApiContract` discriminated union, allowing GET/DELETE contracts with a `requestBodySchema` and POST/PUT/PATCH contracts without one. Both are now compile-time errors.

--- a/.changeset/fix-no-body-response-type-inference.md
+++ b/.changeset/fix-no-body-response-type-inference.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/api-contracts": patch
+---
+
+Treat tagged `noBodyResponse()` the same as the `ContractNoBody` symbol in type-level inference: `IsNoBodySuccessResponse` now returns `true`, `AvailableResponseModes` includes `'noContent'`, and client response inference maps the body to `null` instead of `never`.

--- a/.changeset/fix-path-resolver-param-typing.md
+++ b/.changeset/fix-path-resolver-param-typing.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/api-contracts": patch
+---
+
+Type `pathResolver`'s parameter as `undefined` in `defineApiContract` when no `requestPathParamsSchema` is provided, matching the runtime call. Previously the parameter fell back to a loose `Record<string, unknown>`, allowing resolvers to read path params that are `undefined` at runtime.

--- a/packages/app/api-contracts/src/new/clientTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.spec.ts
@@ -13,7 +13,13 @@ import type {
   InferSseClientResponse,
 } from './clientTypes.ts'
 import { ContractNoBody } from './constants.ts'
-import { anyOfResponses, blobResponse, sseResponse, textResponse } from './contractResponse.ts'
+import {
+  anyOfResponses,
+  blobResponse,
+  noBodyResponse,
+  sseResponse,
+  textResponse,
+} from './contractResponse.ts'
 import { defineApiContract } from './defineApiContract.ts'
 
 type DefaultHeaders = Record<string, string>
@@ -290,6 +296,20 @@ describe('clientTypes', () => {
         method: 'delete',
         pathResolver: () => '/products/1',
         responsesByStatusCode: { 204: ContractNoBody },
+      })
+      type Result = InferNonSseClientResponse<typeof contract>
+      expectTypeOf<Result>().toEqualTypeOf<{
+        statusCode: 204
+        headers: DefaultHeaders
+        body: null
+      }>()
+    })
+
+    it('maps noBodyResponse() success to null body', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/products/1',
+        responsesByStatusCode: { 204: noBodyResponse() },
       })
       type Result = InferNonSseClientResponse<typeof contract>
       expectTypeOf<Result>().toEqualTypeOf<{

--- a/packages/app/api-contracts/src/new/clientTypes.ts
+++ b/packages/app/api-contracts/src/new/clientTypes.ts
@@ -54,20 +54,26 @@ type InferClientResponseHeaders<TApiContract extends ApiContract> =
 
 /**
  * Maps a single responsesByStatusCode entry value to its TypeScript body type.
+ * Both no-body forms (the ContractNoBody symbol and tagged noBodyResponse()) map to null.
  */
 type InferClientResponseBody<T> = T extends typeof ContractNoBody
   ? null
-  : T extends z.ZodType
-    ? InferSchemaOutput<T>
-    : T extends { _tag: 'TextResponse' }
-      ? string
-      : T extends { _tag: 'BlobResponse' }
-        ? Blob
-        : T extends { _tag: 'SseResponse'; schemaByEventName: infer S extends SseSchemaByEventName }
-          ? AsyncIterable<SseEventOf<S>>
-          : T extends { _tag: 'AnyOfResponses'; responses: Array<infer Item> }
-            ? InferClientResponseBody<Item>
-            : never
+  : T extends { _tag: 'NoBodyResponse' }
+    ? null
+    : T extends z.ZodType
+      ? InferSchemaOutput<T>
+      : T extends { _tag: 'TextResponse' }
+        ? string
+        : T extends { _tag: 'BlobResponse' }
+          ? Blob
+          : T extends {
+                _tag: 'SseResponse'
+                schemaByEventName: infer S extends SseSchemaByEventName
+              }
+            ? AsyncIterable<SseEventOf<S>>
+            : T extends { _tag: 'AnyOfResponses'; responses: Array<infer Item> }
+              ? InferClientResponseBody<Item>
+              : never
 
 /**
  * Like InferClientResponseBody but returns only SSE bodies — non-SSE entries resolve to never.

--- a/packages/app/api-contracts/src/new/contractResponse.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.ts
@@ -245,7 +245,7 @@ export function resolveResponseEntry(
     }
   }
 
-  const defaultEntry = responsesByStatusCode['default']
+  const defaultEntry = responsesByStatusCode.default
   if (defaultEntry) {
     return resolveContractResponse(defaultEntry, contentType, strictContentType)
   }

--- a/packages/app/api-contracts/src/new/defineApiContract.spec.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.spec.ts
@@ -61,6 +61,26 @@ describe('defineApiContract', () => {
       expect(mapApiContractToPath(route)).toBe('/users')
     })
 
+    it('types pathResolver param as undefined when no requestPathParamsSchema', () => {
+      defineApiContract({
+        method: 'get',
+        pathResolver: (params) => {
+          expectTypeOf(params).toEqualTypeOf<undefined>()
+          return '/users'
+        },
+        responsesByStatusCode: {},
+      })
+    })
+
+    it('rejects pathResolver that declares params when no requestPathParamsSchema', () => {
+      defineApiContract({
+        method: 'get',
+        // @ts-expect-error pathResolver cannot take params without requestPathParamsSchema
+        pathResolver: (params: { id: string }) => `/users/${params.id}`,
+        responsesByStatusCode: {},
+      })
+    })
+
     it('preserves method literal type', () => {
       const route = defineApiContract({
         method: 'post',

--- a/packages/app/api-contracts/src/new/defineApiContract.spec.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.spec.ts
@@ -72,6 +72,46 @@ describe('defineApiContract', () => {
       expectTypeOf(route.method).toEqualTypeOf<'post'>()
     })
 
+    it('rejects requestBodySchema on GET contracts', () => {
+      // @ts-expect-error GET must not accept a request body
+      defineApiContract({
+        method: 'get',
+        pathResolver: () => '/users',
+        requestBodySchema: z.object({ name: z.string() }),
+        responsesByStatusCode: {},
+      })
+    })
+
+    it('rejects requestBodySchema on DELETE contracts', () => {
+      // @ts-expect-error DELETE must not accept a request body
+      defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/users/1',
+        requestBodySchema: z.object({ name: z.string() }),
+        responsesByStatusCode: {},
+      })
+    })
+
+    it('requires requestBodySchema on POST contracts', () => {
+      // @ts-expect-error POST requires requestBodySchema
+      defineApiContract({
+        method: 'post',
+        pathResolver: () => '/users',
+        responsesByStatusCode: {},
+      })
+    })
+
+    it('accepts ContractNoBody as requestBodySchema on POST contracts', () => {
+      const route = defineApiContract({
+        method: 'post',
+        pathResolver: () => '/users',
+        requestBodySchema: ContractNoBody,
+        responsesByStatusCode: {},
+      })
+
+      expectTypeOf(route.requestBodySchema).toEqualTypeOf<typeof ContractNoBody>()
+    })
+
     it('preserves ContractNoBody sentinel in responsesByStatusCode', () => {
       const route = defineApiContract({
         method: 'delete',

--- a/packages/app/api-contracts/src/new/defineApiContract.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.ts
@@ -54,22 +54,21 @@ export type PayloadApiContract = CommonApiContract & {
 
 export type ApiContract = GetApiContract | DeleteApiContract | PayloadApiContract
 
-type TypedPathApiContract<T extends RequestPathParamsSchema> = DistributiveOmit<
-  ApiContract,
-  'pathResolver' | 'requestPathParamsSchema'
-> & {
-  pathResolver: RoutePathResolver<InferSchemaOutput<T>>
-  requestPathParamsSchema?: T
-}
+type TypedPathApiContract<TPathParamsSchema extends RequestPathParamsSchema | undefined> =
+  DistributiveOmit<ApiContract, 'pathResolver' | 'requestPathParamsSchema'> & {
+    pathResolver: RoutePathResolver<InferSchemaOutput<TPathParamsSchema>>
+    requestPathParamsSchema?: TPathParamsSchema
+  }
 
 export const defineApiContract = <
-  PathParamsSchema extends RequestPathParamsSchema,
-  const Contract extends TypedPathApiContract<PathParamsSchema>,
+  TPathParamsSchema extends RequestPathParamsSchema | undefined = undefined,
+  const TContract extends
+    TypedPathApiContract<TPathParamsSchema> = TypedPathApiContract<TPathParamsSchema>,
 >(
-  contract: Exactly<Contract, TypedPathApiContract<PathParamsSchema>> & {
-    requestPathParamsSchema?: PathParamsSchema
+  contract: Exactly<TContract, TypedPathApiContract<TPathParamsSchema>> & {
+    requestPathParamsSchema?: TPathParamsSchema
   },
-): Contract => contract
+): TContract => contract
 
 export const mapApiContractToPath = (routeConfig: ApiContract): string => {
   if (!routeConfig.requestPathParamsSchema) {

--- a/packages/app/api-contracts/src/new/defineApiContract.ts
+++ b/packages/app/api-contracts/src/new/defineApiContract.ts
@@ -5,7 +5,7 @@ import type {
   RoutePathResolver,
 } from '../apiContracts.ts'
 import { SUCCESSFUL_HTTP_STATUS_CODES } from '../HttpStatusCodes.ts'
-import type { Exactly } from '../typeUtils.ts'
+import type { DistributiveOmit, Exactly } from '../typeUtils.ts'
 import { ContractNoBody } from './constants.ts'
 import {
   isAnyOfResponses,
@@ -54,7 +54,7 @@ export type PayloadApiContract = CommonApiContract & {
 
 export type ApiContract = GetApiContract | DeleteApiContract | PayloadApiContract
 
-type TypedPathApiContract<T extends RequestPathParamsSchema> = Omit<
+type TypedPathApiContract<T extends RequestPathParamsSchema> = DistributiveOmit<
   ApiContract,
   'pathResolver' | 'requestPathParamsSchema'
 > & {

--- a/packages/app/api-contracts/src/new/inferTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.spec.ts
@@ -1,7 +1,13 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod/v4'
 import { ContractNoBody } from './constants.ts'
-import { anyOfResponses, blobResponse, sseResponse, textResponse } from './contractResponse.ts'
+import {
+  anyOfResponses,
+  blobResponse,
+  noBodyResponse,
+  sseResponse,
+  textResponse,
+} from './contractResponse.ts'
 import { defineApiContract } from './defineApiContract.ts'
 import type {
   AvailableResponseModes,
@@ -240,11 +246,41 @@ describe('inferTypes', () => {
       expectTypeOf<Result>().toEqualTypeOf<true>()
     })
 
+    it('returns true when all success responses are noBodyResponse()', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 204: noBodyResponse() },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
+    it('returns true for a mix of ContractNoBody and noBodyResponse()', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 202: ContractNoBody, 204: noBodyResponse() },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<true>()
+    })
+
     it('returns false when a success response has a JSON schema', () => {
       const contract = defineApiContract({
         method: 'get',
         pathResolver: () => '/test',
         responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+      })
+      type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<false>()
+    })
+
+    it('returns false when noBodyResponse() is mixed with a JSON schema', () => {
+      const contract = defineApiContract({
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: z.object({ id: z.string() }), 204: noBodyResponse() },
       })
       type Result = IsNoBodySuccessResponse<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<Result>().toEqualTypeOf<false>()
@@ -451,6 +487,26 @@ describe('inferTypes', () => {
       })
       type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<Result>().toEqualTypeOf<'sse'>()
+    })
+
+    it('includes noContent for ContractNoBody', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 204: ContractNoBody },
+      })
+      type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'noContent'>()
+    })
+
+    it('includes noContent for noBodyResponse()', () => {
+      const contract = defineApiContract({
+        method: 'delete',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 204: noBodyResponse() },
+      })
+      type Result = AvailableResponseModes<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<Result>().toEqualTypeOf<'noContent'>()
     })
   })
 

--- a/packages/app/api-contracts/src/new/inferTypes.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.ts
@@ -2,7 +2,7 @@ import type { z } from 'zod/v4'
 import type { SuccessfulHttpStatusCode } from '../HttpStatusCodes.ts'
 import type { ValueOf } from '../typeUtils.ts'
 import type { ContractNoBody } from './constants.ts'
-import type { ResponsesByStatusCode } from './contractResponse.ts'
+import type { NoBodyResponse, ResponsesByStatusCode } from './contractResponse.ts'
 
 type ExtractSuccessResponses<T extends ResponsesByStatusCode> = ValueOf<
   T,
@@ -10,11 +10,14 @@ type ExtractSuccessResponses<T extends ResponsesByStatusCode> = ValueOf<
 >
 
 /**
- * Returns true if all success responses have no body (ContractNoBody or no success status codes defined).
+ * Returns true if all success responses have no body
+ * (ContractNoBody, noBodyResponse(), or no success status codes defined).
+ *
+ * @deprecated No known consumers — will be removed in a future release.
  */
 export type IsNoBodySuccessResponse<T extends ResponsesByStatusCode> = [
   ExtractSuccessResponses<T>,
-] extends [typeof ContractNoBody | undefined]
+] extends [typeof ContractNoBody | NoBodyResponse | undefined]
   ? true
   : false
 
@@ -63,7 +66,7 @@ type NonSseBodyOf<T> = T extends { _tag: 'SseResponse' }
 /**
  * Infers the TypeScript output type of all non-SSE success responses.
  * JSON schemas → z.output<T>. TextResponse → string. BlobResponse → Blob.
- * ContractNoBody → undefined. SseResponse → never (excluded).
+ * ContractNoBody and noBodyResponse() → undefined. SseResponse → never (excluded).
  * AnyOfResponses are unpacked before mapping.
  */
 export type InferNonSseSuccessResponses<T extends ResponsesByStatusCode> = NonSseBodyOf<
@@ -120,4 +123,9 @@ export type AvailableResponseModes<T extends ResponsesByStatusCode> =
   | (HasAnySseSuccessResponse<T> extends true ? 'sse' : never)
   | (Extract<FlatSuccessResponses<T>, { _tag: 'BlobResponse' }> extends never ? never : 'blob')
   | (Extract<FlatSuccessResponses<T>, { _tag: 'TextResponse' }> extends never ? never : 'text')
-  | (Extract<FlatSuccessResponses<T>, typeof ContractNoBody> extends never ? never : 'noContent')
+  | (Extract<
+      FlatSuccessResponses<T>,
+      typeof ContractNoBody | { _tag: 'NoBodyResponse' }
+    > extends never
+      ? never
+      : 'noContent')

--- a/packages/app/api-contracts/src/typeUtils.ts
+++ b/packages/app/api-contracts/src/typeUtils.ts
@@ -21,11 +21,20 @@ export type Exactly<T, U> = T & {
 }
 
 /**
+ * Distributed `keyof`: the union of keys across all members of a union type.
+ * (Plain `keyof` over a union yields only the keys common to every member.)
+ */
+export type KeysOfUnion<TUnion> = TUnion extends unknown ? keyof TUnion : never
+
+/**
  * Like `Omit`, but distributes over unions: each union member is transformed
  * separately, preserving discriminated-union relationships between keys.
  * (Plain `Omit` collapses a union into a single object type of its common keys.)
+ *
+ * Keys are constrained to `KeysOfUnion` rather than `keyof TUnion`, so keys present
+ * on only some union members can be omitted too — members without the key pass through unchanged.
  */
-export type DistributiveOmit<TUnion, TKeys extends PropertyKey> = TUnion extends unknown
+export type DistributiveOmit<TUnion, TKeys extends KeysOfUnion<TUnion>> = TUnion extends unknown
   ? Omit<TUnion, TKeys>
   : never
 

--- a/packages/app/api-contracts/src/typeUtils.ts
+++ b/packages/app/api-contracts/src/typeUtils.ts
@@ -21,6 +21,15 @@ export type Exactly<T, U> = T & {
 }
 
 /**
+ * Like `Omit`, but distributes over unions: each union member is transformed
+ * separately, preserving discriminated-union relationships between keys.
+ * (Plain `Omit` collapses a union into a single object type of its common keys.)
+ */
+export type DistributiveOmit<TUnion, TKeys extends PropertyKey> = TUnion extends unknown
+  ? Omit<TUnion, TKeys>
+  : never
+
+/**
  * Extracts a union of value types from an object type.
  * Optionally constrained to a subset of keys via ValueType.
  */


### PR DESCRIPTION
## Changes

This PR fixes three compiler-verified type-safety holes in the new contract API (@lokalise/api-contracts) found during a detailed review, plus one deprecation. All changes are patch-level; runtime
  behavior is unchanged — every fix makes the type level tell the truth about what the runtime already does.                                                                            

### 1. defineApiContract did not enforce method/body rules

  TypedPathApiContract used Omit<ApiContract, ...>, and Omit over a union is not distributive — it collapsed the `GetApiContract | DeleteApiContract | PayloadApiContract` discriminated union into a single object type with method: 'get' | 'delete' | 'post' | 'put' | 'patch' and an optional requestBodySchema. As a result, both of these compiled with zero errors:

  defineApiContract({ method: 'get', requestBodySchema: z.object({...}), ... })  // GET with a body
  defineApiContract({ method: 'post', ... })  // POST without its required requestBodySchema

  Fix: new DistributiveOmit utility in typeUtils.ts; TypedPathApiContract now transforms each union member separately. Both cases above are compile errors again.

###  2. Tagged noBodyResponse() was invisible to type-level inference

  The runtime treats the ContractNoBody symbol and the tagged noBodyResponse() object as equivalent, but the type level only knew the symbol. For a { 204: noBodyResponse() } contract:

  - IsNoBodySuccessResponse returned false (symbol: true) → now true
  - AvailableResponseModes resolved to never instead of 'noContent' → now 'noContent'
  - client response inference produced body: never — an untypeable value (symbol: null) → now null

  The no-body convention is now also documented explicitly: handler/server-side inference (InferNonSseSuccessResponses) maps no-body to undefined, client-side inference maps it to null — matching what
  each side actually produces.

###  3. pathResolver param was loosely typed without a requestPathParamsSchema

  When requestPathParamsSchema was omitted, the schema generic fell back to its constraint (z.ZodObject), typing the resolver param as `Record<string, unknown>` — while the runtime always calls `pathResolver(undefined)` in that case. So a resolver could read path params that are undefined at runtime (/users/undefined, or a TypeError for (params: { id: string }) => ``).

  Fix: the generic now defaults to undefined, so without a schema the resolver param is typed undefined and reading params (or declaring a param shape) is a compile error. With a schema, params stay fully typed as before.

###  4. Deprecated IsNoBodySuccessResponse

  No known consumers — marked @deprecated, to be removed in a future release. Tests retained until removal.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
