### PR TITLE
EXP-2264 add optional labels to dimensional metrics

### DIFF
--- a/.changeset/dimensional-metrics-optional-labels.md
+++ b/.changeset/dimensional-metrics-optional-labels.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/metrics-utils": minor
+---
+
+Add optional `labelNames` support to dimensional counter, gauge, and histogram metrics. Declare `labelNames` in the config and pass values via a `labels` sub-object on the measurement; omitting labels preserves the existing label-free behaviour.

--- a/packages/app/metrics-utils/README.md
+++ b/packages/app/metrics-utils/README.md
@@ -417,6 +417,51 @@ request_duration_failed:histogram
 
 `registerMeasurement` takes a single object containing the target `dimension` and either a direct `time` value or a `startTime`/`endTime` pair. A measurement for a dimension that was not declared is silently ignored (see [Lazy initialization](#lazy-initialization) for relaxing this).
 
+### Optional labels
+
+By default each dimension is registered as a plain label-free metric. When you need to, you can attach optional Prometheus labels to every per-dimension metric by declaring `labelNames` in the config and supplying values via a `labels` sub-object on the measurement. This works uniformly across all three dimensional classes; label values are optional per measurement.
+
+```typescript
+export class RequestDurationMetric extends AbstractDimensionalHistogramMetric<
+  ['successful', 'failed'],
+  ['region']
+> {
+  constructor({ promClient }: Deps) {
+    super(
+      {
+        helpDescription: 'Duration of requests in seconds',
+        dimensions: ['successful', 'failed'],
+        labelNames: ['region'],
+        buckets: [0.1, 0.5, 1, 5],
+        buildMetricName: (dimension) => `request_duration_${dimension}:histogram`,
+      },
+      promClient,
+    )
+  }
+}
+
+const requestDurationMetric = new RequestDurationMetric({ appMetrics })
+
+// Histogram — labels sit in the `labels` sub-object alongside `dimension` and the duration:
+requestDurationMetric.registerMeasurement({ dimension: 'successful', labels: { region: 'eu' }, time: 0.32 })
+```
+
+Counter and gauge take the same `labels` sub-object; because their measurement keys are the dimensions, the `labels` object applies to every dimension incremented/set in that call:
+
+```typescript
+// Counter
+pizzaDeliveryCountMetric.registerMeasurement({
+  delivered_to_customer: 1,
+  delivered_to_pickup_point: 2,
+  labels: { region: 'eu' },
+})
+
+// Gauge
+connectionPoolMetric.registerMeasurement({ active: 7, idle: 3, labels: { region: 'eu' } })
+```
+
+> ⚠️ For counter and gauge, `labels` is a reserved key in the measurement object. If you use lazy-unbounded string dimensions, avoid a dimension literally named `labels`, as it would be interpreted as the label sub-object rather than a dimension. Histogram is unaffected — its dimension lives in the dedicated `dimension` field.
+
 ### Lazy initialization
 
 By default, all Dimensional classes (`AbstractDimensionalCounterMetric`, `AbstractDimensionalGaugeMetric` and `AbstractDimensionalHistogramMetric`) operate in **eager mode**: every declared dimension is registered at construction time, and a measurement targeting a dimension that was not listed in `dimensions` is silently ignored — a metrics utility must not throw into the caller's path.

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalCounterMetric.spec.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalCounterMetric.spec.ts
@@ -48,6 +48,23 @@ class LazyUnboundedDimensionalCounterMetric extends AbstractDimensionalCounterMe
   }
 }
 
