### PR TITLE
ci: add zizmor GHA audit, bump actions, address zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,16 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     labels:
       - 'skip-release'
     ignore:

--- a/.github/workflows/ai-assistance-tracking.yml
+++ b/.github/workflows/ai-assistance-tracking.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions: {}
+
 jobs:
   validate-and-label:
     if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }} # Only run for human authors (skip bots)
@@ -49,18 +51,16 @@ jobs:
 
       - name: Add AI label
         if: steps.check_selection.outputs.ai_assisted == 'true'
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
-          repo: ${{ github.repository }}
-          labels: ai-assisted
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label ai-assisted
 
       - name: Remove AI label
         if: steps.check_selection.outputs.ai_assisted == 'false'
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.pull_request.number }}
-          repo: ${{ github.repository }}
-          labels: ai-assisted
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label ai-assisted

--- a/.github/workflows/ci.package.yml
+++ b/.github/workflows/ci.package.yml
@@ -9,16 +9,22 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node ${{ inputs.node_version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'pnpm'
@@ -27,10 +33,16 @@ jobs:
         run: pnpm install --ignore-scripts
 
       - name: Build
-        run: pnpm run build --filter=${{ inputs.package_name }}
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+        run: pnpm run build --filter="$PACKAGE_NAME"
 
       - name: Lint
-        run: pnpm run lint --filter=${{ inputs.package_name }}
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+        run: pnpm run lint --filter="$PACKAGE_NAME"
 
       - name: Run Tests
-        run: pnpm run test:ci --filter=${{ inputs.package_name }}
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+        run: pnpm run test:ci --filter="$PACKAGE_NAME"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,14 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   changed-files-job:
     name: Get changed packages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
     steps:
@@ -78,6 +82,8 @@ jobs:
   general:
     needs: [changed-files-job]
     if: needs.changed-files-job.outputs.packages != '[]'
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [22.x, 24.x]
@@ -95,6 +101,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3
+      - uses: fastify/github-action-merge-dependabot@73ec4cbb5e56df5591eae286972d5b2201ffe90f # v3.15.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   version:
     name: Release
@@ -23,10 +25,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked] changesets/action needs the persisted token to push the release branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -41,7 +44,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm run ci:publish
           title: "Release Packages"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: Zizmor GHA Audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # Inline mode: print findings to the console instead of uploading SARIF to Advanced Security.
+          advanced-security: false


### PR DESCRIPTION
## Summary

Adds the official [zizmor](https://github.com/zizmorcore/zizmor-action) GitHub Actions security audit as a workflow, bumps all actions to their latest versions (pinned to commit SHAs), and addresses every finding zizmor reports against the existing workflows.

## Changes

### New `zizmor.yml` workflow
- Runs `zizmorcore/zizmor-action@v0.5.7` on push to `main` and on PRs
- **Inline mode** (`advanced-security: false`) — findings are printed to the console rather than uploaded as SARIF to Advanced Security
- Least-privilege `permissions` (top-level `{}`, job-level `contents: read`)

### Action version bumps (all pinned to SHA)
| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v6.0.2 | v7.0.0 |
| `pnpm/action-setup` | v6.0.8 / `@v6` | v6.0.9 |
| `actions/setup-node` | `@v6` | v6.4.0 |
| `fastify/github-action-merge-dependabot` | `@v3` | v3.15.0 |
| `changesets/action` | v1.8.0 | v1.9.0 |

`tj-actions/changed-files` was already at the latest (v47.0.6).

### zizmor findings addressed
- **unpinned-uses** — all actions now pinned to full commit SHAs
- **template-injection** — `inputs.package_name` is now passed via an `env` var and referenced as `"$PACKAGE_NAME"` in `run:` steps instead of being interpolated directly
- **excessive-permissions** — added top-level `permissions: {}` and explicit per-job permissions to every workflow
- **artipacked** — set `persist-credentials: false` on checkouts that don't push; suppressed (with justification) on the release checkout, where `changesets/action` needs the persisted token to push the release branch
- **superfluous-actions** — replaced `actions-ecosystem/action-{add,remove}-labels` with `gh pr edit --add-label/--remove-label`

`zizmor --persona=regular .github/workflows/` now reports **no findings**.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**