### PR TITLE
chore: add dependabot group for @aws-sdk updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,6 @@ updates:
       opentelemetry:
         patterns:
           - "@opentelemetry/*"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"


### PR DESCRIPTION
## Summary

Adds a Dependabot group so all `@aws-sdk/*` npm updates are bundled into a single PR instead of one PR per package.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**