+class LabeledConcreteDimensionalCounterMetric extends AbstractDimensionalCounterMetric<
+  ['successful', 'failed'],
+  ['region']
+> {
+  constructor(client?: typeof promClient) {
+    super(
+      {
+        helpDescription: 'Labeled counter',
+        dimensions: ['successful', 'failed'],
+        labelNames: ['region'],
+        buildMetricName: (dimension) => `labeled_${dimension}:counter`,
+      },
+      client,
+    )
+  }
+}
+
 describe('AbstractDimensionalCounterMetric', () => {
   let incMock: Mock
   let counterMock: Mock
@@ -320,6 +337,52 @@ describe('AbstractDimensionalCounterMetric', () => {
         expect(counterMock).toHaveBeenCalledTimes(1)
         expect(incMock).toHaveBeenCalledTimes(2)
       })
+    })
+  })
+
+  describe('labels', () => {
+    it('registers the metric with the declared label names', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+
+      // When
+      new LabeledConcreteDimensionalCounterMetric(client)
+
+      // Then
+      expect(counterMock).toHaveBeenCalledWith({
+        name: 'labeled_successful:counter',
+        help: 'Labeled counter',
+        labelNames: ['region'],
+      })
+    })
+
+    it('increments with the provided label values, applied to every dimension', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+      const metric = new LabeledConcreteDimensionalCounterMetric(client)
+      incMock.mockClear()
+
+      // When
+      metric.registerMeasurement({ successful: 20, failed: 10, labels: { region: 'eu' } })
+
+      // Then
+      expect(incMock).toHaveBeenCalledTimes(2)
+      expect(incMock).toHaveBeenCalledWith({ region: 'eu' }, 20)
+      expect(incMock).toHaveBeenCalledWith({ region: 'eu' }, 10)
+    })
+
+    it('increments without labels when labels are omitted', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+      const metric = new LabeledConcreteDimensionalCounterMetric(client)
+      incMock.mockClear()
+
+      // When
+      metric.registerMeasurement({ successful: 20 })
+
+      // Then
+      expect(incMock).toHaveBeenCalledTimes(1)
+      expect(incMock).toHaveBeenCalledWith(20)
     })
   })
 })

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalCounterMetric.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalCounterMetric.ts
@@ -5,9 +5,12 @@ import {
   type DimensionalMetricParams,
 } from './AbstractDimensionalMetric.ts'
 
-type DimensionalCounterMeasurement<TDimensions extends readonly string[]> = Partial<
-  Record<TDimensions[number], number>
->
+type DimensionalCounterMeasurement<
+  TDimensions extends readonly string[],
+  TLabels extends readonly string[],
+> = Partial<Record<TDimensions[number], number>> & {
+  labels?: Partial<Record<TLabels[number], string | number>>
+}
 
 /**
  * Base class for counter metrics where each dimension is registered as a **separate label-free Prometheus Counter**.
@@ -21,24 +24,28 @@ type DimensionalCounterMeasurement<TDimensions extends readonly string[]> = Part
  */
 export abstract class AbstractDimensionalCounterMetric<
   TDimensions extends readonly string[],
+  TLabels extends readonly string[] = [],
 > extends AbstractDimensionalMetric<
-  Counter,
+  Counter<TLabels[number]>,
   TDimensions,
