### PR TITLE
fix: mark instrumentation-http SERVER spans for SSE filtering (EXP-2169)

### DIFF
--- a/.changeset/sse-filter-http-server-span.md
+++ b/.changeset/sse-filter-http-server-span.md
@@ -1,0 +1,5 @@
+---
+'@lokalise/opentelemetry-fastify-bootstrap': patch
+---
+
+Fix `skipStreamEndpoints` not filtering the HTTP SERVER span. The SSE marker was only applied via the FastifyOtel `requestHook`, so the fastify request span was dropped but the `http.server.request` SERVER span created by `@opentelemetry/instrumentation-http` — the service entry span that latency metrics/SLOs are derived from — was still exported with the full stream lifetime as its duration. The marking hook is now also wired into `@opentelemetry/instrumentation-http` via `getNodeAutoInstrumentations`, so both request-level spans are dropped for streaming/SSE requests.

--- a/packages/app/opentelemetry-fastify-bootstrap/README.md
+++ b/packages/app/opentelemetry-fastify-bootstrap/README.md
@@ -121,7 +121,7 @@ initOpenTelemetry({
 })
 ```
 
-Streaming requests are detected by the `Accept: text/event-stream` request header — the header browser `EventSource` clients are required to send, and the same signal SSE content-negotiation keys on. Matching spans are tagged and dropped before export, generically for every streaming endpoint (no per-route list to maintain). The span still starts, so trace context still propagates to child spans, and it stays visible to console / user-supplied span processors — only the exported traces omit it.
+Streaming requests are detected by the `Accept: text/event-stream` request header — the header browser `EventSource` clients are required to send, and the same signal SSE content-negotiation keys on. Both request-level spans are tagged and dropped before export: the HTTP SERVER span from `@opentelemetry/instrumentation-http` (the service entry span that latency metrics/SLOs are derived from) and the fastify request span. This works generically for every streaming endpoint (no per-route list to maintain). The spans still start, so trace context still propagates to child spans, and they stay visible to console / user-supplied span processors — only the exported traces omit them.
 
 ### Adding Custom Span Processors
 

--- a/packages/app/opentelemetry-fastify-bootstrap/src/index.spec.ts
+++ b/packages/app/opentelemetry-fastify-bootstrap/src/index.spec.ts
@@ -1,5 +1,6 @@
+import type { IncomingMessage } from 'node:http'
 import { setTimeout as sleep } from 'node:timers/promises'
-import { SpanKind, trace } from '@opentelemetry/api'
+import { type Span, SpanKind, trace } from '@opentelemetry/api'
 import {
   InMemorySpanExporter,
   type ReadableSpan,
@@ -8,6 +9,47 @@ import {
 import { type FastifyInstance, fastify } from 'fastify'
 import { gracefulOtelShutdown, initOpenTelemetry } from './index.ts'
 import { STREAM_ENDPOINT_SPAN_ATTRIBUTE } from './streamSpanFilteringExporter.ts'
+
+// instrumentation-http patches node:http via module hooks that don't run under
+// vitest (no --import loader, and vite serves the modules), so a real-socket
+// request never produces an http SERVER span in these tests. To still cover the
+// SSE marking of that span — the service entry span latency metrics/SLOs are
+// derived from — we wrap getNodeAutoInstrumentations with a pass-through that
+// captures the config initOpenTelemetry hands it, and exercise the captured
+// requestHook directly. The real instrumentations are still constructed.
+const capturedAutoInstrumentations = vi.hoisted(() => ({ config: undefined as unknown }))
+
+vi.mock('@opentelemetry/auto-instrumentations-node', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@opentelemetry/auto-instrumentations-node')>()
+  const wrapped: typeof actual.getNodeAutoInstrumentations = (config) => {
+    capturedAutoInstrumentations.config = config
+    return actual.getNodeAutoInstrumentations(config)
+  }
+  return { ...actual, getNodeAutoInstrumentations: wrapped }
+})
+
+type HttpRequestHook = (span: Span, request: unknown) => void
+
+function capturedHttpRequestHook(): HttpRequestHook | undefined {
+  const config = capturedAutoInstrumentations.config as
+    | Record<string, { requestHook?: HttpRequestHook } | undefined>
+    | undefined
+  return config?.['@opentelemetry/instrumentation-http']?.requestHook
+}
+
+function fakeSpan(): { span: Span; attributes: Record<string, unknown> } {
+  const attributes: Record<string, unknown> = {}
+  const span = {
+    setAttribute: (key: string, value: unknown) => {
+      attributes[key] = value
+    },
+  } as unknown as Span
+  return { span, attributes }
+}
+
+function incomingMessageWithAccept(accept?: string): IncomingMessage {
+  return { headers: accept === undefined ? {} : { accept } } as IncomingMessage
+}
 
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV
 const ORIGINAL_OTEL_ENABLED = process.env.OTEL_ENABLED
@@ -453,61 +495,110 @@ describe('opentelemetry-fastify-bootstrap', () => {
       }
     })
 
-    it('tags streaming (Accept: text/event-stream) request spans with the stream marker', async () => {
-      app = fastify()
-      app.get('/events', async () => 'data')
-      await app.ready()
+    describe('stream endpoint marking', () => {
+      describe('fastify request span', () => {
+        it('tags streaming (Accept: text/event-stream) request spans with the stream marker', async () => {
+          app = fastify()
+          app.get('/events', async () => 'data')
+          await app.ready()
 
-      await app.inject().headers({ accept: 'text/event-stream' }).get('/events').end()
-      await waitForSpans(memoryExporter, 1)
+          await app.inject().headers({ accept: 'text/event-stream' }).get('/events').end()
+          await waitForSpans(memoryExporter, 1)
 
-      const eventsSpans = memoryExporter
-        .getFinishedSpans()
-        .filter(isFastifySpan)
-        .filter((span) => span.kind === SpanKind.SERVER)
-        .filter((span) => spanMentions(span, '/events'))
-      expect(eventsSpans.length).toBeGreaterThan(0)
-      expect(
-        eventsSpans.some((span) => span.attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE] === true),
-      ).toBe(true)
-    })
+          const eventsSpans = memoryExporter
+            .getFinishedSpans()
+            .filter(isFastifySpan)
+            .filter((span) => span.kind === SpanKind.SERVER)
+            .filter((span) => spanMentions(span, '/events'))
+          expect(eventsSpans.length).toBeGreaterThan(0)
+          expect(
+            eventsSpans.some((span) => span.attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE] === true),
+          ).toBe(true)
+        })
 
-    it('matches the Accept header case-insensitively (media types are case-insensitive)', async () => {
-      app = fastify()
-      app.get('/mixed-case', async () => 'data')
-      await app.ready()
+        it('matches the Accept header case-insensitively (media types are case-insensitive)', async () => {
+          app = fastify()
+          app.get('/mixed-case', async () => 'data')
+          await app.ready()
 
-      await app.inject().headers({ accept: 'Text/Event-Stream' }).get('/mixed-case').end()
-      await waitForSpans(memoryExporter, 1)
+          await app.inject().headers({ accept: 'Text/Event-Stream' }).get('/mixed-case').end()
+          await waitForSpans(memoryExporter, 1)
 
-      const spans = memoryExporter
-        .getFinishedSpans()
-        .filter(isFastifySpan)
-        .filter((span) => span.kind === SpanKind.SERVER)
-        .filter((span) => spanMentions(span, '/mixed-case'))
-      expect(spans.length).toBeGreaterThan(0)
-      expect(spans.some((span) => span.attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE] === true)).toBe(
-        true,
-      )
-    })
+          const spans = memoryExporter
+            .getFinishedSpans()
+            .filter(isFastifySpan)
+            .filter((span) => span.kind === SpanKind.SERVER)
+            .filter((span) => spanMentions(span, '/mixed-case'))
+          expect(spans.length).toBeGreaterThan(0)
+          expect(
+            spans.some((span) => span.attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE] === true),
+          ).toBe(true)
+        })
 
-    it('does not tag non-streaming request spans', async () => {
-      app = fastify()
-      app.get('/plain', async () => 'data')
-      await app.ready()
+        it('does not tag non-streaming request spans', async () => {
+          app = fastify()
+          app.get('/plain', async () => 'data')
+          await app.ready()
 
-      await app.inject().get('/plain').end()
-      await waitForSpans(memoryExporter, 1)
+          await app.inject().get('/plain').end()
+          await waitForSpans(memoryExporter, 1)
 
-      const plainSpans = memoryExporter
-        .getFinishedSpans()
-        .filter(isFastifySpan)
-        .filter((span) => span.kind === SpanKind.SERVER)
-        .filter((span) => spanMentions(span, '/plain'))
-      expect(plainSpans.length).toBeGreaterThan(0)
-      expect(
-        plainSpans.every((span) => span.attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE] === undefined),
-      ).toBe(true)
+          const plainSpans = memoryExporter
+            .getFinishedSpans()
+            .filter(isFastifySpan)
+            .filter((span) => span.kind === SpanKind.SERVER)
+            .filter((span) => spanMentions(span, '/plain'))
+          expect(plainSpans.length).toBeGreaterThan(0)
+          expect(
+            plainSpans.every(
+              (span) => span.attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE] === undefined,
+            ),
+          ).toBe(true)
+        })
+      })
+
+      describe('http server span (instrumentation-http)', () => {
+        it('wires a requestHook into @opentelemetry/instrumentation-http', () => {
+          expect(capturedHttpRequestHook()).toBeTypeOf('function')
+        })
+
+        it('marks the span when the incoming request negotiated SSE', () => {
+          const hook = capturedHttpRequestHook()
+          const { span, attributes } = fakeSpan()
+
+          hook?.(span, incomingMessageWithAccept('text/event-stream'))
+
+          expect(attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE]).toBe(true)
+        })
+
+        it('matches the Accept header case-insensitively', () => {
+          const hook = capturedHttpRequestHook()
+          const { span, attributes } = fakeSpan()
+
+          hook?.(span, incomingMessageWithAccept('Text/Event-Stream'))
+
+          expect(attributes[STREAM_ENDPOINT_SPAN_ATTRIBUTE]).toBe(true)
+        })
+
+        it('does not mark the span for non-SSE requests', () => {
+          const hook = capturedHttpRequestHook()
+          const { span, attributes } = fakeSpan()
+
+          hook?.(span, incomingMessageWithAccept('application/json'))
+          hook?.(span, incomingMessageWithAccept())
+
+          expect(attributes).toEqual({})
+        })
+
+        it('ignores outgoing client requests (no headers map) without crashing', () => {
+          const hook = capturedHttpRequestHook()
+          const { span, attributes } = fakeSpan()
+
+          // ClientRequest has no `headers` property — only IncomingMessage does.
+          expect(() => hook?.(span, { getHeader: () => undefined })).not.toThrow()
+          expect(attributes).toEqual({})
+        })
+      })
     })
 
     // End-to-end: dbNamespaceBySystem only shapes the Datadog-bound OTLP payload;

--- a/packages/app/opentelemetry-fastify-bootstrap/src/index.ts
+++ b/packages/app/opentelemetry-fastify-bootstrap/src/index.ts
@@ -1,3 +1,4 @@
+import type { ClientRequest, IncomingMessage } from 'node:http'
 import { FastifyOtelInstrumentation } from '@fastify/otel'
 import type { Span } from '@opentelemetry/api'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
@@ -79,20 +80,33 @@ const logger = {
 const DEFAULT_SKIPPED_PATHS = ['/health', '/metrics', '/']
 
 /**
- * Marks the request's HTTP server span as a streaming/SSE endpoint when the
- * client negotiated SSE via `Accept: text/event-stream`. Runs as the
- * FastifyOtel `requestHook`, so the span already exists; the marker is later
- * consumed by {@link StreamSpanFilteringExporter} to drop the span before it is
+ * Marks a span as belonging to a streaming/SSE request when the client
+ * negotiated SSE via `Accept: text/event-stream`. The marker is later consumed
+ * by {@link StreamSpanFilteringExporter} to drop the span before it is
  * exported. Browser `EventSource` clients are required to send this header, and
  * it is the same signal SSE content-negotiation keys on.
  */
-const markStreamEndpointSpan = (span: Span, request: FastifyRequest): void => {
-  const accept = request.headers.accept
+const markSpanIfStreamNegotiated = (span: Span, accept: string | string[] | undefined): void => {
   // Media types are case-insensitive (RFC 7231 §3.1.1.1), so normalize before matching.
   if (typeof accept === 'string' && accept.toLowerCase().includes('text/event-stream')) {
     span.setAttribute(STREAM_ENDPOINT_SPAN_ATTRIBUTE, true)
   }
 }
+const markStreamEndpointSpan = (span: Span, request: FastifyRequest): void =>
+  markSpanIfStreamNegotiated(span, request.headers.accept)
+const markStreamEndpointHttpSpan = (span: Span, request: ClientRequest | IncomingMessage): void =>
+  'headers' in request ? markSpanIfStreamNegotiated(span, request.headers.accept) : undefined
+
+/**
+ * Builds the node auto-instrumentations, wiring the SSE-marking hook into the
+ * HTTP instrumentation when stream-endpoint filtering is enabled.
+ */
+const createNodeAutoInstrumentations = (skipStreamEndpoints: boolean) =>
+  getNodeAutoInstrumentations(
+    skipStreamEndpoints
+      ? { '@opentelemetry/instrumentation-http': { requestHook: markStreamEndpointHttpSpan } }
+      : undefined,
+  )
 
 /**
  * Builds the Fastify OpenTelemetry instrumentation.
@@ -289,7 +303,7 @@ export function initOpenTelemetry(options: OpenTelemetryOptions = {}): void {
     sdk = new NodeSDK({
       spanProcessors: allSpanProcessors,
       instrumentations: [
-        getNodeAutoInstrumentations(),
+        createNodeAutoInstrumentations(skipStreamEndpoints),
         createFastifyOtelInstrumentation(skippedPaths, skipStreamEndpoints),
       ],
     })


### PR DESCRIPTION
## Changes

`skipStreamEndpoints` (enabled by default since 4.0.0) was not filtering the span that actually feeds latency metrics/SLOs.

The SSE marker was only wired into the **FastifyOtel** `requestHook`, so the fastify request span was dropped — but the `http.server.request` SERVER span created by `@opentelemetry/instrumentation-http` (via `getNodeAutoInstrumentations()`) was still exported with the full stream lifetime as its duration. That span is the service entry span Datadog derives `trace.http.server.request` metrics from, so SSE keep-alive streams (e.g. TSS `GET .../editor/bulk-actions`, 300s) kept burning the Editor 500ms latency SLO after the 4.0.0 rollout (verified in production, see EXP-2169).

This PR wires the same marking hook into `@opentelemetry/instrumentation-http`:

- `markStreamEndpointHttpSpan` marks the span when the incoming request (`IncomingMessage`) negotiated SSE via `Accept: text/event-stream`; outgoing `ClientRequest`s (no `headers` map) are left untouched.
- Detection logic shared with the fastify hook via `markSpanIfStreamNegotiated`.
- `StreamSpanFilteringExporter` needs no changes — it already drops any marked span.

**Why tests didn't catch this:** the suite uses `app.inject()`, which bypasses the network stack, and `instrumentation-http` can't patch `node:http` under vitest anyway (no `--import` loader, vite serves the modules). The new tests wrap `getNodeAutoInstrumentations` with a pass-through mock that captures the config `initOpenTelemetry` hands it and exercise the captured `requestHook` directly, grouped in `index.spec.ts` under `stream endpoint marking` alongside the fastify-span tests.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)