### PR TITLE
feat: EXP-2186 Text measure lib implementation

### DIFF
--- a/.changeset/text-measure-initial-release.md
+++ b/.changeset/text-measure-initial-release.md
@@ -1,0 +1,8 @@
+---
+"@lokalise/text-measure": major
+---
+
+Add `@lokalise/text-measure`, utilities to measure text:
+
+- `countCharacters` — NTC-aware character count with a pluggable algorithm (`utf16` / `codePoints`).
+- `countTranslatableWords` — NTC- and tag-aware, locale-aware word count.

--- a/packages/app/text-measure/README.md
+++ b/packages/app/text-measure/README.md
@@ -1,3 +1,46 @@
-# Text measure package
+# Text measure
 
-This package provides utils to measure text (e.g. character count, word count), with a pluggable counting unit.
+Utilities to measure text for Lokalise — character count and translatable word count — with
+pluggable counting rules. Runs in both the browser and Node.
+
+## `countCharacters`
+
+Counts the characters in a text. Non-translatable (NTC) marker tags are excluded (the content they
+wrap is kept); everything else in the text, including whitespace, is counted.
+
+```typescript
+import { countCharacters } from '@lokalise/text-measure'
+
+countCharacters('Hello world') // 11
+```
+
+The counting algorithm is pluggable via `options.algorithm` (defaults to `utf16`):
+
+- `utf16` — UTF-16 code units (JS `String.length`). A surrogate pair (e.g. an emoji) counts as two.
+- `codePoints` — Unicode code points. A surrogate pair counts as one.
+
+```typescript
+countCharacters('👍') // 2 (default: utf16)
+countCharacters('👍', { algorithm: 'utf16' }) // 2
+countCharacters('👍', { algorithm: 'codePoints' }) // 1
+```
+
+More algorithms (e.g. UTF-8 bytes, glyphs — à la XLIFF size-units) can be added over time.
+
+## `countTranslatableWords`
+
+Counts the translatable words in a text, excluding non-translatable content (NTC) and tags. Backed
+by `gmx-word-counter`.
+
+```typescript
+import { countTranslatableWords } from '@lokalise/text-measure'
+
+countTranslatableWords('Hello world') // 2
+```
+
+`options.locale` is a BCP47 language subtag used for word segmentation (defaults to `-`), so
+logographic scripts are counted correctly:
+
+```typescript
+countTranslatableWords('你好世界', { locale: 'zh' })
+```

--- a/packages/app/text-measure/package.json
+++ b/packages/app/text-measure/package.json
@@ -31,6 +31,10 @@
         "package-version": "echo $npm_package_version",
         "postversion": "biome check --write package.json"
     },
+    "dependencies": {
+        "@lokalise/non-translatable-markup": "workspace:^",
+        "gmx-word-counter": "^1.2.0"
+    },
     "devDependencies": {
         "@biomejs/biome": "^2.5.6",
         "@lokalise/biome-config": "workspace:^",

--- a/packages/app/text-measure/package.json
+++ b/packages/app/text-measure/package.json
@@ -6,6 +6,7 @@
     ],
     "license": "Apache-2.0",
     "type": "module",
