### PR TITLE
Fix drizzle-utils Date handling

### DIFF
--- a/.changeset/drizzle-utils-timestamp-cast.md
+++ b/.changeset/drizzle-utils-timestamp-cast.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/drizzle-utils": patch
+---
+
+Fix drizzleFullBulkUpdate rejecting Date values: timestamp/date/time columns now serialize Date to an ISO-8601 string before the explicit VALUES cast, in both `where` and `data` columns.

--- a/packages/app/drizzle-utils/src/drizzleFullBulkUpdate.test.ts
+++ b/packages/app/drizzle-utils/src/drizzleFullBulkUpdate.test.ts
@@ -1,4 +1,4 @@
-import { jsonb, pgSchema, pgTable, smallint } from 'drizzle-orm/pg-core'
+import { jsonb, pgSchema, pgTable, smallint, timestamp } from 'drizzle-orm/pg-core'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
@@ -54,9 +54,15 @@ describe('drizzleFullBulkUpdate', () => {
     status: objectStatusDbEnum(),
   })
 
+  const timestampTableName = 'test_timestamp'
+  const timestampTable = pgTable(timestampTableName, {
+    id: smallint(),
+    updated_at: timestamp({ withTimezone: true }),
+  })
+
   beforeAll(async () => {
     await db.execute(
-      `DROP TABLE IF EXISTS ${surrogateTableName}, ${surrogateJsonTableName}, ${compositeTableName}, ${standardEnumTableName}, ${objectEnumTableName}`,
+      `DROP TABLE IF EXISTS ${surrogateTableName}, ${surrogateJsonTableName}, ${compositeTableName}, ${standardEnumTableName}, ${objectEnumTableName}, ${timestampTableName}`,
     )
     await db.execute(`DROP TYPE IF EXISTS ${enumSchema}.${standardStatusEnumName}`)
     await db.execute(`DROP TYPE IF EXISTS ${enumSchema}.${objectStatusEnumName}`)
@@ -83,6 +89,7 @@ describe('drizzleFullBulkUpdate', () => {
       db.execute(
         `CREATE TABLE ${objectEnumTableName} (id smallint, status ${enumSchema}.${objectStatusEnumName})`,
       ),
+      db.execute(`CREATE TABLE ${timestampTableName} (id smallint, updated_at timestamptz)`),
     ])
   })
 
@@ -93,6 +100,7 @@ describe('drizzleFullBulkUpdate', () => {
       db.delete(compositeTable),
       db.delete(standardEnumTable),
       db.delete(objectEnumTable),
+      db.delete(timestampTable),
     ])
   })
 
@@ -331,5 +339,28 @@ describe('drizzleFullBulkUpdate', () => {
         { id: 2, status: 'inactive' },
       ]),
     )
+  })
+
+  it('handles Date values in timestamp columns correctly', async () => {
+    await db.execute(`INSERT INTO ${timestampTableName} (id) values (1), (2)`)
+
+    const ts1 = new Date('2026-01-15T10:30:00.000Z')
+    const ts2 = new Date('2026-02-20T08:00:00.000Z')
+
+    await drizzleFullBulkUpdate(db, timestampTable, [
+      { where: { id: 1 }, data: { updated_at: ts1 } },
+      { where: { id: 2 }, data: { updated_at: ts2 } },
+    ])
+
+    const updatedData = (await db.execute(
+      `SELECT id, updated_at FROM ${timestampTableName} ORDER BY id`,
+    )) as unknown as { id: number; updated_at: string | Date }[]
+
+    expect(
+      updatedData.map((r) => ({ id: r.id, updated_at: new Date(r.updated_at).toISOString() })),
+    ).toEqual([
+      { id: 1, updated_at: ts1.toISOString() },
+      { id: 2, updated_at: ts2.toISOString() },
+    ])
   })
 })

--- a/packages/app/drizzle-utils/src/drizzleFullBulkUpdate.ts
+++ b/packages/app/drizzle-utils/src/drizzleFullBulkUpdate.ts
@@ -19,6 +19,23 @@ export type BulkUpdateEntry<T> = {
   data: T
 }
 
+// Serializes a single value into a `<value>::<type>` SQL fragment.
+// - json/jsonb: must be stringified so Postgres parses it as a JSON literal.
+// - Date: must be converted to an ISO-8601 string; a raw Date bound parameter
+//   is rejected on the explicit-cast VALUES path. ISO strings cast cleanly to
+//   timestamp / timestamptz / date / time.
+const toSqlCastValue = (value: unknown, type: string) => {
+  if (type === 'json' || type === 'jsonb') {
+    return sql`${JSON.stringify(value)}::${sql.raw(type)}`
+  }
+
+  if (value instanceof Date) {
+    return sql`${value.toISOString()}::${sql.raw(type)}`
+  }
+
+  return sql`${value}::${sql.raw(type)}`
+}
+
 const getColumns = (table: PgTable, columnNames: string[]): Column[] => {
   const tableColumns = getTableColumns(table)
 
@@ -59,7 +76,7 @@ const prepareSqlValuesExpressions = (
         )
       }
 
-      return sql`${whereConditionValue}::${sql.raw(whereConditionColumn.type)}`
+      return toSqlCastValue(whereConditionValue, whereConditionColumn.type)
     })
 
     if (dataColumns.length !== Object.keys(entry.data).length) {
@@ -77,11 +94,7 @@ const prepareSqlValuesExpressions = (
         )
       }
 
-      if (setExpressionColumn.type === 'json' || setExpressionColumn.type === 'jsonb') {
-        return sql`${JSON.stringify(setExpressionValue)}::${sql.raw(setExpressionColumn.type)}`
-      }
-
-      return sql`${setExpressionValue}::${sql.raw(setExpressionColumn.type)}`
+      return toSqlCastValue(setExpressionValue, setExpressionColumn.type)
     })
 
     return sql`(${sql.join(sqlWhereValues, sql.raw(','))},${sql.join(sqlSetValues, sql.raw(','))})`


### PR DESCRIPTION
## Fix `drizzleFullBulkUpdate` rejecting `Date` values

**Problem**

Passing a `Date` into a timestamp/date/time column caused Postgres to reject the query. The bulk update builds a `VALUES` list with explicit `::type` casts, and only `json`/`jsonb` values were being serialized beforehand — every other value was bound raw. A raw `Date` parameter on the explicit-cast path (`$1::timestamp`) is invalid, so the update failed.

**Fix**

Values are now serialized through a single shared helper before the cast: `json`/`jsonb` are stringified, `Date` is converted to an ISO-8601 string (which casts cleanly to `timestamp`/`timestamptz`/`date`/`time`), and everything else is bound as before. The helper is applied to both `where` and `data` columns, so timestamps work in either position.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
- [x] **Yes, AI assisted with this PR**
