### PR TITLE
fix: unblock changesets publish under devEngines

### DIFF
--- a/.changeset/retrigger-bullboard-release.md
+++ b/.changeset/retrigger-bullboard-release.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/fastify-bullboard-plugin": patch
+---
+
+Retrigger release after fixing the changesets publish step, which failed with EBADDEVENGINES when npm validated the pnpm devEngines constraint.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "11.9.0",
-      "onFail": "error"
+      "onFail": "warn"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Problem

The [Release job](https://github.com/lokalise/shared-ts-libs/actions/runs/28785821459/job/85352126831) fails with:

```
error Received an unknown error code: EBADDEVENGINES for npm info "@lokalise/script-utils"
error Invalid devEngines.packageManager
error Invalid name "pnpm" does not match "npm" for "packageManager"
[ELIFECYCLE] Command failed with exit code 1.
```

The migration to `devEngines` (#1109) replaced the `packageManager` field with a `devEngines.packageManager` block whose `onFail` is `"error"`. During release, `changeset publish` shells out to `npm info <pkg>` from the repo root to check which versions are already published. npm validates the root `devEngines.packageManager` against the running manager (itself, npm), and hard-fails because the declared name is `pnpm`.

## Fix

Set `packageManager.onFail` to `"warn"`. `devEngines` still steers contributors toward pnpm (a warning shows on `npm install`), but it no longer hard-blocks npm's own read commands that changesets relies on during publish. The `runtime` (node) constraint keeps `onFail: "error"` since npm always runs on node.

A changeset bumping `@lokalise/fastify-bullboard-plugin` is included to retrigger its release once this lands.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