-  DimensionalMetricParams<TDimensions>,
-  DimensionalCounterMeasurement<TDimensions>
+  DimensionalMetricParams<TDimensions, TLabels>,
+  DimensionalCounterMeasurement<TDimensions, TLabels>
 > {
   protected constructor(
-    metricConfig: DimensionalMetricParams<TDimensions>,
+    metricConfig: DimensionalMetricParams<TDimensions, TLabels>,
     client?: typeof promClient,
   ) {
     super(metricConfig, client)
   }
 
-  protected override createMetric(name: string, client: typeof promClient): Counter {
+  protected override createMetric(
+    name: string,
+    client: typeof promClient,
+  ): Counter<TLabels[number]> {
     const counter = new client.Counter({
       name,
       help: this.metricConfig.helpDescription,
-      labelNames: [],
+      labelNames: this.metricConfig.labelNames ?? [],
     })
     // Eager mode: pre-init to 0 so the series is exposed in scrapes before any measurement.
     // Lazy mode: the metric is created on the first measurement, pre-init is not needed.
@@ -51,18 +58,25 @@ export abstract class AbstractDimensionalCounterMetric<
    * Increments the per-dimension counter for one or more dimensions.
    *
    * Pass an object mapping each dimension to the amount to add. Keys with `undefined` values are skipped.
+   * Optional Prometheus label values can be supplied via `labels`, applied to every dimension in the call.
    * A measurement targeting a dimension outside the declared set is silently ignored.
    */
   public override registerMeasurement(
-    measurement: DimensionalCounterMeasurement<TDimensions>,
+    measurement: DimensionalCounterMeasurement<TDimensions, TLabels>,
   ): void {
     if (!this.client) return
 
-    const entries = Object.entries(measurement) as [string, number | undefined][]
+    const { labels, ...dimensions } = measurement
+    const hasLabels = labels && Object.keys(labels).length > 0
+    const entries = Object.entries(dimensions) as [string, number | undefined][]
     for (const [dimension, value] of entries) {
       if (value === undefined) continue
 
-      this.getOrRegisterMetric(dimension)?.inc(value)
+      const counter = this.getOrRegisterMetric(dimension)
+      if (!counter) continue
+
+      if (hasLabels) counter.inc(labels as object, value)
+      else counter.inc(value)
     }
   }
 }

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalGaugeMetric.spec.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalGaugeMetric.spec.ts
@@ -46,6 +46,23 @@ class LazyUnboundedDimensionalGaugeMetric extends AbstractDimensionalGaugeMetric
   }
 }
 
+class LabeledConcreteDimensionalGaugeMetric extends AbstractDimensionalGaugeMetric<
+  ['active', 'idle'],
+  ['region']
+> {
+  constructor(client?: typeof promClient) {
+    super(
+      {
+        helpDescription: 'Labeled gauge',
+        dimensions: ['active', 'idle'],
+        labelNames: ['region'],
+        buildMetricName: (dimension) => `labeled_${dimension}:gauge`,
+      },
+      client,
+    )
+  }
+}
+
 describe('AbstractDimensionalGaugeMetric', () => {
   let setMock: Mock
   let gaugeMock: Mock
@@ -312,6 +329,52 @@ describe('AbstractDimensionalGaugeMetric', () => {
         expect(gaugeMock).toHaveBeenCalledTimes(1)
         expect(setMock).toHaveBeenCalledTimes(2)
       })
+    })
+  })
+
+  describe('labels', () => {
+    it('registers the metric with the declared label names', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+
+      // When
+      new LabeledConcreteDimensionalGaugeMetric(client)
+
+      // Then
+      expect(gaugeMock).toHaveBeenCalledWith({
+        name: 'labeled_active:gauge',
+        help: 'Labeled gauge',
+        labelNames: ['region'],
+      })
+    })
+
+    it('sets with the provided label values, applied to every dimension', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+      const metric = new LabeledConcreteDimensionalGaugeMetric(client)
+      setMock.mockClear()
+
+      // When
+      metric.registerMeasurement({ active: 7, idle: 3, labels: { region: 'eu' } })
+
+      // Then
+      expect(setMock).toHaveBeenCalledTimes(2)
+      expect(setMock).toHaveBeenCalledWith({ region: 'eu' }, 7)
+      expect(setMock).toHaveBeenCalledWith({ region: 'eu' }, 3)
+    })
+
+    it('sets without labels when labels are omitted', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+      const metric = new LabeledConcreteDimensionalGaugeMetric(client)
+      setMock.mockClear()
+
+      // When
+      metric.registerMeasurement({ active: 7 })
+
+      // Then
+      expect(setMock).toHaveBeenCalledTimes(1)
+      expect(setMock).toHaveBeenCalledWith(7)
     })
   })
 })

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalGaugeMetric.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalGaugeMetric.ts
@@ -5,9 +5,12 @@ import {
   type DimensionalMetricParams,
 } from './AbstractDimensionalMetric.ts'
 
