### PR TITLE
feat: EXP-2244 Text measure skip ntc

### DIFF
--- a/.changeset/text-measure-exclude-ntc.md
+++ b/.changeset/text-measure-exclude-ntc.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/text-measure": minor
+---
+
+Add `excludeNtc` option to `countCharacters` to exclude non-translatable content (text wrapped between NTC tags) from the count. Defaults to `false`, preserving the current behavior of counting the wrapped content.

--- a/packages/app/text-measure/README.md
+++ b/packages/app/text-measure/README.md
@@ -27,6 +27,18 @@ countCharacters('👍', { algorithm: 'codePoints' }) // 1
 
 More algorithms (e.g. UTF-8 bytes, glyphs — à la XLIFF size-units) can be added over time.
 
+By default the content wrapped between NTC tags is counted (only the marker tags are excluded). Set
+`options.excludeNtc` to `true` to drop non-translatable content — the whole region, tags and wrapped
+content — from the count:
+
+```typescript
+// NTC markers are two private-use code points: U+E101 (start) and U+E102 (end).
+const text = 'a\uE101bc\uE102d' // "bc" is wrapped in NTC markers
+
+countCharacters(text) // 4 — NTC content "bc" is counted
+countCharacters(text, { excludeNtc: true }) // 2 — only "a" and "d" counted
+```
+
 ## `countTranslatableWords`
 
 Counts the translatable words in a text, excluding non-translatable content (NTC) and tags. Backed

