### PR TITLE
feat(universal-testing-utils): add ApiContractMswHelper and explicit contentType selection

### DIFF
--- a/.changeset/api-contract-msw-helper.md
+++ b/.changeset/api-contract-msw-helper.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/universal-testing-utils": minor
+---
+
+Add ApiContractMswHelper — an MSW-based counterpart to ApiContractMockttpHelper for mocking new-style ApiContract responses (JSON, SSE, blob, dual-mode content maps, no-body entries, and range/default status-code keys).

--- a/.changeset/mock-response-content-type.md
+++ b/.changeset/mock-response-content-type.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/universal-testing-utils": minor
+---
+
+Support explicit contentType selection in MockResponseParams for ApiContractMockttpHelper and ApiContractMswHelper. When a response entry declares multiple content types, passing contentType pins the mock to that single entry (skipping Accept negotiation) and only that entry's body field is required — making it possible to mock entries negotiation would never pick, such as a second JSON content type or a blob entry next to a JSON one.

--- a/packages/app/universal-testing-utils/README.md
+++ b/packages/app/universal-testing-utils/README.md
@@ -7,6 +7,7 @@ Reusable testing utilities that are potentially relevant for both backend and fr
 | Helper | Contract API |
 |---|---|
 | `ApiContractMockttpHelper` | `defineApiContract` |
+| `ApiContractMswHelper` | `defineApiContract` |
 | `MswHelper` | `buildRestContract` / `buildSseContract` |
 | `MockttpHelper` *(deprecated)* | `buildRestContract` / `buildSseContract` |
 