-type DimensionalGaugeMeasurement<TDimensions extends readonly string[]> = Partial<
-  Record<TDimensions[number], number>
->
+type DimensionalGaugeMeasurement<
+  TDimensions extends readonly string[],
+  TLabels extends readonly string[],
+> = Partial<Record<TDimensions[number], number>> & {
+  labels?: Partial<Record<TLabels[number], string | number>>
+}
 
 /**
  * Base class for gauge metrics where each dimension is registered as a **separate label-free Prometheus Gauge**.
@@ -23,24 +26,25 @@ type DimensionalGaugeMeasurement<TDimensions extends readonly string[]> = Partia
  */
 export abstract class AbstractDimensionalGaugeMetric<
   TDimensions extends readonly string[],
+  TLabels extends readonly string[] = [],
 > extends AbstractDimensionalMetric<
-  Gauge,
+  Gauge<TLabels[number]>,
   TDimensions,
-  DimensionalMetricParams<TDimensions>,
-  DimensionalGaugeMeasurement<TDimensions>
+  DimensionalMetricParams<TDimensions, TLabels>,
+  DimensionalGaugeMeasurement<TDimensions, TLabels>
 > {
   protected constructor(
-    metricConfig: DimensionalMetricParams<TDimensions>,
+    metricConfig: DimensionalMetricParams<TDimensions, TLabels>,
     client?: typeof promClient,
   ) {
     super(metricConfig, client)
   }
 
-  protected override createMetric(name: string, client: typeof promClient): Gauge {
+  protected override createMetric(name: string, client: typeof promClient): Gauge<TLabels[number]> {
     const gauge = new client.Gauge({
       name,
       help: this.metricConfig.helpDescription,
-      labelNames: [],
+      labelNames: this.metricConfig.labelNames ?? [],
     })
     // Eager mode: pre-init to 0 so the series is exposed in scrapes before any measurement.
     // Lazy mode: the metric is created on the first measurement, pre-init is not needed.
@@ -53,16 +57,25 @@ export abstract class AbstractDimensionalGaugeMetric<
    * Sets the per-dimension gauge for one or more dimensions.
    *
    * Pass an object mapping each dimension to the value to set. Keys with `undefined` values are skipped.
+   * Optional Prometheus label values can be supplied via `labels`, applied to every dimension in the call.
    * A measurement targeting a dimension outside the declared set is silently ignored.
    */
-  public override registerMeasurement(measurement: DimensionalGaugeMeasurement<TDimensions>): void {
+  public override registerMeasurement(
+    measurement: DimensionalGaugeMeasurement<TDimensions, TLabels>,
+  ): void {
     if (!this.client) return
 
-    const entries = Object.entries(measurement) as [string, number | undefined][]
+    const { labels, ...dimensions } = measurement
+    const hasLabels = labels && Object.keys(labels).length > 0
+    const entries = Object.entries(dimensions) as [string, number | undefined][]
     for (const [dimension, value] of entries) {
       if (value === undefined) continue
 
-      this.getOrRegisterMetric(dimension)?.set(value)
+      const gauge = this.getOrRegisterMetric(dimension)
+      if (!gauge) continue
+
+      if (hasLabels) gauge.set(labels as object, value)
+      else gauge.set(value)
     }
   }
 }

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalHistogramMetric.spec.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalHistogramMetric.spec.ts
@@ -51,6 +51,24 @@ class LazyUnboundedDimensionalHistogramMetric extends AbstractDimensionalHistogr
   }
 }
 
+class LabeledConcreteDimensionalHistogramMetric extends AbstractDimensionalHistogramMetric<
+  ['successful', 'failed'],
+  ['region']
+> {
+  constructor(client?: typeof promClient) {
+    super(
+      {
+        helpDescription: 'Labeled histogram',
+        dimensions: ['successful', 'failed'],
+        labelNames: ['region'],
+        buckets: [1, 2, 3],
+        buildMetricName: (dimension) => `labeled_${dimension}:histogram`,
+      },
+      client,
+    )
+  }
+}
+
 describe('AbstractDimensionalHistogramMetric', () => {
   let observeMock: Mock
   let histogramMock: Mock
@@ -284,6 +302,49 @@ describe('AbstractDimensionalHistogramMetric', () => {
         expect(histogramMock).toHaveBeenCalledTimes(1)
         expect(observeMock).toHaveBeenCalledTimes(2)
       })
+    })
+  })
+
+  describe('labels', () => {
+    it('registers the metric with the declared label names', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+
+      // When
+      const metric = new LabeledConcreteDimensionalHistogramMetric(client)
+      metric.registerMeasurement({ dimension: 'successful', labels: { region: 'eu' }, time: 100 })
+
+      // Then
+      expect(histogramMock).toHaveBeenCalledWith({
+        name: 'labeled_successful:histogram',
+        help: 'Labeled histogram',
+        buckets: [1, 2, 3],
+        labelNames: ['region'],
+      })
+    })
+
+    it('observes with the provided label values', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+      const metric = new LabeledConcreteDimensionalHistogramMetric(client)
+
+      // When
+      metric.registerMeasurement({ dimension: 'successful', labels: { region: 'eu' }, time: 100 })
+
+      // Then
+      expect(observeMock).toHaveBeenCalledWith({ region: 'eu' }, 100)
+    })
+
+    it('observes with an empty label object when labels are omitted', () => {
+      // Given
+      getSingleMetricMock.mockReturnValue(undefined)
+      const metric = new LabeledConcreteDimensionalHistogramMetric(client)
+
+      // When
+      metric.registerMeasurement({ dimension: 'failed', startTime: 100, endTime: 150 })
+
+      // Then
+      expect(observeMock).toHaveBeenCalledWith({}, 50)
     })
   })
 })

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalHistogramMetric.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalHistogramMetric.ts
@@ -5,14 +5,20 @@ import {
   type DimensionalMetricParams,
 } from './AbstractDimensionalMetric.ts'
 