+    "sideEffects": false,
     "main": "./dist/index.js",
     "homepage": "https://github.com/lokalise/shared-ts-libs",
     "repository": {

--- a/packages/app/text-measure/src/index.spec.ts
+++ b/packages/app/text-measure/src/index.spec.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from 'vitest'
-import { hello } from './index.ts'
-
-describe('text-measure', () => {
-  it('exports hello', () => {
-    expect(hello).toBe('world')
-  })
-})

--- a/packages/app/text-measure/src/index.ts
+++ b/packages/app/text-measure/src/index.ts
@@ -1,2 +1,1 @@
-// TODO: Implement package
-export const hello = 'world'
+export * from './methods/countTranslatableWords.ts'

--- a/packages/app/text-measure/src/index.ts
+++ b/packages/app/text-measure/src/index.ts
@@ -1,1 +1,2 @@
+export * from './methods/countCharacters.ts'
 export * from './methods/countTranslatableWords.ts'

--- a/packages/app/text-measure/src/methods/countCharacters.spec.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.spec.ts
@@ -1,0 +1,38 @@
+import {
+  NON_TRANSLATABLE_END_TAG,
+  NON_TRANSLATABLE_START_TAG,
+} from '@lokalise/non-translatable-markup'
+import { countCharacters } from './countCharacters.ts'
+
+describe('countCharacters', () => {
+  it('defaults to codePoints', () => {
+    expect(countCharacters('Hello 𐐷')).toBe(countCharacters('Hello 𐐷', { algorithm: 'codePoints' }))
+  })
+
+  it.each([
+    { name: 'plain text', text: 'Hello', expected: 5 },
+    { name: 'whitespace is counted', text: 'Hello world', expected: 11 },
+    { name: 'empty string', text: '', expected: 0 },
+    {
+      name: 'NTC markers are excluded but the content they wrap is kept',
+      text: `a${NON_TRANSLATABLE_START_TAG}bc${NON_TRANSLATABLE_END_TAG}d`,
+      expected: 4,
+    },
+    {
+      name: 'text consisting only of an NTC region keeps its content',
+      text: `${NON_TRANSLATABLE_START_TAG}abc${NON_TRANSLATABLE_END_TAG}`,
+      expected: 3,
+    },
+    {
+      name: 'multiple NTC regions, content kept',
+      text: `${NON_TRANSLATABLE_START_TAG}a${NON_TRANSLATABLE_END_TAG}x${NON_TRANSLATABLE_START_TAG}b${NON_TRANSLATABLE_END_TAG}`,
+      expected: 3,
+    },
+    { name: 'astral characters count as a single code point', text: '𐐷', expected: 1 },
+    { name: 'astral characters within surrounding text', text: 'a𐐷b', expected: 3 },
+    { name: 'emoji counts as its code points', text: '👍', expected: 1 },
+    { name: 'newlines and tabs are counted', text: 'a\n\tb', expected: 4 },
+  ])('counts characters with codePoints algorithm ($name)', ({ text, expected }) => {
+    expect(countCharacters(text, { algorithm: 'codePoints' })).toBe(expected)
+  })
+})

--- a/packages/app/text-measure/src/methods/countCharacters.spec.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.spec.ts
@@ -5,14 +5,17 @@ import {
 import { countCharacters } from './countCharacters.ts'
 
 describe('countCharacters', () => {
-  it('defaults to codePoints', () => {
-    expect(countCharacters('Hello 𐐷')).toBe(countCharacters('Hello 𐐷', { algorithm: 'codePoints' }))
+  it('defaults to utf16', () => {
+    expect(countCharacters('Hello')).toBe(countCharacters('Hello', { algorithm: 'utf16' }))
   })
 
+  // Simple strings and NTC handling — algorithm-agnostic (same result for every algorithm).
   it.each([
     { name: 'plain text', text: 'Hello', expected: 5 },
     { name: 'whitespace is counted', text: 'Hello world', expected: 11 },
+    { name: 'newlines and tabs are counted', text: 'a\n\tb', expected: 4 },
     { name: 'empty string', text: '', expected: 0 },
+    { name: 'non-ASCII BMP character', text: '€', expected: 1 },
     {
       name: 'NTC markers are excluded but the content they wrap is kept',
       text: `a${NON_TRANSLATABLE_START_TAG}bc${NON_TRANSLATABLE_END_TAG}d`,
@@ -28,11 +31,25 @@ describe('countCharacters', () => {
       text: `${NON_TRANSLATABLE_START_TAG}a${NON_TRANSLATABLE_END_TAG}x${NON_TRANSLATABLE_START_TAG}b${NON_TRANSLATABLE_END_TAG}`,
       expected: 3,
     },
-    { name: 'astral characters count as a single code point', text: '𐐷', expected: 1 },
-    { name: 'astral characters within surrounding text', text: 'a𐐷b', expected: 3 },
-    { name: 'emoji counts as its code points', text: '👍', expected: 1 },
-    { name: 'newlines and tabs are counted', text: 'a\n\tb', expected: 4 },
-  ])('counts characters with codePoints algorithm ($name)', ({ text, expected }) => {
-    expect(countCharacters(text, { algorithm: 'codePoints' })).toBe(expected)
+  ])('counts simple strings and NTC ($name)', ({ text, expected }) => {
+    expect(countCharacters(text)).toBe(expected)
+  })
+
+  describe('algorithm', () => {
+    it.each([
+      { name: 'emoji', text: '👍', expected: 2 },
+      { name: 'emoji within text', text: 'a👍b', expected: 4 },
+      { name: 'family emoji (ZWJ emoji sequence)', text: '👨‍👩‍👧', expected: 8 },
+    ])('utf16 counts surrogate pairs as two ($name)', ({ text, expected }) => {
+      expect(countCharacters(text, { algorithm: 'utf16' })).toBe(expected)
+    })
+
+    it.each([
+      { name: 'emoji', text: '👍', expected: 1 },
+      { name: 'emoji within text', text: 'a👍b', expected: 3 },
+      { name: 'family emoji (ZWJ emoji sequence)', text: '👨‍👩‍👧', expected: 5 },
+    ])('codePoints counts surrogate pairs as one ($name)', ({ text, expected }) => {
+      expect(countCharacters(text, { algorithm: 'codePoints' })).toBe(expected)
+    })
   })
 })

--- a/packages/app/text-measure/src/methods/countCharacters.spec.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.spec.ts
@@ -9,8 +9,8 @@ describe('countCharacters', () => {
     const text = '👨‍👩‍👧' //counts differently under every algorithm
     const defaultAlgResult = countCharacters(text)
 
-    expect(countCharacters(text, {algorithm: "utf16"})).toBe(defaultAlgResult)
-    expect(countCharacters(text, {algorithm: "codePoints"})).not.toBe(defaultAlgResult)
+    expect(countCharacters(text, { algorithm: 'utf16' })).toBe(defaultAlgResult)
+    expect(countCharacters(text, { algorithm: 'codePoints' })).not.toBe(defaultAlgResult)
   })
 
   // Simple strings and NTC handling — algorithm-agnostic (same result for every algorithm).

--- a/packages/app/text-measure/src/methods/countCharacters.spec.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.spec.ts
@@ -6,7 +6,11 @@ import { countCharacters } from './countCharacters.ts'
 
 describe('countCharacters', () => {
   it('defaults to utf16', () => {
-    expect(countCharacters('Hello')).toBe(countCharacters('Hello', { algorithm: 'utf16' }))
+    const text = '👨‍👩‍👧' //counts differently under every algorithm
+    const defaultAlgResult = countCharacters(text)
+
+    expect(countCharacters(text, {algorithm: "utf16"})).toBe(defaultAlgResult)
+    expect(countCharacters(text, {algorithm: "codePoints"})).not.toBe(defaultAlgResult)
   })
 
   // Simple strings and NTC handling — algorithm-agnostic (same result for every algorithm).

--- a/packages/app/text-measure/src/methods/countCharacters.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.ts
@@ -1,13 +1,16 @@
 import { removeNonTranslatableTags } from '@lokalise/non-translatable-markup'
 
 /**
- * How characters are counted.
- * Only `codePoints` (Unicode code points) exist today, but this is pluggable for future algorithms.
+ * How characters are counted:
+ * - `utf16`: UTF-16 code units.
+ * - `codePoints`: Unicode code points.
+ *
+ * Pluggable for future algorithms too.
  */
-export type CharacterCountAlgorithm = 'codePoints'
+export type CharacterCountAlgorithm = 'utf16' | 'codePoints'
 
 export type CountCharactersOptions = {
-  /** The counting algorithm to use. Defaults to `codePoints`. */
+  /** The counting algorithm to use. Defaults to `utf16`. */
   algorithm?: CharacterCountAlgorithm
 }
 
@@ -15,11 +18,12 @@ export type CountCharactersOptions = {
  * Counts the characters in a text.
  */
 export function countCharacters(text: string, options?: CountCharactersOptions): number {
-  const algorithm = options?.algorithm ?? 'codePoints'
+  const algorithm = options?.algorithm ?? 'utf16'
 
   return algorithms[algorithm](removeNonTranslatableTags(text))
 }
 
 const algorithms: Record<CharacterCountAlgorithm, (text: string) => number> = {
+  utf16: (text) => text.length,
   codePoints: (text) => [...text].length,
 }

--- a/packages/app/text-measure/src/methods/countCharacters.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.ts
@@ -1,0 +1,25 @@
+import { removeNonTranslatableTags } from '@lokalise/non-translatable-markup'
+
+/**
+ * How characters are counted.
+ * Only `codePoints` (Unicode code points) exist today, but this is pluggable for future algorithms.
+ */
+export type CharacterCountAlgorithm = 'codePoints'
+
+export type CountCharactersOptions = {
+  /** The counting algorithm to use. Defaults to `codePoints`. */
+  algorithm?: CharacterCountAlgorithm
+}
+
+/**
+ * Counts the characters in a text.
+ */
+export function countCharacters(text: string, options?: CountCharactersOptions): number {
+  const algorithm = options?.algorithm ?? 'codePoints'
+
+  return algorithms[algorithm](removeNonTranslatableTags(text))
+}
+
+const algorithms: Record<CharacterCountAlgorithm, (text: string) => number> = {
+  codePoints: (text) => [...text].length,
+}

--- a/packages/app/text-measure/src/methods/countTranslatableWords.spec.ts
+++ b/packages/app/text-measure/src/methods/countTranslatableWords.spec.ts
@@ -1,0 +1,39 @@
+import {
+  NON_TRANSLATABLE_END_TAG,
+  NON_TRANSLATABLE_START_TAG,
+} from '@lokalise/non-translatable-markup'
+import * as gmxWordCounter from 'gmx-word-counter'
+import { countTranslatableWords } from './countTranslatableWords.ts'
+
+describe('countTranslatableWords', () => {
+  it.each([
+    { name: 'plain text', text: 'Hello world', expected: 2 },
+    { name: 'empty string', text: '', expected: 0 },
+    {
+      name: 'non-translatable content and its markers are excluded',
+      text: `Hello ${NON_TRANSLATABLE_START_TAG}world${NON_TRANSLATABLE_END_TAG} again`,
+      expected: 2,
+    },
+    { name: 'HTML-like tags are excluded', text: '<div class="x">Hello</div> world', expected: 2 },
+  ])('counts translatable words: $name', ({ text, expected }) => {
+    expect(countTranslatableWords(text)).toBe(expected)
+  })
+
+  describe('locale', () => {
+    it("defaults to '-' when no locale is provided", () => {
+      const countWordsSpy = vi.spyOn(gmxWordCounter, 'countWords')
+
+      countTranslatableWords('Hello world')
+
+      expect(countWordsSpy).toHaveBeenCalledWith('Hello world', '-')
+    })
+
+    it('forwards the provided locale to the counter', () => {
+      const countWordsSpy = vi.spyOn(gmxWordCounter, 'countWords')
+
+      countTranslatableWords('Hello world', { locale: 'en' })
+
+      expect(countWordsSpy).toHaveBeenCalledWith('Hello world', 'en')
+    })
+  })
+})

--- a/packages/app/text-measure/src/methods/countTranslatableWords.ts
+++ b/packages/app/text-measure/src/methods/countTranslatableWords.ts
@@ -1,0 +1,24 @@
+import { extractTextBetweenTags } from '@lokalise/non-translatable-markup'
+import { countWords } from 'gmx-word-counter'
+
+export type CountTranslatableWordsOptions = {
+  /**
+   * BCP47 language subtag used for word segmentation (e.g. `en`, `zh`).
+   * A full tag like `zh-CN` is reduced to its primary subtag by the counter.
+   *
+   * Defaults to `-` (language-agnostic).
+   */
+  locale?: string
+}
+
+/**
+ * Counts the translatable words in a text, excluding non-translatable content (NTC) and tags.
+ */
+export const countTranslatableWords = (
+  text: string,
+  options?: CountTranslatableWordsOptions,
+): number => {
+  const locale = options?.locale ?? '-'
+
+  return extractTextBetweenTags(text).reduce((total, piece) => total + countWords(piece, locale), 0)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,13 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(msw@2.15.0(@types/node@26.1.2)(typescript@7.0.2))(vite@6.4.3(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/app/text-measure:
+    dependencies:
+      '@lokalise/non-translatable-markup':
+        specifier: workspace:^
+        version: link:../non-translatable-markup
+      gmx-word-counter:
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -5269,6 +5276,10 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  gmx-word-counter@1.2.0:
+    resolution: {integrity: sha512-pa0yhdtyL4dXq7vEibbIKriCCSMMh/LO03A4kKu4bEIeNbum7nscE9hnMzmgwk+d4SKVuUVD5DNqfauWBO2DAg==}
+    engines: {node: '>=16'}
 
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
@@ -12004,6 +12015,8 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  gmx-word-counter@1.2.0: {}
 
   google-logging-utils@1.1.3: {}
 


### PR DESCRIPTION
## Changes

Implements `@lokalise/text-measure` (EXP-2186) — the utilities on top of the package scaffolded in #1133.

**`countCharacters(text, options?)`**
Counts characters. NTC marker tags are excluded (the content they wrap is kept); everything else in the text, including whitespace, is counted. The algorithm is pluggable via `options.algorithm`:
- `utf16` (default) — UTF-16 code units (JS `String.length`).
- `codePoints` — Unicode code points.

**`countTranslatableWords(text, options?)`**
Counts translatable words, excluding NTC regions and tags, via `gmx-word-counter`; `options.locale` (BCP47) drives segmentation. Extracted from the logic that lives in TSS today so FE, BE and Polyglot can share a single implementation.

**Dependencies:** `@lokalise/non-translatable-markup` (workspace) and `gmx-word-counter`.

### Why `utf16` is the default

The first integration where we enforce character limits is Contentful, and we verified empirically how Contentful measures a field's length: it counts **UTF-16 code units** (equivalent to JS `String.length`). Measured directly in a Contentful field:

| Input | Contentful | `utf16` | `codePoints` |
|-------|:---------:|:-------:|:------------:|
| `€` | 1 | 1 | 1 |
| `👍` | 2 | 2 | 1 |
| `👨‍👩‍👧` | 8 | 8 | 5 |

_The published package stays integration-agnostic; the Contentful rationale for the default is kept here in the PR, not in the package docs._

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**