@@ -16,6 +17,7 @@ Reusable testing utilities that are potentially relevant for both backend and fr
   - [Setup](#setup)
   - [mockResponse](#mockresponse)
   - [Type safety](#type-safety)
+- [ApiContractMswHelper](#apicontractmswhelper)
 - [msw integration with API contracts](#msw-integration-with-api-contracts)
   - [Basic usage](#basic-usage)
   - [SSE contracts](#msw-sse-contracts)
@@ -164,6 +166,33 @@ await helper.mockResponse(contract, {
 - Requests with `Accept: text/event-stream` receive the SSE stream.
 - All other requests receive the JSON body.
 
+#### Selecting a content type
+
+When a status code declares multiple content types, pass `contentType` to pin the mock to one specific entry — only that entry's body field is required, and the response always uses that content type (no `Accept` negotiation). This is the only way to mock an entry that negotiation would never pick, e.g. a second JSON content type or a blob entry that sits next to a JSON one.
+
+```ts
+const contract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/report',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({ id: z.string() }),
+        'application/problem+json': z.object({ title: z.string(), detail: z.string() }),
+      },
+    },
+  },
+})
+
+await helper.mockResponse(contract, {
+  responseStatus: 200,
+  contentType: 'application/problem+json',
+  responseJson: { title: 'Invalid', detail: 'Something went wrong' },
+})
+```
+
+Without `contentType`, the existing behavior applies: SSE is served when the request negotiates it via `Accept`, otherwise the first JSON entry wins, then blob.
+
 #### Range and wildcard status keys
 
 Contracts may use range keys (`'1xx'`–`'5xx'`) or `'default'` in `responsesByStatusCode` instead of exact codes. Pass any concrete numeric code covered by that range as `responseStatus`; the helper resolves the contract entry using the same **exact → range → `'default'`** precedence as the runtime client.
@@ -231,6 +260,27 @@ import type { MockResponseParams } from '@lokalise/universal-testing-utils'
 function mockUser(params: MockResponseParams<typeof getUserContract>) {
   return helper.mockResponse(getUserContract, params)
 }
+```
+
+## ApiContractMswHelper
+
+The [msw](https://mswjs.io/)-based counterpart to [`ApiContractMockttpHelper`](#apicontractmockttphelper) for contracts defined with `defineApiContract`. `mockResponse` accepts the same `MockResponseParams` and follows the same rules — response entry resolution with **exact → range → `'default'`** precedence, Zod validation of `responseJson`, SSE/JSON negotiation via the `Accept` header, blob and no-body entries. The only differences are the setup (an msw `SetupServer` plus a base URL, since msw matches absolute URLs) and that `mockResponse` is synchronous.
+
+```ts
+import { setupServer } from 'msw/node'
+import { ApiContractMswHelper } from '@lokalise/universal-testing-utils'
+
+const server = setupServer()
+const helper = new ApiContractMswHelper(server, 'http://localhost:8080')
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+helper.mockResponse(contract, {
+  responseStatus: 200,
+  responseJson: { id: '1' },
+})
 ```
 
 ## msw integration with API contracts

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -1,41 +1,21 @@
 import {
   type ApiContract,
-  type ApiContractResponse,
-  type HttpStatusCode,
   isBlobBody,
   isContentResponseEntry,
   isJsonBody,
   isSseBody,
   mapApiContractToPath,
-  type ResponseEntry,
-  type ResponsesByStatusCode,
 } from '@lokalise/api-contracts'
 import type { Mockttp, RequestRuleBuilder } from 'mockttp'
 import type { z } from 'zod/v4'
-import { formatSseResponse, type MockResponseParams } from './types.ts'
+import {
+  formatSseResponse,
+  type MockResponseParams,
+  resolveContractEntry,
+  resolveExplicitContentBody,
+} from './types.ts'
 
 type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
-
-function getRangeKey(statusCode: HttpStatusCode) {
-  if (statusCode >= 100 && statusCode < 200) return '1xx'
-  if (statusCode >= 200 && statusCode < 300) return '2xx'
-  if (statusCode >= 300 && statusCode < 400) return '3xx'
-  if (statusCode >= 400 && statusCode < 500) return '4xx'
-  if (statusCode >= 500 && statusCode < 600) return '5xx'
-}
-
-function resolveContractEntry(
-  responsesByStatusCode: ResponsesByStatusCode,
-  statusCode: HttpStatusCode,
-): ApiContractResponse | ResponseEntry | undefined {
-  const rangeKey = getRangeKey(statusCode)
-
-  return (
-    responsesByStatusCode[statusCode] ??
-    (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ??
-    responsesByStatusCode.default
-  )
-}
 
 export class ApiContractMockttpHelper {
   private readonly mockServer: Mockttp
@@ -87,6 +67,17 @@ export class ApiContractMockttpHelper {
       // A no-body content entry (`{ allowNoBody: true }`) carries no `content`.
       if (!responseEntry.content) {
         await mockRule.thenReply(statusCode)
+        return
+      }
+
+      // An explicit contentType pins the mock to that single content entry, skipping negotiation.
+      if (anyParams.contentType) {
+        const body = resolveExplicitContentBody(
+          responseEntry.content,
+          anyParams.contentType,
+          anyParams,
+        )
+        await mockRule.thenReply(statusCode, body, { 'content-type': anyParams.contentType })
         return
       }
 

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
@@ -1,6 +1,6 @@
 import { sendByApiContract } from '@lokalise/frontend-http-client'
-import { getLocal } from 'mockttp'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import wretch from 'wretch'
 import {
   blobContentApiContract,
@@ -32,30 +32,37 @@ import {
   sseGetApiContractWithPathParams,
   sseGetApiContractWithQueryParams,
 } from '../../test/testApiContracts.ts'
-import { ApiContractMockttpHelper } from './ApiContractMockttpHelper.ts'
+import { ApiContractMswHelper } from './ApiContractMswHelper.ts'
 
-describe('ApiContractMockttpHelper', () => {
-  const mockServer = getLocal()
-  const helper = new ApiContractMockttpHelper(mockServer)
+const BASE_URL = 'http://localhost:8080'
 
-  beforeEach(async () => {
-    await mockServer.start()
+describe('ApiContractMswHelper', () => {
+  const server = setupServer()
+  const helper = new ApiContractMswHelper(server, BASE_URL)
+
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'error' })
   })
-  afterEach(() => mockServer.stop())
+  afterEach(() => {
+    server.resetHandlers()
+  })
+  afterAll(() => {
+    server.close()
+  })
 
   function client() {
-    return wretch(mockServer.url)
+    return wretch(BASE_URL)
   }
 
   describe('mockResponse — REST contracts', () => {
     it('mocks GET without path params', async () => {
-      await helper.mockResponse(getApiContract, { responseStatus: 200, responseJson: { id: '1' } })
+      helper.mockResponse(getApiContract, { responseStatus: 200, responseJson: { id: '1' } })
       const result = await sendByApiContract(client(), getApiContract, {})
       expect(result.result?.body).toEqual({ id: '1' })
     })
 
     it('enforces GET contract schema (strips unknown properties)', async () => {
-      await helper.mockResponse(getApiContract, {
+      helper.mockResponse(getApiContract, {
         responseStatus: 200,
         // @ts-expect-error wrong property on responseJson
         responseJson: { id: '1', wrong: 'x' },
@@ -65,7 +72,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks GET with path params', async () => {
-      await helper.mockResponse(getApiContractWithPathParams, {
+      helper.mockResponse(getApiContractWithPathParams, {
         pathParams: { userId: '3' },
         responseStatus: 200,
         responseJson: { id: '3' },
@@ -77,7 +84,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks GET with query params', async () => {
-      await helper.mockResponse(getApiContractWithQueryParams, {
+      helper.mockResponse(getApiContractWithQueryParams, {
         responseStatus: 200,
         responseJson: { id: '1' },
       })
@@ -88,7 +95,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks GET with path and query params', async () => {
-      await helper.mockResponse(getApiContractWithPathAndQueryParams, {
+      helper.mockResponse(getApiContractWithPathAndQueryParams, {
         pathParams: { userId: '3' },
         responseStatus: 200,
         responseJson: { id: '3' },
@@ -101,13 +108,13 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks POST without path params', async () => {
-      await helper.mockResponse(postApiContract, { responseStatus: 200, responseJson: { id: '1' } })
+      helper.mockResponse(postApiContract, { responseStatus: 200, responseJson: { id: '1' } })
       const result = await sendByApiContract(client(), postApiContract, { body: { name: 'test' } })
       expect(result.result?.body).toEqual({ id: '1' })
     })
 
     it('mocks POST with path params', async () => {
-      await helper.mockResponse(postApiContractWithPathParams, {
+      helper.mockResponse(postApiContractWithPathParams, {
         pathParams: { userId: '3' },
         responseStatus: 200,
         responseJson: { id: '2' },
@@ -120,7 +127,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks no-body DELETE response (204)', async () => {
-      await helper.mockResponse(noBodyApiContract, {
+      helper.mockResponse(noBodyApiContract, {
         pathParams: { userId: '1' },
         responseStatus: 204,
       })
@@ -133,7 +140,7 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — SSE contracts', () => {
     it('mocks SSE-only GET response', async () => {
-      await helper.mockResponse(sseGetApiContract, {
+      helper.mockResponse(sseGetApiContract, {
         responseStatus: 200,
         events: [
           { event: 'item.updated', data: { items: [{ id: '1' }] } },
@@ -149,7 +156,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks SSE with path params', async () => {
-      await helper.mockResponse(sseGetApiContractWithPathParams, {
+      helper.mockResponse(sseGetApiContractWithPathParams, {
         pathParams: { userId: '5' },
         responseStatus: 200,
         events: [{ event: 'completed', data: { totalCount: 5 } }],
@@ -165,7 +172,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks SSE with query params', async () => {
-      await helper.mockResponse(sseGetApiContractWithQueryParams, {
+      helper.mockResponse(sseGetApiContractWithQueryParams, {
         responseStatus: 200,
         events: [{ event: 'completed', data: { totalCount: 3 } }],
       })
@@ -182,7 +189,7 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — dual-mode contracts', () => {
     it('returns JSON when no SSE Accept header', async () => {
-      await helper.mockResponse(dualModeApiContract, {
+      helper.mockResponse(dualModeApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
         events: [{ event: 'completed', data: { totalCount: 1 } }],
@@ -195,7 +202,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('returns SSE when Accept: text/event-stream', async () => {
-      await helper.mockResponse(dualModeApiContract, {
+      helper.mockResponse(dualModeApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
         events: [{ event: 'completed', data: { totalCount: 1 } }],
@@ -216,7 +223,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks dual-mode with path params', async () => {
-      await helper.mockResponse(dualModeApiContractWithPathParams, {
+      helper.mockResponse(dualModeApiContractWithPathParams, {
         pathParams: { userId: '2' },
         responseStatus: 200,
         responseJson: { id: '2' },
@@ -233,7 +240,7 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — content-map contracts', () => {
     it('mocks a JSON content entry', async () => {
-      await helper.mockResponse(jsonContentApiContract, {
+      helper.mockResponse(jsonContentApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
       })
@@ -242,7 +249,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks a blob content entry', async () => {
-      await helper.mockResponse(blobContentApiContract, {
+      helper.mockResponse(blobContentApiContract, {
         responseStatus: 200,
         responseBlob: 'binary-data',
       })
@@ -251,7 +258,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks an SSE content entry', async () => {
-      await helper.mockResponse(sseContentApiContract, {
+      helper.mockResponse(sseContentApiContract, {
         responseStatus: 200,
         events: [
           { event: 'item.updated', data: { items: [{ id: '1' }] } },
@@ -267,7 +274,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('returns JSON for a dual content entry when not streaming', async () => {
-      await helper.mockResponse(dualContentApiContract, {
+      helper.mockResponse(dualContentApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
         events: [{ event: 'completed', data: { totalCount: 1 } }],
@@ -280,7 +287,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('returns SSE for a dual content entry when streaming', async () => {
-      await helper.mockResponse(dualContentApiContract, {
+      helper.mockResponse(dualContentApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
         events: [{ event: 'completed', data: { totalCount: 1 } }],
@@ -298,7 +305,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks a no-body content entry', async () => {
-      await helper.mockResponse(noBodyContentApiContract, {
+      helper.mockResponse(noBodyContentApiContract, {
         pathParams: { userId: '1' },
         responseStatus: 204,
       })
@@ -311,55 +318,55 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — explicit contentType', () => {
     it('serves the selected JSON content type', async () => {
-      await helper.mockResponse(multiJsonContentApiContract, {
+      helper.mockResponse(multiJsonContentApiContract, {
         responseStatus: 200,
         contentType: 'application/problem+json',
         responseJson: { title: 'Invalid', detail: 'Something went wrong' },
       })
-      const response = await fetch(`${mockServer.url}/content-multi-json`)
+      const response = await fetch(`${BASE_URL}/content-multi-json`)
       expect(response.headers.get('content-type')).toBe('application/problem+json')
       expect(await response.json()).toEqual({ title: 'Invalid', detail: 'Something went wrong' })
     })
 
     it('serves the first JSON content type when contentType is omitted', async () => {
-      await helper.mockResponse(multiJsonContentApiContract, {
+      helper.mockResponse(multiJsonContentApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
       })
-      const response = await fetch(`${mockServer.url}/content-multi-json`)
+      const response = await fetch(`${BASE_URL}/content-multi-json`)
       expect(response.headers.get('content-type')).toBe('application/json')
       expect(await response.json()).toEqual({ id: '1' })
     })
 
     it('serves the blob entry when selected over JSON', async () => {
-      await helper.mockResponse(jsonAndBlobContentApiContract, {
+      helper.mockResponse(jsonAndBlobContentApiContract, {
         responseStatus: 200,
         contentType: 'application/octet-stream',
         responseBlob: 'binary-data',
       })
-      const response = await fetch(`${mockServer.url}/content-json-blob`)
+      const response = await fetch(`${BASE_URL}/content-json-blob`)
       expect(response.headers.get('content-type')).toBe('application/octet-stream')
       expect(await response.text()).toBe('binary-data')
     })
 
     it('serves the JSON entry when selected next to a blob entry', async () => {
-      await helper.mockResponse(jsonAndBlobContentApiContract, {
+      helper.mockResponse(jsonAndBlobContentApiContract, {
         responseStatus: 200,
         contentType: 'application/json',
         responseJson: { id: '9' },
       })
-      const response = await fetch(`${mockServer.url}/content-json-blob`)
+      const response = await fetch(`${BASE_URL}/content-json-blob`)
       expect(response.headers.get('content-type')).toBe('application/json')
       expect(await response.json()).toEqual({ id: '9' })
     })
 
     it('serves SSE without Accept negotiation when text/event-stream is selected', async () => {
-      await helper.mockResponse(dualContentApiContract, {
+      helper.mockResponse(dualContentApiContract, {
         responseStatus: 200,
         contentType: 'text/event-stream',
         events: [{ event: 'completed', data: { totalCount: 1 } }],
       })
-      const response = await fetch(`${mockServer.url}/content-dual`, {
+      const response = await fetch(`${BASE_URL}/content-dual`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ name: 'test' }),
@@ -369,7 +376,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks only the JSON entry of a dual content map', async () => {
-      await helper.mockResponse(dualContentApiContract, {
+      helper.mockResponse(dualContentApiContract, {
         responseStatus: 200,
         contentType: 'application/json',
         responseJson: { id: '1' },
@@ -381,21 +388,21 @@ describe('ApiContractMockttpHelper', () => {
       expect(result.result?.body).toEqual({ id: '1' })
     })
 
-    it('throws when contentType is not declared in the contract', async () => {
-      await expect(
+    it('throws when contentType is not declared in the contract', () => {
+      expect(() =>
         helper.mockResponse(multiJsonContentApiContract, {
           responseStatus: 200,
           // @ts-expect-error contentType not declared in the contract
           contentType: 'text/plain',
           responseJson: { id: '1' },
         }),
-      ).rejects.toThrow('Specified contentType cannot be mapped with contract')
+      ).toThrow('Specified contentType cannot be mapped with contract')
     })
   })
 
   describe('mockResponse — range / wildcard status key fallback', () => {
     it('resolves response entry via range key when exact code is absent', async () => {
-      await helper.mockResponse(getApiContractWith2xxRange, {
+      helper.mockResponse(getApiContractWith2xxRange, {
         responseStatus: 201,
         responseJson: { id: '42' },
       })
@@ -404,7 +411,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('resolves response entry via default key when no exact or range key matches', async () => {
-      await helper.mockResponse(getApiContractWithDefault, {
+      helper.mockResponse(getApiContractWithDefault, {
         responseStatus: 200,
         responseJson: { id: '7' },
       })
@@ -413,7 +420,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('exact key takes priority over range key', async () => {
-      await helper.mockResponse(getApiContractWithExactAndRange, {
+      helper.mockResponse(getApiContractWithExactAndRange, {
         responseStatus: 200,
         responseJson: { id: 'exact' },
       })
@@ -422,7 +429,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('range key is used when exact code is absent but range matches', async () => {
-      await helper.mockResponse(getApiContractWithExactAndRange, {
+      helper.mockResponse(getApiContractWithExactAndRange, {
         responseStatus: 201,
         responseJson: { id: 'range', created: true },
       })
@@ -433,7 +440,7 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — NoBodyResponse', () => {
     it('replies with no body for noBodyResponse() entry', async () => {
-      await helper.mockResponse(deleteApiContractWithNoBodyResponse, { responseStatus: 204 })
+      helper.mockResponse(deleteApiContractWithNoBodyResponse, { responseStatus: 204 })
       const response = await client().url('/no-body').delete().res()
       expect(response.status).toBe(204)
     })
@@ -441,7 +448,7 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — HTTP methods', () => {
     it('mocks PATCH request', async () => {
-      await helper.mockResponse(patchApiContract, {
+      helper.mockResponse(patchApiContract, {
         responseStatus: 200,
         responseJson: { id: '1' },
       })
@@ -450,7 +457,7 @@ describe('ApiContractMockttpHelper', () => {
     })
 
     it('mocks PUT request', async () => {
-      await helper.mockResponse(putApiContract, { responseStatus: 200, responseJson: { id: '2' } })
+      helper.mockResponse(putApiContract, { responseStatus: 200, responseJson: { id: '2' } })
       const result = await sendByApiContract(client(), putApiContract, { body: { name: 'test' } })
       expect(result.result?.body).toEqual({ id: '2' })
     })
@@ -458,7 +465,7 @@ describe('ApiContractMockttpHelper', () => {
 
   describe('mockResponse — non-JSON response types', () => {
     it('mocks blob response', async () => {
-      await helper.mockResponse(blobResponseApiContract, {
+      helper.mockResponse(blobResponseApiContract, {
         responseStatus: 200,
         responseBlob: 'binary-data',
       })
@@ -469,30 +476,30 @@ describe('ApiContractMockttpHelper', () => {
   })
 
   describe('mockResponse — error handling', () => {
-    it('throws when responseStatus cannot be mapped with contract', async () => {
-      await expect(
+    it('throws when responseStatus cannot be mapped with contract', () => {
+      expect(() =>
         // @ts-expect-error testing runtime error path with status code not in contract
         helper.mockResponse(getApiContract, { responseStatus: 999, responseJson: { id: 'x' } }),
-      ).rejects.toThrow('Specified responseStatus cannot be mapped with contract')
+      ).toThrow('Specified responseStatus cannot be mapped with contract')
     })
   })
 
   describe('mockResponse — extended range / wildcard status key fallback', () => {
     it('resolves response entry via 4xx range key', async () => {
-      await helper.mockResponse(getApiContractWith4xxRange, {
+      helper.mockResponse(getApiContractWith4xxRange, {
         responseStatus: 404,
         responseJson: { id: 'not-found' },
       })
-      const response = await fetch(`${mockServer.url}/not-found`)
+      const response = await fetch(`${BASE_URL}/not-found`)
       expect(response.status).toBe(404)
     })
 
     it('resolves response entry via 5xx range key', async () => {
-      await helper.mockResponse(getApiContractWith5xxRange, {
+      helper.mockResponse(getApiContractWith5xxRange, {
         responseStatus: 503,
         responseJson: { id: 'error' },
       })
-      const response = await fetch(`${mockServer.url}/server-error`)
+      const response = await fetch(`${BASE_URL}/server-error`)
       expect(response.status).toBe(503)
     })
   })

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
@@ -1,0 +1,136 @@
+import {
+  type ApiContract,
+  isBlobBody,
+  isContentResponseEntry,
+  isJsonBody,
+  isSseBody,
+  mapApiContractToPath,
+} from '@lokalise/api-contracts'
+import { HttpResponse, http, type JsonBodyType } from 'msw'
+import type { SetupServer } from 'msw/node'
+import type { z } from 'zod/v4'
+import {
+  formatSseResponse,
+  type MockResponseParams,
+  resolveContractEntry,
+  resolveExplicitContentBody,
+} from './types.ts'
+
+type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
+
+function joinURL(base: string, path: string): string {
+  return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
+}
+
+export class ApiContractMswHelper {
+  private readonly server: SetupServer
+  private readonly baseUrl: string
+
+  constructor(server: SetupServer, baseUrl: string) {
+    this.server = server
+    this.baseUrl = baseUrl
+  }
+
+  private resolvePath(contract: ApiContract, pathParams: unknown): string {
+    const path =
+      contract.requestPathParamsSchema && pathParams
+        ? contract.pathResolver(pathParams)
+        : mapApiContractToPath(contract)
+
+    return joinURL(this.baseUrl, path)
+  }
+
+  mockResponse<TContract extends ApiContract>(
+    contract: TContract,
+    params: MockResponseParams<TContract>,
+  ): void {
+    // biome-ignore lint/suspicious/noExplicitAny: field access is safe — type is enforced by the public signature
+    const anyParams = params as any
+    const path = this.resolvePath(contract, params.pathParams)
+    const statusCode = params.responseStatus
+    const responseEntry = resolveContractEntry(contract.responsesByStatusCode, statusCode)
+
+    if (!responseEntry) {
+      throw new Error('Specified responseStatus cannot be mapped with contract')
+    }
+
+    const method = contract.method as HttpMethod
+
+    if (isContentResponseEntry(responseEntry)) {
+      // A no-body content entry (`{ allowNoBody: true }`) carries no `content`.
+      if (!responseEntry.content) {
+        this.server.use(http[method](path, () => new HttpResponse(null, { status: statusCode })))
+        return
+      }
+
+      // An explicit contentType pins the mock to that single content entry, skipping negotiation.
+      if (anyParams.contentType) {
+        const body = resolveExplicitContentBody(
+          responseEntry.content,
+          anyParams.contentType,
+          anyParams,
+        )
+        this.server.use(
+          http[method](
+            path,
+            () =>
+              new HttpResponse(body, {
+                status: statusCode,
+                headers: { 'content-type': anyParams.contentType },
+              }),
+          ),
+        )
+        return
+      }
+
+      const contentEntries = Object.entries(responseEntry.content)
+      const jsonEntry = contentEntries.find((entry): entry is [string, z.ZodType] =>
+        isJsonBody(entry[1]),
+      )
+      const sseEntry = contentEntries.find(([, descriptor]) => isSseBody(descriptor))
+      const blobEntry = contentEntries.find(([, descriptor]) => isBlobBody(descriptor))
+
+      this.server.use(
+        http[method](path, ({ request }) => {
+          const accept = request.headers.get('accept') ?? ''
+
+          // SSE wins only when the caller negotiates it via Accept.
+          if (sseEntry && accept.includes('text/event-stream')) {
+            return new HttpResponse(formatSseResponse(anyParams.events), {
+              status: statusCode,
+              headers: { 'content-type': sseEntry[0] },
+            })
+          }
+
+          if (jsonEntry) {
+            const body = jsonEntry[1].parse(anyParams.responseJson) as JsonBodyType
+            return HttpResponse.json(body, {
+              status: statusCode,
+              headers: { 'content-type': jsonEntry[0] },
+            })
+          }
+
+          if (blobEntry) {
+            return new HttpResponse(anyParams.responseBlob, {
+              status: statusCode,
+              headers: { 'content-type': blobEntry[0] },
+            })
+          }
+
+          if (sseEntry) {
+            return new HttpResponse(formatSseResponse(anyParams.events), {
+              status: statusCode,
+              headers: { 'content-type': sseEntry[0] },
+            })
+          }
+
+          return new HttpResponse(null, { status: statusCode })
+        }),
+      )
+      return
+    }
+
+    const body = responseEntry.parse(anyParams.responseJson) as JsonBodyType
+    this.server.use(http[method](path, () => HttpResponse.json(body, { status: statusCode })))
+  }
+}

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -1,11 +1,17 @@
-import type {
-  ApiContract,
-  ExpandStatusRangeKey,
-  HttpStatusCode,
-  InferSchemaInput,
-  RequestPathParamsSchema,
-  SseSchemaByEventName,
-  WildcardStatusCodeKey,
+import {
+  type ApiContract,
+  type ApiContractResponse,
+  type BodyDescriptor,
+  type ExpandStatusRangeKey,
+  type HttpStatusCode,
+  type InferSchemaInput,
+  isBlobBody,
+  isSseBody,
+  type RequestPathParamsSchema,
+  type ResponseEntry,
+  type ResponsesByStatusCode,
+  type SseSchemaByEventName,
+  type WildcardStatusCodeKey,
 } from '@lokalise/api-contracts'
 import type { z } from 'zod/v4'
 
@@ -17,6 +23,46 @@ export function formatSseResponse(events: { event: string; data: unknown }[]): s
   return events
     .map(({ event, data }) => `event: ${event}\ndata: ${JSON.stringify(data)}\n`)
     .join('\n')
+}
+
+function getRangeKey(statusCode: HttpStatusCode) {
+  if (statusCode >= 100 && statusCode < 200) return '1xx'
+  if (statusCode >= 200 && statusCode < 300) return '2xx'
+  if (statusCode >= 300 && statusCode < 400) return '3xx'
+  if (statusCode >= 400 && statusCode < 500) return '4xx'
+  if (statusCode >= 500 && statusCode < 600) return '5xx'
+}
+
+// Resolves the response body for an explicitly selected content-type entry.
+// JSON descriptors validate/strip the body through their schema, like the negotiated path does.
+export function resolveExplicitContentBody(
+  content: Record<string, BodyDescriptor>,
+  contentType: string,
+  // biome-ignore lint/suspicious/noExplicitAny: field access is safe — type is enforced by MockResponseParams
+  params: any,
+): string {
+  const descriptor = content[contentType]
+
+  if (descriptor === undefined) {
+    throw new Error('Specified contentType cannot be mapped with contract')
+  }
+  if (isSseBody(descriptor)) return formatSseResponse(params.events)
+  if (isBlobBody(descriptor)) return params.responseBlob
+
+  return JSON.stringify(descriptor.parse(params.responseJson))
+}
+
+export function resolveContractEntry(
+  responsesByStatusCode: ResponsesByStatusCode,
+  statusCode: HttpStatusCode,
+): ApiContractResponse | ResponseEntry | undefined {
+  const rangeKey = getRangeKey(statusCode)
+
+  return (
+    responsesByStatusCode[statusCode] ??
+    (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ??
+    responsesByStatusCode.default
+  )
 }
 
 // Maps a content-map entry's descriptors to the body field(s) needed for mocking:
@@ -35,14 +81,30 @@ type InferContentBodyParam<C> = ([Extract<C[keyof C], z.ZodType>] extends [never
       : object) &
   ([Extract<C[keyof C], { _tag: 'BlobBody' }>] extends [never] ? object : { responseBlob: string })
 
+// Maps one content descriptor to the single body field it needs for mocking.
+type InferDescriptorBodyParam<D> = D extends z.ZodType
+  ? { responseJson: z.input<D> }
+  : D extends { _tag: 'SseBody'; schemaByEventName: infer S extends SseSchemaByEventName }
+    ? { events: SseMockEventInput<S>[] }
+    : D extends { _tag: 'BlobBody' }
+      ? { responseBlob: string }
+      : object
+
+// Selecting one content-type entry explicitly — only that descriptor's body field is required.
+type PerContentTypeBodyParam<C> = {
+  [K in keyof C & string]: { contentType: K } & InferDescriptorBodyParam<C[K]>
+}[keyof C & string]
+
 // Maps a single responsesByStatusCode entry to the body field(s) needed for mocking.
 // ZodType              → { responseJson: z.input<T> }
-// content-map entry    → body field(s) for its declared descriptors (see InferContentBodyParam)
+// content-map entry    → without `contentType`: body field(s) for all declared descriptors
+//                        (see InferContentBodyParam); with `contentType`: only the selected
+//                        descriptor's body field (see PerContentTypeBodyParam)
 //                        (a no-body entry `{ allowNoBody: true }` falls through to no body field)
 type InferBodyParam<T> = T extends z.ZodType
   ? { responseJson: z.input<T> }
   : T extends { content: infer C }
-    ? InferContentBodyParam<C>
+    ? ({ contentType?: never } & InferContentBodyParam<C>) | PerContentTypeBodyParam<C>
     : object
 
 type ExactStatusCodePairs<TContract extends ApiContract> = {

--- a/packages/app/universal-testing-utils/src/index.ts
+++ b/packages/app/universal-testing-utils/src/index.ts
@@ -1,4 +1,5 @@
 export { ApiContractMockttpHelper } from './api-contracts/ApiContractMockttpHelper.ts'
+export { ApiContractMswHelper } from './api-contracts/ApiContractMswHelper.ts'
 export type { MockResponseParams } from './api-contracts/types.ts'
 export {
   type DualModeMockParams,

--- a/packages/app/universal-testing-utils/test/testApiContracts.ts
+++ b/packages/app/universal-testing-utils/test/testApiContracts.ts
@@ -216,6 +216,36 @@ export const dualContentApiContract = defineApiContract({
   },
 })
 
+const PROBLEM_BODY_SCHEMA = z.object({ title: z.string(), detail: z.string() })
+
+export const multiJsonContentApiContract = defineApiContract({
+  summary: 'Test contract',
+  method: 'get',
+  pathResolver: () => '/content-multi-json',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': RESPONSE_BODY_SCHEMA,
+        'application/problem+json': PROBLEM_BODY_SCHEMA,
+      },
+    },
+  },
+})
+
+export const jsonAndBlobContentApiContract = defineApiContract({
+  summary: 'Test contract',
+  method: 'get',
+  pathResolver: () => '/content-json-blob',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': RESPONSE_BODY_SCHEMA,
+        'application/octet-stream': blobBody(),
+      },
+    },
+  },
+})
+
 export const noBodyContentApiContract = defineApiContract({
   summary: 'Test contract',
   method: 'delete',


### PR DESCRIPTION
## Summary

- Adds **`ApiContractMswHelper`** — an [msw](https://mswjs.io/)-based counterpart to `ApiContractMockttpHelper` for contracts defined with `defineApiContract`. Same `mockResponse(contract, params)` API and behavior: exact → range → `default` status-key resolution, Zod validation of `responseJson`, SSE/JSON negotiation via the `Accept` header, blob and no-body content entries. Differences: the constructor takes `(server: SetupServer, baseUrl: string)` (msw matches absolute URLs) and `mockResponse` is synchronous.
- Adds **explicit `contentType` selection** to `MockResponseParams`, supported by both helpers. When a status code declares multiple content types, passing `contentType` pins the mock to that single entry (skipping `Accept` negotiation) and only that entry's body field is required. This makes it possible to mock entries negotiation would never pick — e.g. a second JSON content type (`application/problem+json`) or a blob entry next to a JSON one. Without `contentType`, behavior is unchanged.
- Extracts shared `resolveContractEntry` / `resolveExplicitContentBody` logic into `api-contracts/types.ts` so both helpers reuse it.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**