-export type DimensionalHistogramMetricConfiguration<TDimensions extends readonly string[]> =
-  DimensionalMetricParams<TDimensions> & {
-    buckets: number[]
-  }
+export type DimensionalHistogramMetricConfiguration<
+  TDimensions extends readonly string[],
+  TLabels extends readonly string[] = [],
+> = DimensionalMetricParams<TDimensions, TLabels> & {
+  buckets: number[]
+}
 
-type DimensionalHistogramMeasurement<TDimensions extends readonly string[]> =
+type DimensionalHistogramMeasurement<
+  TDimensions extends readonly string[],
+  TLabels extends readonly string[],
+> = { labels?: Partial<Record<TLabels[number], string | number>> } & (
   | { dimension: TDimensions[number]; time: number; startTime?: never; endTime?: never }
   | { dimension: TDimensions[number]; time?: never; startTime: number; endTime: number }
+)
 
 /**
  * Base class for histogram metrics where each dimension is registered as a **separate label-free Prometheus Histogram**.
@@ -26,25 +32,29 @@ type DimensionalHistogramMeasurement<TDimensions extends readonly string[]> =
  */
 export abstract class AbstractDimensionalHistogramMetric<
   TDimensions extends readonly string[],
+  TLabels extends readonly string[] = [],
 > extends AbstractDimensionalMetric<
-  Histogram,
+  Histogram<TLabels[number]>,
   TDimensions,
