### PR TITLE
feat: EXP-2144 NTC markup extract text between tags preserve spacing

### DIFF
--- a/.changeset/ntm-preserve-spacing-option.md
+++ b/.changeset/ntm-preserve-spacing-option.md
@@ -1,0 +1,5 @@
+---
+'@lokalise/non-translatable-markup': minor
+---
+
+Add `preserveSpacing` option to `extractTextBetweenTags`. When set, the extracted pieces keep their original whitespace (no trimming) and whitespace-only pieces are preserved, so joining the pieces with `''` reconstructs the original text minus the removed regions — without inventing or dropping spaces around them.

--- a/packages/app/non-translatable-markup/src/index.ts
+++ b/packages/app/non-translatable-markup/src/index.ts
@@ -1,5 +1,8 @@
 export { areNonTranslatableTagsComplementary } from './methods/areNonTranslatableTagsComplementary.ts'
-export { extractTextBetweenTags } from './methods/extractTextBetweenTags.ts'
+export {
+  type ExtractTextBetweenTagsOptions,
+  extractTextBetweenTags,
+} from './methods/extractTextBetweenTags.ts'
 export { isAttemptToEditNonTranslatableContent } from './methods/isAttemptToEditNonTranslatableContent.ts'
 export { isTextTranslatable } from './methods/isTextTranslatable.ts'
 export { removeNonTranslatableTags } from './methods/removeNonTranslatableTags.ts'

--- a/packages/app/non-translatable-markup/src/methods/extractTextBetweenTags.spec.ts
+++ b/packages/app/non-translatable-markup/src/methods/extractTextBetweenTags.spec.ts
@@ -102,4 +102,46 @@ describe('extractTextBetweenTags', () => {
       }),
     ).toEqual([testcase.text])
   })
+
+  it.each([
+    // NT region glued to punctuation: original spacing must survive so that
+    // joining the pieces with '' does not invent or drop spaces
+    {
+      text: 'Through their \uE101{op:1}\uE102strategic partnership\uE101{cl:1}\uE102, the experts',
+      result: ['Through their ', 'strategic partnership', ', the experts'],
+    },
+    // Whitespace-only pieces between NT regions are kept
+    {
+      text: 'foo \uE101{op:1}\uE102 \uE101{cl:1}\uE102bar',
+      result: ['foo ', ' ', 'bar'],
+    },
+    // Leading and trailing whitespace is kept
+    {
+      text: ' Hello \uE101World!\uE102 ',
+      result: [' Hello ', ' '],
+    },
+    // Adjacent NT regions produce no empty pieces
+    {
+      text: 'experience\uE101{ph:1}\uE102\uE101{op:2}\uE1024 steps',
+      result: ['experience', '4 steps'],
+    },
+    // HTML tags are still split out when keepHtml is not set
+    {
+      text: 'Hello</br>world',
+      result: ['Hello', 'world'],
+    },
+  ])('should extract text pieces between tags (%#) preserving spacing', (testcase) => {
+    expect(extractTextBetweenTags(testcase.text, { preserveSpacing: true })).toEqual(
+      testcase.result,
+    )
+  })
+
+  it('should preserve spacing while keeping HTML', () => {
+    expect(
+      extractTextBetweenTags('Their \uE101{op:1}\uE102<b>partnership</b>\uE101{cl:1}\uE102, ok', {
+        keepHtml: true,
+        preserveSpacing: true,
+      }),
+    ).toEqual(['Their ', '<b>partnership</b>', ', ok'])
+  })
 })

--- a/packages/app/non-translatable-markup/src/methods/extractTextBetweenTags.ts
+++ b/packages/app/non-translatable-markup/src/methods/extractTextBetweenTags.ts
@@ -1,23 +1,32 @@
 import { nonTranslatableTextRegexp, tagRegexpG } from './utils.ts'
 
+export type ExtractTextBetweenTagsOptions = {
+  keepNtc?: boolean
+  keepHtml?: boolean
+  preserveSpacing?: boolean
+}
+
 /**
  * Extract text parts between NTC tags and HTML like tags and returns them as array.
  * The tags itself and the content they wrap are removed from the result.
  *
- * With the second parameter (`options`) you can explicitly specify if you want to keep html and/or ntc tags
+ * With the second parameter (`options`) you can explicitly specify if you want to keep html and/or ntc tags.
+ * With `preserveSpacing` the pieces keep their original whitespace (no trimming), so joining them
+ * with '' reconstructs the text exactly as authored, minus the removed regions.
  *
  * Note:
  *  - symbols and numbers are preserved
- *  - result text parts are trimmed.
+ *  - result text parts are trimmed, unless `preserveSpacing` is set.
  *
  * Examples:
  *  - 'Hello world' -> ['Hello world']
  *  - '<div class="test">Hello</div> world' -> ['Hello', 'world']
- *  - 'Hello \uE101 world!\uE102' -> ['Hello', 'world']
+ *  - 'Hello \uE101world!\uE102' -> ['Hello']
+ *  - 'Hi \uE101x\uE102, bye' with `preserveSpacing` -> ['Hi ', ', bye']
  */
 export const extractTextBetweenTags = (
   text: string,
-  options?: { keepNtc?: boolean; keepHtml?: boolean },
+  options?: ExtractTextBetweenTagsOptions,
 ): string[] => {
   let pieces: string[] = [text]
   // split the text by non-translatable tags
@@ -25,7 +34,7 @@ export const extractTextBetweenTags = (
   // split the text by tags (<*>)
   if (!options?.keepHtml) pieces = pieces.flatMap((piece) => piece.split(tagRegexpG))
 
-  return pieces
-    .map((piece) => piece.trim()) // remove trailing whitespaces
-    .filter((piece) => piece !== '') // remove empty pieces
+  if (!options?.preserveSpacing) pieces = pieces.map((piece) => piece.trim())
+
+  return pieces.filter((piece) => piece !== '') // remove empty pieces
 }


### PR DESCRIPTION
## Changes

Adds an opt-in `preserveSpacing` option to `extractTextBetweenTags` (`@lokalise/non-translatable-markup`).

By default the function trims every extracted piece and drops whitespace-only pieces, so callers that re-join the pieces cannot reconstruct the original spacing — e.g. joining with `' '` invents a space that was never authored:

```
Input:  Through their ⟨NTC⟩{op:1}⟨/NTC⟩strategic partnership⟨NTC⟩{cl:1}⟨/NTC⟩, the experts…
Today:  Through their strategic partnership , the experts…   ← space before the comma
```

With `preserveSpacing: true` the pieces keep their original whitespace (no trimming, whitespace-only pieces kept), so joining them with `''` reconstructs the text exactly as authored, minus the removed regions:

```
['Through their ', 'strategic partnership', ', the experts…'] → 'Through their strategic partnership, the experts…'
```

* The option is **opt-in**: existing consumers (word counters, length validation) keep the current trimming behaviour.
* Also exports the `ExtractTextBetweenTagsOptions` type and fixes an inaccurate JSDoc example (`'Hello world!'` returns `['Hello']`, not `['Hello', 'world']`).

Context: [EXP-2144](https://lokalise.atlassian.net/browse/EXP-2144) — the in-context preview (FE live updates + BE static HTML) and the editor copy-to-clipboard invent spaces around removed NTC regions. Follow-up PR in `autopilot` will consume this via `preserveSpacing: true` + `join('')` after the release.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**


[EXP-2144]: https://lokalise.atlassian.net/browse/EXP-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