### PR TITLE
feat(universal-ts-utils): add concatObjectValues util

### DIFF
--- a/.changeset/concat-object-values.md
+++ b/.changeset/concat-object-values.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/universal-ts-utils": minor
+---
+
+Add `concatObjectValues` util that flattens a list of objects into a single array of their values, typed as the union of every object's values. A readable replacement for the `[...Object.values(a), ...Object.values(b)]` spread pattern.

--- a/packages/app/universal-ts-utils/README.md
+++ b/packages/app/universal-ts-utils/README.md
@@ -226,6 +226,20 @@ areDeepEqual([1, [2, 3]], [1, [2, 3]]) // true
 areDeepEqual([{ id: 1 }], [{ id: 1 }]) // true
 ```
 
+#### `concatObjectValues`
+
+Flattens a list of objects into a single array containing all of their values. A readable replacement for the
+`[...Object.values(a), ...Object.values(b)]` spread pattern, useful for combining several keyed-by-name definitions
+(e.g. event, queue or message maps) into one array. The result is typed as the union of every input object's values.
+
+```typescript
+const ImportEvents = { created: { name: 'import.created' }, failed: { name: 'import.failed' } }
+const ExportEvents = { done: { name: 'export.done' } }
+
+const supportedEvents = concatObjectValues([ImportEvents, ExportEvents])
+// Returns: [{ name: 'import.created' }, { name: 'import.failed' }, { name: 'export.done' }]
+```
+
 #### `convertDateFieldsToIsoString`
 
 Recursively converts all Date fields in an object or array of objects to ISO string format. This function retains the

--- a/packages/app/universal-ts-utils/src/node.ts
+++ b/packages/app/universal-ts-utils/src/node.ts
@@ -19,6 +19,7 @@ export * from './public/array/uniqueByProperty.ts'
 export * from './public/iterable/collectFromIterable.ts'
 // object
 export * from './public/object/areDeepEqual.ts'
+export * from './public/object/concatObjectValues.ts'
 export * from './public/object/convertDateFieldsToIsoString.ts'
 export * from './public/object/copyWithoutEmpty.ts'
 export * from './public/object/copyWithoutNullish.ts'

--- a/packages/app/universal-ts-utils/src/public/object/concatObjectValues.spec.ts
+++ b/packages/app/universal-ts-utils/src/public/object/concatObjectValues.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { concatObjectValues } from './concatObjectValues.ts'
+
+describe('concatObjectValues', () => {
+  it('concatenates the values of multiple objects into a single array', () => {
+    const first = { a: 'a1', b: 'b1' }
+    const second = { c: 'c1' }
+    const third = { d: 'd1', e: 'e1' }
+
+    const result = concatObjectValues([first, second, third])
+
+    expect(result).toEqual(['a1', 'b1', 'c1', 'd1', 'e1'])
+  })
+
+  it('returns the values of a single object', () => {
+    const only = { a: 1, b: 2 }
+
+    const result = concatObjectValues([only])
+
+    expect(result).toEqual([1, 2])
+  })
+
+  it('returns an empty array when given no objects', () => {
+    const result = concatObjectValues([])
+
+    expect(result).toEqual([])
+  })
+
+  it('returns the values typed as the union of every object value', () => {
+    const events = { created: { name: 'created' as const } }
+    const processes = { started: { name: 'started' as const } }
+
+    const result = concatObjectValues([events, processes])
+
+    expectTypeOf(result).toEqualTypeOf<({ name: 'created' } | { name: 'started' })[]>()
+  })
+})

--- a/packages/app/universal-ts-utils/src/public/object/concatObjectValues.ts
+++ b/packages/app/universal-ts-utils/src/public/object/concatObjectValues.ts
@@ -27,5 +27,5 @@ export const concatObjectValues = <T extends object>(
   objects: T[],
 ): (T extends unknown ? ObjectValues<T> : never)[] =>
   objects.flatMap(
-    (object) => Object.values(object) as (T extends unknown ? ObjectValues<T> : never)[],
+    (object) => Object.values(object),
   )

--- a/packages/app/universal-ts-utils/src/public/object/concatObjectValues.ts
+++ b/packages/app/universal-ts-utils/src/public/object/concatObjectValues.ts
@@ -1,0 +1,31 @@
+import type { ObjectValues } from '../type/ObjectValues.ts'
+
+/**
+ * Concatenates the values of a list of objects into a single flat array.
+ *
+ * This is a readable replacement for the common
+ * `[...Object.values(a), ...Object.values(b)]` spread pattern used to combine
+ * several keyed-by-name definitions (e.g. event, queue or message maps) into a
+ * single array. The returned array is typed as the union of every input
+ * object's values, matching what the manual spread produces.
+ *
+ * @template T - The object type whose values are collected. When the array holds
+ * objects of different shapes, `T` is inferred as their union.
+ * @param {T[]} objects - The objects whose values should be concatenated.
+ * @returns {ObjectValues<T>[]} A flat array with the values of every object.
+ *
+ * @example
+ * ```typescript
+ * const supportedEvents = concatObjectValues([
+ *   ImportEvents,
+ *   ContentManagerEvents,
+ *   ExportProcessEvents,
+ * ])
+ * ```
+ */
+export const concatObjectValues = <T extends object>(
+  objects: T[],
+): (T extends unknown ? ObjectValues<T> : never)[] =>
+  objects.flatMap(
+    (object) => Object.values(object) as (T extends unknown ? ObjectValues<T> : never)[],
+  )

--- a/packages/app/universal-ts-utils/src/public/object/concatObjectValues.ts
+++ b/packages/app/universal-ts-utils/src/public/object/concatObjectValues.ts
@@ -26,6 +26,4 @@ import type { ObjectValues } from '../type/ObjectValues.ts'
 export const concatObjectValues = <T extends object>(
   objects: T[],
 ): (T extends unknown ? ObjectValues<T> : never)[] =>
-  objects.flatMap(
-    (object) => Object.values(object),
-  )
+  objects.flatMap((object) => Object.values(object))


### PR DESCRIPTION
## What

Adds a `concatObjectValues` utility to `@lokalise/universal-ts-utils`.

It flattens a list of objects into a single array containing all of their values — a readable replacement for the `[...Object.values(a), ...Object.values(b)]` spread pattern used across services to combine keyed-by-name definitions (SNS event maps, Amplitude message maps, bullmq queue maps) into a single array.

```ts
const supportedEvents = concatObjectValues([
  ImportEvents,
  ContentManagerEvents,
  ExportProcessEvents,
]) satisfies SnsAwareEventDefinition[]
```

The return type is the **union of every input object's values**, identical to the manual spread. It uses a distributive conditional type (`T extends unknown ? ObjectValues<T> : never`) so that a union of object shapes does not collapse to `never` — a non-distributive `ObjectValues<T>` would, since `keyof` of a union only keeps the keys common to every member.

## Why

This spread pattern is repeated in 10+ `CommonModule.ts` / `commonDiConfig.ts` files and is hard to read. Came out of a discussion to factor it into a generic TS util (alongside existing helpers like `ObjectValues` and `arrayToEnum`).

## Changes

- `src/public/object/concatObjectValues.ts` — implementation
- `src/public/object/concatObjectValues.spec.ts` — runtime + type tests (`expectTypeOf`)
- `src/node.ts` — export
- `README.md` — docs entry under Object Utilities
- changeset (minor)

## Testing

- `pnpm vitest run` → all pass
- `pnpm lint` (biome + tsc) → clean
- `pnpm test:ci` → 100% coverage maintained

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**