-  DimensionalHistogramMetricConfiguration<TDimensions>,
-  DimensionalHistogramMeasurement<TDimensions>
+  DimensionalHistogramMetricConfiguration<TDimensions, TLabels>,
+  DimensionalHistogramMeasurement<TDimensions, TLabels>
 > {
   protected constructor(
-    metricConfig: DimensionalHistogramMetricConfiguration<TDimensions>,
+    metricConfig: DimensionalHistogramMetricConfiguration<TDimensions, TLabels>,
     client?: typeof promClient,
   ) {
     super(metricConfig, client)
   }
 
-  protected override createMetric(name: string, client: typeof promClient): Histogram {
+  protected override createMetric(
+    name: string,
+    client: typeof promClient,
+  ): Histogram<TLabels[number]> {
     return new client.Histogram({
       name,
       help: this.metricConfig.helpDescription,
       buckets: this.metricConfig.buckets,
-      labelNames: [],
+      labelNames: this.metricConfig.labelNames ?? [],
     })
   }
 
@@ -52,16 +62,17 @@ export abstract class AbstractDimensionalHistogramMetric<
    * Records an observation on the histogram for the given `dimension`.
    *
    * Provide the duration as either `time` directly, or as a `startTime`/`endTime` pair from which the duration
-   * is computed. A measurement targeting a dimension outside the declared set is silently ignored.
+   * is computed. Optional Prometheus label values can be supplied via `labels`. A measurement targeting a
+   * dimension outside the declared set is silently ignored.
    */
   public override registerMeasurement(
-    measurement: DimensionalHistogramMeasurement<TDimensions>,
+    measurement: DimensionalHistogramMeasurement<TDimensions, TLabels>,
   ): void {
     const histogram = this.getOrRegisterMetric(measurement.dimension)
     if (!histogram) return
 
-    const { time, startTime, endTime } = measurement
+    const { time, startTime, endTime, labels } = measurement
     const duration = time ?? endTime - startTime
-    histogram.observe({}, duration)
+    histogram.observe((labels ?? {}) as object, duration)
   }
 }

--- a/packages/app/metrics-utils/src/dimensional/AbstractDimensionalMetric.ts
+++ b/packages/app/metrics-utils/src/dimensional/AbstractDimensionalMetric.ts
@@ -3,8 +3,16 @@ import type { Metric } from 'prom-client'
 import { AbstractMetric, type CommonMetricParams } from '../AbstractMetric.ts'
 import { getOrCreateMetric } from '../getOrCreateMetric.ts'
 
-export type DimensionalMetricParams<TDimensions extends readonly string[]> = CommonMetricParams & {
+export type DimensionalMetricParams<
+  TDimensions extends readonly string[],
+  TLabels extends readonly string[] = [],
+> = CommonMetricParams & {
   buildMetricName: (dimension: TDimensions[number]) => string
+  /**
+   * Optional Prometheus label names carried by every per-dimension metric. When omitted, each dimension
+   * is registered as a plain label-free metric.
+   */
+  labelNames?: TLabels
 } & (
     | {
         /**
@@ -32,7 +40,7 @@ export type DimensionalMetricParams<TDimensions extends readonly string[]> = Com
 export abstract class AbstractDimensionalMetric<
   MetricType extends Metric,
   TDimensions extends readonly string[],
-  MetricsParams extends DimensionalMetricParams<TDimensions>,
+  MetricsParams extends DimensionalMetricParams<TDimensions, readonly string[]>,
   TMeasurement,
 > extends AbstractMetric<MetricType, MetricsParams, TMeasurement> {
   protected readonly metrics: Map<TDimensions[number], MetricType>


### PR DESCRIPTION
## What & why

Dimensional metrics previously registered one **label-free** metric per dimension (`labelNames: []` was hardcoded). This adds **optional** Prometheus labels to all three dimensional types (counter, gauge, histogram), so a dimensional metric can be split per-dimension **and** carry extra labels when needed.

## How

- `DimensionalMetricParams` gains a `TLabels` generic (defaults to `[]`) and an optional `labelNames`.
- Each `createMetric` now uses `labelNames ?? []`.
- Measurements accept a uniform optional `labels` sub-object (consistent across all three types):
  ```ts
  histogram.registerMeasurement({ dimension: 'successful', labels: { region: 'eu' }, time: 100 })
  counter.registerMeasurement({ successful: 20, failed: 10, labels: { region: 'eu' } })
  gauge.registerMeasurement({ active: 7, idle: 3, labels: { region: 'eu' } })
  ```

Fully backward compatible: existing subclasses omit `labelNames`, `TLabels` defaults to `[]`, and omitting `labels` reproduces today's exact calls (`observe({}, d)`, `inc(v)`, `set(v)`, eager `inc(0)`/`set(0)`).

Includes new label tests per type and README docs (with the `labels`-reserved-key caveat for counter/gauge).

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
