### PR TITLE
feat(tsconfig)!: default strict to true

### DIFF
--- a/.changeset/tsconfig-default-strict.md
+++ b/.changeset/tsconfig-default-strict.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/tsconfig": major
+---
+
+Set `compilerOptions.strict` to `true` in the base config. All presets extend `base.json`, so every consumer now gets strict mode by default instead of inheriting whatever the compiler defaults to. This pins the contract to the package rather than the TypeScript version (TS 6.0 flips `strict` to `true` by default). Consumers not yet ready for strict can opt out with `"strict": false`.

--- a/packages/dev/tsconfig/README.md
+++ b/packages/dev/tsconfig/README.md
@@ -128,6 +128,20 @@ To override either, set `rootDir` or `outDir` in your `tsconfig.build.json`:
 
 ## **Options That Can Be Disabled To Ease Adoption**
 
+### [strict](https://www.typescriptlang.org/tsconfig/#strict)
+
+Enables the full set of strict type-checking options. This is the default.
+
+To disable:
+```json
+{
+  "extends": "@lokalise/tsconfig/tsc",
+  "compilerOptions": {
+    "strict": false
+  }
+}
+```
+
 ### [erasableSyntaxOnly](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)
 
 It marks the following syntax as errors:

--- a/packages/dev/tsconfig/configs/base.json
+++ b/packages/dev/tsconfig/configs/base.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
+        "strict": true,
         "lib": ["ES2023"],
         "target": "ES2023",
         "skipLibCheck": true,


### PR DESCRIPTION
## Changes

Set `compilerOptions.strict` to `true` in `@lokalise/tsconfig`'s `base.json`. All presets (`tsc`, `tsc-dom`, `bundler`, `bundler-dom`, `build-app`, `build-public-lib`, `build-private-lib`) extend `base.json`, so strict mode is now the explicit default for every consumer.

The package requires TypeScript `>=6.0.0`, and TS 6.0 flips the `strict` default from `false` to `true` ([microsoft/TypeScript#63087](https://github.com/microsoft/TypeScript/pull/63087)). Until now no config set `strict`, so the contract was whatever the compiler defaulted to — it changed across the TS 6.0 upgrade with no diff in our config. Pinning `strict: true` ties the contract to this package instead of the compiler version.

Against TS 6.0 this is a no-op: consumers already get strict mode (verified — reverting the change produces identical typecheck output across the monorepo). The value is an explicit, stable contract that holds even if a consumer pins an older TS or the default flips again.

**Breaking change** → `major` bump for `@lokalise/tsconfig`. The published contract changes; a consumer on TS 5.x or one relying on the old default could see new type errors. Consumers not ready for strict can opt out with `"strict": false`, now documented in the README.

Closes #1087.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [ ] I've updated the tests, or no changes were necessary — N/A, config-only change

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
