### PR TITLE
feat: autocomplete common content types in response content maps

### DIFF
--- a/.changeset/response-content-type-autocomplete.md
+++ b/.changeset/response-content-type-autocomplete.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/api-contracts": minor
+---
+
+Add `ResponseContentType` and `CommonResponseContentType` types so well-known media types are autocompleted (with a string fallback) in `ResponseContentMap` keys and the `blobResponse()` content type argument.

--- a/packages/app/api-contracts/src/new/contractResponse.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.ts
@@ -87,8 +87,40 @@ export const isJsonBody = (value: BodyDescriptor): value is z.ZodType =>
  */
 export type BodyDescriptor = z.ZodType | BlobBody | SseBody
 
-/** Maps a response media type (e.g. `application/json`) to the body it carries. */
-export type ResponseContentMap = Record<string, BodyDescriptor>
+/** Commonly used response media types, offered as autocomplete suggestions. */
+export type CommonResponseContentType =
+  | 'application/json'
+  | 'application/octet-stream'
+  | 'application/pdf'
+  | 'application/x-ndjson'
+  | 'application/xml'
+  | 'application/zip'
+  | 'audio/mpeg'
+  | 'audio/ogg'
+  | 'image/gif'
+  | 'image/jpeg'
+  | 'image/png'
+  | 'image/svg+xml'
+  | 'image/webp'
+  | 'text/csv'
+  | 'text/event-stream'
+  | 'text/html'
+  | 'text/plain'
+  | 'video/mp4'
+  | 'video/webm'
+
+/**
+ * A response media type. Common values are autocompleted; any other string
+ * (e.g. a vendored variant like `application/json+01`) is accepted too.
+ */
+export type ResponseContentType = CommonResponseContentType | (string & {})
+
+/**
+ * Maps a response media type (e.g. `application/json`) to the body it carries.
+ * {@link CommonResponseContentType} keys are autocompleted; any other media type is accepted too.
+ */
+export type ResponseContentMap = Partial<Record<CommonResponseContentType, BodyDescriptor>> &
+  Record<string, BodyDescriptor>
 
 /** A content-map response carrying a body for one or more media types. */
 export type BodyContentResponseEntry = {
@@ -128,7 +160,7 @@ export const noBodyResponse = (options?: ResponseOptions): NoBodyContentResponse
  * Declares a binary/opaque response for a single media type.
  */
 export const blobResponse = (
-  contentType: string,
+  contentType: ResponseContentType,
   options?: ResponseOptions,
 ): BodyContentResponseEntry => ({
   content: { [contentType]: blobBody() },


### PR DESCRIPTION
## Summary

Improves DX of `ResponseContentMap` in `@lokalise/api-contracts`: content-type keys are now autocompleted by TypeScript while still accepting any string.

- Add `CommonResponseContentType` — a curated union of media types commonly used in API responses (JSON, NDJSON, SSE, common images/audio/video, pdf, zip, csv, etc.)
- Add `ResponseContentType = CommonResponseContentType | (string & {})` — the literal-union pattern that keeps autocomplete with a string fallback (e.g. vendored variants like `application/json+01` still work)
- `ResponseContentMap` is now `Partial<Record<CommonResponseContentType, BodyDescriptor>> & Record<string, BodyDescriptor>` — the intersection keeps the common keys optional (a plain `Record` over the union would make them all required) while arbitrary keys stay accepted
- `blobResponse()`'s `contentType` parameter uses `ResponseContentType` too

No runtime changes; purely type-level. Includes a `minor` changeset.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**