### PR TITLE
Chore: Propagate tags to Fastify routes

### DIFF
--- a/.changeset/route-builders-map-contract-tags.md
+++ b/.changeset/route-builders-map-contract-tags.md
@@ -1,0 +1,7 @@
+---
+"@lokalise/fastify-api-contracts": minor
+---
+
+Propagate the contract's `tags` into the Fastify route schema in `buildFastifyRoute`, `buildFastifyNoPayloadRoute` and `buildFastifyPayloadRoute`, so contracts built with `buildRestContract({ tags: [...] })` produce tagged operations in the generated OpenAPI spec.
+
+Previously only `summary` and `description` were mapped, so `@fastify/swagger` — which reads operation tags from `schema.tags` — grouped every such route under `default`. `ExtendedFastifySchema` now declares the `tags` field; contracts without `tags` are unaffected (the field is dropped by `copyWithoutUndefined` as before).

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.spec.ts
@@ -511,4 +511,37 @@ describe('fastifyApiContracts', () => {
       expect(response.statusCode).toBe(200)
     })
   })
+
+  describe('OpenAPI metadata', () => {
+    it('maps tags to the schema of a no-payload route', () => {
+      const contract = buildRestContract({
+        method: 'get',
+        successResponseBodySchema: BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        summary: 'Get user',
+        tags: ['users'],
+      })
+
+      const route = buildFastifyNoPayloadRoute(contract, () => Promise.resolve({}))
+
+      expect(route.schema).toMatchObject({ summary: 'Get user', tags: ['users'] })
+    })
+
+    it('maps tags to the schema of a payload route', () => {
+      const contract = buildRestContract({
+        method: 'post',
+        requestBodySchema: REQUEST_BODY_SCHEMA,
+        successResponseBodySchema: BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        summary: 'Create user',
+        tags: ['users'],
+      })
+
+      const route = buildFastifyPayloadRoute(contract, () => Promise.resolve({}))
+
+      expect(route.schema).toMatchObject({ summary: 'Create user', tags: ['users'] })
+    })
+  })
 })

--- a/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyApiContracts.ts
@@ -157,6 +157,7 @@ export function buildFastifyNoPayloadRoute<
       describe: apiContract.description,
       description: apiContract.description,
       summary: apiContract.summary,
+      tags: apiContract.tags,
       response: apiContract.responseSchemasByStatusCode,
     } satisfies ExtendedFastifySchema),
   }
@@ -281,6 +282,7 @@ export function buildFastifyPayloadRoute<
       describe: apiContract.description,
       description: apiContract.description,
       summary: apiContract.summary,
+      tags: apiContract.tags,
       response: apiContract.responseSchemasByStatusCode,
     } satisfies ExtendedFastifySchema),
   }

--- a/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.spec.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.spec.ts
@@ -540,4 +540,40 @@ describe('buildFastifyRoute', () => {
       })
     })
   })
+
+  describe('OpenAPI metadata', () => {
+    it('maps summary, description and tags to the route schema', () => {
+      const contract = buildRestContract({
+        method: 'get',
+        successResponseBodySchema: BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        summary: 'Get user',
+        description: 'Returns a single user',
+        tags: ['users'],
+      })
+
+      const route = buildFastifyRoute(contract, () => Promise.resolve({}))
+
+      expect(route.schema).toMatchObject({
+        summary: 'Get user',
+        description: 'Returns a single user',
+        tags: ['users'],
+      })
+    })
+
+    it('omits tags the contract does not declare', () => {
+      const contract = buildRestContract({
+        method: 'get',
+        successResponseBodySchema: BODY_SCHEMA,
+        requestPathParamsSchema: PATH_PARAMS_SCHEMA,
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+        summary: 'Get user',
+      })
+
+      const route = buildFastifyRoute(contract, () => Promise.resolve({}))
+
+      expect(route.schema).not.toHaveProperty('tags')
+    })
+  })
 })

--- a/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.ts
+++ b/packages/app/fastify-api-contracts/src/fastifyRouteBuilder.ts
@@ -292,6 +292,7 @@ export function buildFastifyRoute(
       describe: apiContract.description,
       description: apiContract.description,
       summary: apiContract.summary,
+      tags: apiContract.tags,
       response: apiContract.responseSchemasByStatusCode,
     } satisfies ExtendedFastifySchema),
   }

--- a/packages/app/fastify-api-contracts/src/types.ts
+++ b/packages/app/fastify-api-contracts/src/types.ts
@@ -26,6 +26,7 @@ export type ExtendedFastifySchema = FastifySchema & {
   describe?: string
   description?: string
   summary?: string
+  tags?: readonly string[]
 }
 
 export type RouteType<


### PR DESCRIPTION
## Changes

Route builders in `@lokalise/fastify-api-contracts` now propagate the contract's `tags` into the Fastify route schema.

`@lokalise/api-contracts` has always accepted `tags` on `buildRestContract` and keeps them on the contract object, but the Fastify route builders only mapped `summary` and `description` — `tags` were silently dropped. Since `@fastify/swagger` derives operation tags exclusively from `schema.tags`, every contract-built route ended up untagged (grouped under `default`) in the generated OpenAPI spec, no matter what the contract declared.

Affected builders:

- `buildFastifyRoute` (`fastifyRouteBuilder.ts`)
- `buildFastifyNoPayloadRoute` / `buildFastifyPayloadRoute` (`fastifyApiContracts.ts`, deprecated but still widely used downstream)

`ExtendedFastifySchema` gains the `tags?: readonly string[]` field so the mapping type-checks against the `satisfies` clause already in place.

Note: the newer `defineApiContract` + `buildFastifyApiRoute` path already maps tags (`buildFastifyApiSchema.ts`); this brings the legacy builders in line, for consumers that cannot yet move to the v7 contract API.

## Why

Discovered while generating a separate `openApiSpec.yaml` for public REST API, the service declared a tag in its `openapi.tags` block, and the generated `openApiSpec.yaml` still had no operation-level tags — with no error anywhere, since the value is dropped in a plain object literal.

## Behaviour change

- Contracts **with** `tags` — the tags now appear on the route schema and in the generated spec. Consumers that already declare tags will see their operations regrouped in Swagger/Scalar UI (that is the intent).
- Contracts **without** `tags` — unchanged; `copyWithoutUndefined` drops the undefined field exactly as before.

No API surface, type or runtime-validation change beyond the added optional schema field.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