--- a/packages/app/text-measure/src/methods/countCharacters.spec.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.spec.ts
@@ -5,14 +5,6 @@ import {
 import { countCharacters } from './countCharacters.ts'
 
 describe('countCharacters', () => {
-  it('defaults to utf16', () => {
-    const text = '👨‍👩‍👧' //counts differently under every algorithm
-    const defaultAlgResult = countCharacters(text)
-
-    expect(countCharacters(text, { algorithm: 'utf16' })).toBe(defaultAlgResult)
-    expect(countCharacters(text, { algorithm: 'codePoints' })).not.toBe(defaultAlgResult)
-  })
-
   // Simple strings and NTC handling — algorithm-agnostic (same result for every algorithm).
   it.each([
     { name: 'plain text', text: 'Hello', expected: 5 },
@@ -39,7 +31,72 @@ describe('countCharacters', () => {
     expect(countCharacters(text)).toBe(expected)
   })
 
+  describe('excludeNtc', () => {
+    it('counts NTC content by default and when explicitly false', () => {
+      const text = `a${NON_TRANSLATABLE_START_TAG}bc${NON_TRANSLATABLE_END_TAG}d`
+
+      expect(countCharacters(text)).toBe(4)
+      expect(countCharacters(text, { excludeNtc: false })).toBe(4)
+    })
+
+    // NTC regions (tags + wrapped content) are removed; everything else is untouched.
+    it.each([
+      {
+        name: 'content between NTC tags is dropped',
+        text: `a${NON_TRANSLATABLE_START_TAG}bc${NON_TRANSLATABLE_END_TAG}d`,
+        expected: 2,
+      },
+      {
+        name: 'text consisting only of an NTC region becomes empty',
+        text: `${NON_TRANSLATABLE_START_TAG}abc${NON_TRANSLATABLE_END_TAG}`,
+        expected: 0,
+      },
+      {
+        name: 'multiple NTC regions are all dropped',
+        text: `${NON_TRANSLATABLE_START_TAG}a${NON_TRANSLATABLE_END_TAG}x${NON_TRANSLATABLE_START_TAG}b${NON_TRANSLATABLE_END_TAG}`,
+        expected: 1,
+      },
+      {
+        name: 'whitespace outside NTC is preserved',
+        text: `Hello ${NON_TRANSLATABLE_START_TAG}world!${NON_TRANSLATABLE_END_TAG} bye`,
+        expected: 10,
+      },
+      {
+        name: 'text without NTC is unchanged',
+        text: 'Hello',
+        expected: 5,
+      },
+      {
+        name: 'HTML-like tags outside NTC are kept',
+        text: `<b>hi</b>${NON_TRANSLATABLE_START_TAG}x${NON_TRANSLATABLE_END_TAG}`,
+        expected: 9,
+      },
+      {
+        name: 'whitespace around NTC regions is preserved',
+        text: ` a ${NON_TRANSLATABLE_START_TAG}x${NON_TRANSLATABLE_END_TAG} b `,
+        expected: 6,
+      },
+    ])('excludes NTC content ($name)', ({ text, expected }) => {
+      expect(countCharacters(text, { excludeNtc: true })).toBe(expected)
+    })
+
+    it('drops surrogate pairs living inside an NTC region under every algorithm', () => {
+      const text = `a${NON_TRANSLATABLE_START_TAG}👍${NON_TRANSLATABLE_END_TAG}b`
+
+      expect(countCharacters(text, { excludeNtc: true, algorithm: 'utf16' })).toBe(2)
+      expect(countCharacters(text, { excludeNtc: true, algorithm: 'codePoints' })).toBe(2)
+    })
+  })
+
   describe('algorithm', () => {
+    it('defaults to utf16', () => {
+      const text = '👨‍👩‍👧' //counts differently under every algorithm
+      const defaultAlgResult = countCharacters(text)
+
+      expect(countCharacters(text, { algorithm: 'utf16' })).toBe(defaultAlgResult)
+      expect(countCharacters(text, { algorithm: 'codePoints' })).not.toBe(defaultAlgResult)
+    })
+
     it.each([
       { name: 'emoji', text: '👍', expected: 2 },
       { name: 'emoji within text', text: 'a👍b', expected: 4 },

--- a/packages/app/text-measure/src/methods/countCharacters.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.ts
@@ -1,4 +1,4 @@
-import { removeNonTranslatableTags } from '@lokalise/non-translatable-markup'
+import { extractTextBetweenTags, removeNonTranslatableTags } from '@lokalise/non-translatable-markup'
 
 export const CharacterCountAlgorithmEnum = {
   UTF_16: 'utf16',
@@ -17,6 +17,12 @@ export type CharacterCountAlgorithm =
 export type CountCharactersOptions = {
   /** The counting algorithm to use. Defaults to `utf16`. */
   algorithm?: CharacterCountAlgorithm
+  /**
+   * When `true`, non-translatable content (the text wrapped between NTC tags,
+   * tags included) is removed before counting. Defaults to `false`, in which
+   * case only the NTC tags are stripped and the content they wrap is counted.
+   */
+  excludeNtc?: boolean
 }
 
 /**
@@ -25,7 +31,11 @@ export type CountCharactersOptions = {
 export function countCharacters(text: string, options?: CountCharactersOptions): number {
   const algorithm = options?.algorithm ?? 'utf16'
 
-  return algorithms[algorithm](removeNonTranslatableTags(text))
+  const normalized = options?.excludeNtc
+    ? extractTextBetweenTags(text, { keepHtml: true, preserveSpacing: true }).join('')
+    : removeNonTranslatableTags(text)
+
+  return algorithms[algorithm](normalized)
 }
 
 const algorithms: Record<CharacterCountAlgorithm, (text: string) => number> = {

--- a/packages/app/text-measure/src/methods/countCharacters.ts
+++ b/packages/app/text-measure/src/methods/countCharacters.ts
@@ -1,4 +1,7 @@
-import { extractTextBetweenTags, removeNonTranslatableTags } from '@lokalise/non-translatable-markup'
+import {
+  extractTextBetweenTags,
+  removeNonTranslatableTags,
+} from '@lokalise/non-translatable-markup'
 
 export const CharacterCountAlgorithmEnum = {
   UTF_16: 'utf16',


### PR DESCRIPTION
## Changes

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
