### PR TITLE
fix(api-contracts): preserve type narrowing in sseResponse and blobResponse

### DIFF
--- a/.changeset/sse-response-narrow-types.md
+++ b/.changeset/sse-response-narrow-types.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/api-contracts": patch
+---
+
+Fix `sseResponse()` and `blobResponse()` losing type narrowing: both were annotated to return the wide `BodyContentResponseEntry`, so contracts using them inferred every response mode (json/sse/blob) and `InferSseSuccessResponses` widened event schemas to `Record<string, z.ZodType>`. They now infer narrow entry types — `sseResponse()` preserves the concrete event-schema map and `blobResponse()` preserves the literal media-type key — narrowing exactly like an inline `content` map with `sseBody()` / `blobBody()`.

--- a/packages/app/api-contracts/src/new/contractResponse.ts
+++ b/packages/app/api-contracts/src/new/contractResponse.ts
@@ -159,13 +159,16 @@ export const noBodyResponse = (options?: ResponseOptions): NoBodyContentResponse
 /**
  * Declares a binary/opaque response for a single media type.
  */
-export const blobResponse = (
-  contentType: ResponseContentType,
+export const blobResponse = <TContentType extends ResponseContentType>(
+  contentType: TContentType,
   options?: ResponseOptions,
-): BodyContentResponseEntry => ({
-  content: { [contentType]: blobBody() },
-  ...(options?.description !== undefined && { description: options.description }),
-})
+) =>
+  ({
+    // A computed property with a generic key widens to `{ [x: string]: ... }`, losing the literal
+    // media type — assert the single-key record shape to keep `TContentType` in the entry type.
+    content: { [contentType]: blobBody() } as { readonly [K in TContentType]: BlobBody },
+    ...(options?.description !== undefined && { description: options.description }),
+  }) as const satisfies BodyContentResponseEntry
 
 /**
  * Declares a Server-Sent Events response.
@@ -173,10 +176,11 @@ export const blobResponse = (
 export const sseResponse = <T extends SseSchemaByEventName>(
   schemaByEventName: T,
   options?: ResponseOptions,
-): BodyContentResponseEntry => ({
-  content: { 'text/event-stream': sseBody(schemaByEventName) },
-  ...(options?.description !== undefined && { description: options.description }),
-})
+) =>
+  ({
+    content: { 'text/event-stream': sseBody(schemaByEventName) },
+    ...(options?.description !== undefined && { description: options.description }),
+  }) as const satisfies BodyContentResponseEntry
 
 export type ResponsesByStatusCode = Partial<
   Record<HttpStatusCode | WildcardStatusCodeKey, ApiContractResponse | ResponseEntry>

--- a/packages/app/api-contracts/src/new/inferTypes.spec.ts
+++ b/packages/app/api-contracts/src/new/inferTypes.spec.ts
@@ -1,6 +1,13 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { z } from 'zod/v4'
-import { blobBody, noBodyResponse, sseBody } from './contractResponse.ts'
+import {
+  type BlobBody,
+  blobBody,
+  blobResponse,
+  noBodyResponse,
+  sseBody,
+  sseResponse,
+} from './contractResponse.ts'
 import { defineApiContract } from './defineApiContract.ts'
 import type {
   AvailableResponseModes,
@@ -474,6 +481,69 @@ describe('inferTypes', () => {
       })
       type Result = InferSseSuccessResponses<(typeof contract)['responsesByStatusCode']>
       expectTypeOf<keyof Result>().toEqualTypeOf<'chunk' | 'done'>()
+    })
+
+    it('extracts schemas object from sseResponse()', () => {
+      const translationSchema = z.object({ text: z.string() })
+      const errorSchema = z.object({ message: z.string() })
+      const contract = defineApiContract({
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          200: sseResponse({ translation: translationSchema, error: errorSchema }),
+        },
+      })
+      type Result = InferSseSuccessResponses<(typeof contract)['responsesByStatusCode']>
+      expectTypeOf<keyof Result>().toEqualTypeOf<'translation' | 'error'>()
+      expectTypeOf<Result['translation']>().toEqualTypeOf<typeof translationSchema>()
+      expectTypeOf<Result['error']>().toEqualTypeOf<typeof errorSchema>()
+    })
+  })
+
+  describe('response factories narrow like their content-map equivalents', () => {
+    it('sseResponse() yields sse mode only', () => {
+      const contract = defineApiContract({
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: {
+          200: sseResponse({ chunk: z.object({ delta: z.string() }) }),
+          400: z.object({ message: z.string() }),
+        },
+      })
+      type Responses = (typeof contract)['responsesByStatusCode']
+      expectTypeOf<ContractResponseMode<Responses>>().toEqualTypeOf<'sse'>()
+      expectTypeOf<AvailableResponseModes<Responses>>().toEqualTypeOf<'sse'>()
+      expectTypeOf<HasAnyJsonSuccessResponse<Responses>>().toEqualTypeOf<false>()
+      expectTypeOf<InferNonSseSuccessResponses<Responses>>().toEqualTypeOf<never>()
+    })
+
+    it('blobResponse() yields blob mode only', () => {
+      const contract = defineApiContract({
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: blobResponse('image/png') },
+      })
+      type Responses = (typeof contract)['responsesByStatusCode']
+
+      expectTypeOf<ContractResponseMode<Responses>>().toEqualTypeOf<'non-sse'>()
+      expectTypeOf<AvailableResponseModes<Responses>>().toEqualTypeOf<'blob'>()
+      expectTypeOf<HasAnySseSuccessResponse<Responses>>().toEqualTypeOf<false>()
+      expectTypeOf<InferSseSuccessResponses<Responses>>().toEqualTypeOf<never>()
+    })
+
+    it('blobResponse() preserves the literal media-type key in the content map', () => {
+      const contract = defineApiContract({
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/test',
+        responsesByStatusCode: { 200: blobResponse('image/png') },
+      })
+      type Content = (typeof contract)['responsesByStatusCode'][200]['content']
+      expectTypeOf<keyof Content>().toEqualTypeOf<'image/png'>()
+      expectTypeOf<Content['image/png']>().toEqualTypeOf<BlobBody>()
     })
   })
 })


### PR DESCRIPTION
## Summary

`sseResponse()` and `blobResponse()` were annotated to return the wide `BodyContentResponseEntry`, which erased their generics. As a result:

- `InferSseSuccessResponses` widened SSE event schemas to `Record<string, z.ZodType>`, so clients lost typed events and users had to inline `{ content: { 'text/event-stream': sseBody({...}) } }` manually.
- The widened `content` map values (`BodyDescriptor` union) made contracts appear to have every response mode — a blob-only contract also reported `sse`/`json` in `AvailableResponseModes`, and `ContractResponseMode` degraded accordingly.
- `blobResponse('image/png')` lost the literal media-type key (`{ [x: string]: BlobBody }`).

## Changes

- `sseResponse()` now infers a narrow entry type preserving the concrete event-schema map (`SseBody<T>` under the `text/event-stream` key).
- `blobResponse()` preserves the literal media-type key via an assertion on the content map — a computed property with a generic key otherwise always widens to a string index signature, which neither `as const` nor `satisfies` can recover.
- Both keep an `as const satisfies BodyContentResponseEntry` check, so the produced shape is still validated against the contract entry type.
- Added type tests: `InferSseSuccessResponses` extracts exact event schemas from `sseResponse()`, factories yield only their own response mode, and `blobResponse()` keeps its literal content-type key.
- Changeset: patch for `@lokalise/api-contracts`.

## Testing

- `pnpm test` in `packages/app/api-contracts` (799 tests incl. vitest typecheck) — the new type tests fail without the fix
- `pnpm lint` (biome + tsc) in api-contracts and in dependents (`backend-http-client`, `frontend-http-client`, `universal-testing-utils`) against a rebuilt `dist`

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**