### PR TITLE
feat: EXP-2240 Legacy contract input compatibility

### DIFF
--- a/.changeset/client-compatible-contracts.md
+++ b/.changeset/client-compatible-contracts.md
@@ -1,0 +1,11 @@
+---
+"@lokalise/backend-http-client": patch
+"@lokalise/frontend-http-client": patch
+"@lokalise/universal-testing-utils": patch
+---
+
+Accept contracts compiled against older `@lokalise/api-contracts` versions. Every contract input
+(HTTP client senders, SSE connector, and mock helpers) now loosens the server-only `visibility`
+field to optional via `ClientCompatibleContract`, so contracts whose types predate the field
+(<7.2) keep working. The clients and testing helpers never read server-only fields; they only
+matter on the serving side.

--- a/packages/app/backend-http-client/src/api-contract/sendByApiContract.spec.ts
+++ b/packages/app/backend-http-client/src/api-contract/sendByApiContract.spec.ts
@@ -53,6 +53,29 @@ describe('sendByApiContract', () => {
       expect(result.result).toMatchObject({ body: { id: 1, title: 'Backpack' } })
     })
 
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const responseSchema = z.object({ id: z.number(), title: z.string() })
+      // the shape of a contract compiled against pre-visibility api-contracts (<7.2)
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/products/1',
+        responsesByStatusCode: { 200: responseSchema },
+      })
+
+      await mockServer
+        .forGet('/products/1')
+        .thenJson(200, { id: 1, title: 'Backpack' }, JSON_HEADERS)
+
+      const result = await sendByApiContract(client, legacyContract, {})
+
+      expectTypeOf(result.result).toMatchTypeOf<
+        { body: { id: number; title: string } } | undefined
+      >()
+      expect(result.result).toMatchObject({ body: { id: 1, title: 'Backpack' } })
+    })
+
     it('sends GET request with path params', async () => {
       const contract = defineApiContract({
         visibility: 'public',
@@ -341,6 +364,24 @@ describe('sendByApiContract', () => {
 
       expect(result.result).toMatchObject({ body: { id: '1' } })
     })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'post',
+        pathResolver: () => '/products',
+        requestBodySchema: z.object({ name: z.string() }),
+        responsesByStatusCode: { 201: z.object({ id: z.number() }) },
+      })
+
+      await mockServer.forPost('/products').thenJson(201, { id: 21 }, JSON_HEADERS)
+
+      const result = await sendByApiContract(client, legacyContract, { body: { name: 'test' } })
+
+      expectTypeOf(result.result).toMatchTypeOf<{ body: { id: number } } | undefined>()
+      expect(result.result).toMatchObject({ body: { id: 21 } })
+    })
   })
 
   describe('content-type request header', () => {
@@ -500,6 +541,23 @@ describe('sendByApiContract', () => {
       const result = await sendByApiContract(client, contract, { pathParams: { id: '1' } })
 
       expectTypeOf(result.result).toMatchTypeOf<{ body: null } | undefined>()
+      expect(result.result).toMatchObject({ statusCode: 204, body: null })
+    })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'delete',
+        requestPathParamsSchema: z.object({ id: z.string() }),
+        pathResolver: ({ id }) => `/products/${id}`,
+        responsesByStatusCode: { 204: noBodyResponse() },
+      })
+
+      await mockServer.forDelete('/products/1').thenReply(204)
+
+      const result = await sendByApiContract(client, legacyContract, { pathParams: { id: '1' } })
+
       expect(result.result).toMatchObject({ statusCode: 204, body: null })
     })
   })
@@ -669,6 +727,39 @@ describe('sendByApiContract', () => {
           // consume
         }
       }).rejects.toThrow('Schema for event "unknown" not found.')
+    })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/events',
+        responsesByStatusCode: {
+          200: {
+            content: { 'text/event-stream': sseBody({ update: z.object({ id: z.string() }) }) },
+          },
+        },
+      })
+
+      const sseStreamPayload = 'event: update\ndata: {"id":"1"}\n\n'
+
+      await mockServer
+        .forGet('/events')
+        .withHeaders({ accept: 'text/event-stream' })
+        .thenReply(200, sseStreamPayload, { 'content-type': 'text/event-stream' })
+
+      const response = await sendByApiContract(client, legacyContract, {})
+
+      if (!response.result) throw new Error('Expected result')
+      const events: unknown[] = []
+      for await (const event of response.result.body) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([
+        { type: 'update', data: { id: '1' }, lastEventId: '', retry: undefined },
+      ])
     })
   })
 

--- a/packages/app/backend-http-client/src/api-contract/sendByApiContract.ts
+++ b/packages/app/backend-http-client/src/api-contract/sendByApiContract.ts
@@ -5,10 +5,13 @@ import {
   buildRequestPath,
   type ClientRequestParams,
   type DefaultStreaming,
+  type DeleteApiContract,
+  type GetApiContract,
   type HeadersParam,
   hasAnySuccessSseResponse,
   type InferNonSseClientResponse,
   type InferSseClientResponse,
+  type PayloadApiContract,
   type ResponseKind,
   resolveResponseEntry,
   type SseSchemaByEventName,
@@ -16,6 +19,10 @@ import {
 } from '@lokalise/api-contracts'
 import { ServerSentEventTransformStream } from 'parse-sse'
 import type { Client, Dispatcher } from 'undici'
+import type {
+  ClientCompatibleContract,
+  ServerOnlyContractFields,
+} from '../client/apiContractTypes.ts'
 import { REQUEST_ID_HEADER } from '../client/constants.ts'
 import type { HttpRequestContext } from '../client/types.ts'
 import { type RetryConfig, resolveRetryConfig, withRetry } from './retry.ts'
@@ -70,16 +77,33 @@ type Either<TError, TResult> =
   | { error: TError; result?: never }
   | { error?: never; result: TResult }
 
+// `ApiContract` accepted as client input: `ClientCompatibleContract` applied per union member
+// so the method/body discrimination is preserved (an `Omit` over the whole union would
+// collapse it to the common keys).
+type ApiContractInput =
+  | ClientCompatibleContract<GetApiContract>
+  | ClientCompatibleContract<DeleteApiContract>
+  | ClientCompatibleContract<PayloadApiContract>
+
+// Re-tightens a loosened contract type back to a full `ApiContract` by completing the
+// server-only fields, so it satisfies the `extends ApiContract` constraint of the
+// api-contracts infer helpers. The `infer C extends ApiContract` indirection defers the
+// check until instantiation, where the intersection always completes the missing fields.
+type CompleteApiContract<T extends ApiContractInput> = T &
+  ServerOnlyContractFields extends infer C extends ApiContract
+  ? C
+  : never
+
 type AllContractResponses<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
 > = TIsStreaming extends true
-  ? InferSseClientResponse<TApiContract>
-  : InferNonSseClientResponse<TApiContract>
+  ? InferSseClientResponse<CompleteApiContract<TApiContract>>
+  : InferNonSseClientResponse<CompleteApiContract<TApiContract>>
 
 // captureAsError: true → success codes only; captureAsError: false → all codes from contract
 type ContractResultType<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
   TDoCaptureAsError extends boolean,
 > = TDoCaptureAsError extends true
@@ -92,7 +116,7 @@ type ContractResultType<
 // captureAsError: true → UnexpectedResponseError | <error-status-code responses from contract>
 // captureAsError: false → only UnexpectedResponseError (all contract responses go to result)
 type ContractErrorType<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
   TDoCaptureAsError extends boolean,
 > = TDoCaptureAsError extends true
@@ -105,7 +129,7 @@ type ContractErrorType<
   : UnexpectedResponseError
 
 type ReturnTypeForContract<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
   TDoCaptureAsError extends boolean,
 > = Either<
@@ -238,18 +262,20 @@ async function parseBody(body: Dispatcher.ResponseData['body'], resolvedEntry: R
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: it is acceptable
 export async function sendByApiContract<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean = DefaultStreaming<TApiContract['responsesByStatusCode']>,
   TCaptureAsError extends boolean = true,
 >(
   client: Client,
   apiContract: TApiContract,
-  params: ClientRequestParams<TApiContract, TIsStreaming> & ContractRequestOptions<TCaptureAsError>,
+  params: ClientRequestParams<CompleteApiContract<TApiContract>, TIsStreaming> &
+    ContractRequestOptions<TCaptureAsError>,
 ): Promise<ReturnTypeForContract<TApiContract, TIsStreaming, TCaptureAsError>> {
   const strictContentType = params.strictContentType ?? true
   const captureAsError = params.captureAsError ?? true
 
-  const useStreaming: boolean = params.streaming ?? hasAnySuccessSseResponse(apiContract)
+  const useStreaming: boolean =
+    params.streaming ?? hasAnySuccessSseResponse(apiContract as ApiContract)
 
   const userHeaders = (await resolveRequestHeaders(params.headers)) ?? {}
 

--- a/packages/app/backend-http-client/src/client/apiContractTypes.ts
+++ b/packages/app/backend-http-client/src/client/apiContractTypes.ts
@@ -4,7 +4,10 @@ import type { ApiContract, CommonRouteDefinition } from '@lokalise/api-contracts
  * Contract fields that only the serving side acts upon; the HTTP client never reads them.
  * Add future mandatory server-side fields here.
  */
-export type ServerOnlyContractFields = Pick<ApiContract, 'visibility'>
+// The `Extract` keeps this resolvable against pre-visibility `@lokalise/api-contracts` peers
+// (<7.2), where `ApiContract` has no `visibility` key: the type degrades to `{}` there, so
+// `ClientCompatibleContract` becomes a no-op instead of a compile error.
+export type ServerOnlyContractFields = Pick<ApiContract, Extract<keyof ApiContract, 'visibility'>>
 
 /**
  * Loosens a route definition's server-only fields to optional, so contracts compiled against

--- a/packages/app/backend-http-client/src/client/apiContractTypes.ts
+++ b/packages/app/backend-http-client/src/client/apiContractTypes.ts
@@ -1,3 +1,21 @@
+import type { ApiContract, CommonRouteDefinition } from '@lokalise/api-contracts'
+
+/**
+ * Contract fields that only the serving side acts upon; the HTTP client never reads them.
+ * Add future mandatory server-side fields here.
+ */
+export type ServerOnlyContractFields = Pick<ApiContract, 'visibility'>
+
+/**
+ * Loosens a route definition's server-only fields to optional, so contracts compiled against
+ * older `@lokalise/api-contracts` — whose types lack them (e.g. `visibility` before 7.2) — are
+ * still accepted. The HTTP client never reads those fields; they only matter on server side.
+ */
+export type ClientCompatibleContract<
+  // biome-ignore lint/suspicious/noExplicitAny: accepts any route definition shape
+  T extends ApiContract | CommonRouteDefinition<any, any, any, any, any, any, any, any>,
+> = Omit<T, keyof ServerOnlyContractFields> & Partial<ServerOnlyContractFields>
+
 export type PayloadRouteRequestParams<
   PathParams = undefined,
   RequestBody = undefined,

--- a/packages/app/backend-http-client/src/client/httpClient.spec.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.spec.ts
@@ -669,6 +669,28 @@ describe('httpClient', () => {
       expectTypeOf(result.result.body).toEqualTypeOf<z.output<typeof schema>>()
       expect(result.result.body).toEqual(mockProduct1)
     })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildGetRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ id: z.number() }),
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      await mockServer.forGet('/products/1').thenJson(200, { id: 1 }, JSON_HEADERS)
+
+      const response = await sendByGetRoute(
+        client,
+        legacyContract,
+        {},
+        {
+          requestLabel: 'Test request',
+        },
+      )
+
+      expect(response.result?.body).toEqual({ id: 1 })
+    })
   })
 
   describe('DELETE', () => {
@@ -967,6 +989,26 @@ describe('httpClient', () => {
       expectTypeOf(result.result.body).toEqualTypeOf<{ id: number } | null>()
       expect(result.result.body).toEqual({ id: 1 })
     })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildDeleteRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ id: z.number() }),
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      await mockServer.forDelete('/products/1').thenJson(200, { id: 1 }, JSON_HEADERS)
+
+      const response = await sendByDeleteRoute(
+        client,
+        legacyContract,
+        {},
+        { requestLabel: 'Test request' },
+      )
+
+      expect(response.result?.body).toEqual({ id: 1 })
+    })
   })
 
   describe('sendByPayloadRoute', () => {
@@ -1113,6 +1155,28 @@ describe('httpClient', () => {
 
       expectTypeOf(result.result.body).toEqualTypeOf<{ id: number }>()
       expect(result.result.body).toEqual({ id: 1 })
+    })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildPayloadRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ id: z.number() }),
+        requestPathParamsSchema: z.undefined(),
+        method: 'post',
+        requestBodySchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      await mockServer.forPost('/products/1').thenJson(200, { id: 1 }, JSON_HEADERS)
+
+      const response = await sendByPayloadRoute(
+        client,
+        legacyContract,
+        {},
+        { requestLabel: 'Test request' },
+      )
+
+      expect(response.result?.body).toEqual({ id: 1 })
     })
   })
 
@@ -2279,6 +2343,28 @@ describe('httpClient', () => {
       const body = await streamToString(result.result.body)
       expect(JSON.parse(body)).toEqual(mockProduct1)
     })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildGetRoute({
+        visibility: 'public',
+        successResponseBodySchema: undefined,
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      await mockServer.forGet('/products/1').thenReply(200, JSON.stringify({ id: 1 }), JSON_HEADERS)
+
+      const result = await sendByGetRouteWithStreamedResponse(
+        client,
+        legacyContract,
+        {},
+        { requestLabel: 'dummy' },
+      )
+
+      expect(result.result.statusCode).toBe(200)
+      const body = await streamToString(result.result.body)
+      expect(JSON.parse(body)).toEqual({ id: 1 })
+    })
   })
 
   describe('sendPostWithStreamedResponse', () => {
@@ -2564,6 +2650,30 @@ describe('httpClient', () => {
 
       expect(result.result).toBeUndefined()
       expect(isInternalRequestError(result.error)).toBe(true)
+    })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildPayloadRoute({
+        visibility: 'public',
+        method: 'post',
+        successResponseBodySchema: undefined,
+        requestBodySchema: z.undefined(),
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products',
+      })
+
+      await mockServer.forPost('/products').thenReply(200, JSON.stringify({ id: 1 }), JSON_HEADERS)
+
+      const result = await sendByPayloadRouteWithStreamedResponse(
+        client,
+        legacyContract,
+        {},
+        { requestLabel: 'dummy' },
+      )
+
+      expect(result.result.statusCode).toBe(200)
+      const body = await streamToString(result.result.body)
+      expect(JSON.parse(body)).toEqual({ id: 1 })
     })
   })
 
@@ -3376,6 +3486,26 @@ describe('httpClient', () => {
         ),
       ).rejects.toThrow()
     })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildGetRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ id: z.number() }),
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      await mockServer.forGet('/products/1').thenJson(200, { id: 1 }, JSON_HEADERS)
+
+      const result = await sendByContract(
+        client,
+        legacyContract,
+        {},
+        { throwOnError: true, requestLabel: 'dummy' },
+      )
+
+      expect(result.result.body).toEqual({ id: 1 })
+    })
   })
 
   describe('sendByContractWithStreamedResponse', () => {
@@ -3594,6 +3724,28 @@ describe('httpClient', () => {
         message: 'Response status code 500',
         errorCode: 'REQUEST_ERROR',
       })
+    })
+
+    it('accepts contracts without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _, ...legacyContract } = buildGetRoute({
+        visibility: 'public',
+        successResponseBodySchema: undefined,
+        requestPathParamsSchema: z.undefined(),
+        pathResolver: () => '/products/1',
+      })
+
+      await mockServer.forGet('/products/1').thenReply(200, JSON.stringify({ id: 1 }), JSON_HEADERS)
+
+      const result = await sendByContractWithStreamedResponse(
+        client,
+        legacyContract,
+        {},
+        { requestLabel: 'dummy' },
+      )
+
+      expect(result.result.statusCode).toBe(200)
+      const body = await streamToString(result.result.body)
+      expect(JSON.parse(body)).toEqual({ id: 1 })
     })
   })
 })

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -14,7 +14,11 @@ import { Client } from 'undici'
 import type { ZodError, ZodSchema, z } from 'zod/v4'
 import type { InternalRequestError } from '../errors/InternalRequestError.ts'
 import { ResponseStatusError } from '../errors/ResponseStatusError.ts'
-import type { PayloadRouteRequestParams, RouteRequestParams } from './apiContractTypes.ts'
+import type {
+  ClientCompatibleContract,
+  PayloadRouteRequestParams,
+  RouteRequestParams,
+} from './apiContractTypes.ts'
 import { DEFAULT_OPTIONS, defaultClientOptions, REQUEST_ID_HEADER } from './constants.ts'
 import { executeRequest, executeStreamRequest, isRequestResult } from './requestExecutor.ts'
 import type {
@@ -530,16 +534,18 @@ export function sendByPayloadRoute<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: PayloadRouteDefinition<
-    RequestBodySchema,
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    PayloadRouteDefinition<
+      RequestBodySchema,
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -595,15 +601,17 @@ export function sendByGetRoute<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: GetRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    GetRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -656,15 +664,17 @@ export function sendByDeleteRoute<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: DeleteRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    DeleteRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -713,15 +723,17 @@ export function sendByGetRouteWithStreamedResponse<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: GetRouteDefinition<
-    undefined,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    undefined,
-    false,
-    false,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    GetRouteDefinition<
+      undefined,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      undefined,
+      false,
+      false,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -768,16 +780,18 @@ export function sendByPayloadRouteWithStreamedResponse<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: PayloadRouteDefinition<
-    RequestBodySchema,
-    undefined,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    undefined,
-    false,
-    false,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    PayloadRouteDefinition<
+      RequestBodySchema,
+      undefined,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      undefined,
+      false,
+      false,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -846,15 +860,17 @@ export function sendByContract<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: GetRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    GetRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -889,16 +905,18 @@ export function sendByContract<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: PayloadRouteDefinition<
-    RequestBodySchema,
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    PayloadRouteDefinition<
+      RequestBodySchema,
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -933,15 +951,17 @@ export function sendByContract<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: DeleteRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    DeleteRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -964,11 +984,11 @@ export function sendByContract<
 export function sendByContract(
   client: Client,
   routeDefinition: // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | GetRouteDefinition<any, any, any, any, any, any, any, any>
+    | ClientCompatibleContract<GetRouteDefinition<any, any, any, any, any, any, any, any>>
     // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | PayloadRouteDefinition<any, any, any, any, any, any, any, any, any>
+    | ClientCompatibleContract<PayloadRouteDefinition<any, any, any, any, any, any, any, any, any>>
     // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | DeleteRouteDefinition<any, any, any, any, any, any, any, any>,
+    | ClientCompatibleContract<DeleteRouteDefinition<any, any, any, any, any, any, any, any>>,
   // biome-ignore lint/suspicious/noExplicitAny: params type depends on overload
   params: any,
   // biome-ignore lint/suspicious/noExplicitAny: options type depends on overload
@@ -1018,15 +1038,17 @@ export function sendByContractWithStreamedResponse<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: GetRouteDefinition<
-    undefined,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    undefined,
-    false,
-    false,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    GetRouteDefinition<
+      undefined,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      undefined,
+      false,
+      false,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -1058,16 +1080,18 @@ export function sendByContractWithStreamedResponse<
     | undefined = undefined,
 >(
   client: Client,
-  routeDefinition: PayloadRouteDefinition<
-    RequestBodySchema,
-    undefined,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    undefined,
-    false,
-    false,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    PayloadRouteDefinition<
+      RequestBodySchema,
+      undefined,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      undefined,
+      false,
+      false,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -1092,9 +1116,9 @@ export function sendByContractWithStreamedResponse<
 export function sendByContractWithStreamedResponse(
   client: Client,
   routeDefinition: // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | GetRouteDefinition<any, any, any, any, any, any, any, any>
+    | ClientCompatibleContract<GetRouteDefinition<any, any, any, any, any, any, any, any>>
     // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | PayloadRouteDefinition<any, any, any, any, any, any, any, any, any>,
+    | ClientCompatibleContract<PayloadRouteDefinition<any, any, any, any, any, any, any, any, any>>,
   // biome-ignore lint/suspicious/noExplicitAny: params type depends on overload
   params: any,
   // biome-ignore lint/suspicious/noExplicitAny: options type depends on overload

--- a/packages/app/frontend-http-client/src/api-contract/sendByApiContract.spec.ts
+++ b/packages/app/frontend-http-client/src/api-contract/sendByApiContract.spec.ts
@@ -284,6 +284,26 @@ describe('sendByApiContract', () => {
       expect(result.result?.headers['x-request-id']).toBe('abc-123')
       expect(result.result?.headers['content-type']).toBe('application/json')
     })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      // the shape of a contract compiled against pre-visibility api-contracts (<7.2)
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/products/1',
+        responsesByStatusCode: { 200: z.object({ id: z.number(), title: z.string() }) },
+      })
+
+      await mockServer.forGet('/products/1').thenJson(200, { id: 1, title: 'Backpack' })
+
+      const result = await sendByApiContract(buildClient(), legacyContract, {})
+
+      expectTypeOf(result.result).toMatchTypeOf<
+        { body: { id: number; title: string } } | undefined
+      >()
+      expect(result.result).toMatchObject({ body: { id: 1, title: 'Backpack' } })
+    })
   })
 
   describe('POST', () => {
@@ -324,6 +344,26 @@ describe('sendByApiContract', () => {
       })
 
       expect(result.result).toMatchObject({ body: { id: '1' } })
+    })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'post',
+        pathResolver: () => '/products',
+        requestBodySchema: z.object({ name: z.string() }),
+        responsesByStatusCode: { 201: z.object({ id: z.number() }) },
+      })
+
+      await mockServer.forPost('/products').thenJson(201, { id: 21 })
+
+      const result = await sendByApiContract(buildClient(), legacyContract, {
+        body: { name: 'test' },
+      })
+
+      expectTypeOf(result.result).toMatchTypeOf<{ body: { id: number } } | undefined>()
+      expect(result.result).toMatchObject({ body: { id: 21 } })
     })
   })
 
@@ -391,6 +431,25 @@ describe('sendByApiContract', () => {
       const result = await sendByApiContract(buildClient(), contract, { pathParams: { id: '1' } })
 
       expectTypeOf(result.result).toMatchTypeOf<{ body: null } | undefined>()
+      expect(result.result).toMatchObject({ statusCode: 204, body: null })
+    })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'delete',
+        requestPathParamsSchema: z.object({ id: z.string() }),
+        pathResolver: ({ id }) => `/products/${id}`,
+        responsesByStatusCode: { 204: noBodyResponse() },
+      })
+
+      await mockServer.forDelete('/products/1').thenReply(204)
+
+      const result = await sendByApiContract(buildClient(), legacyContract, {
+        pathParams: { id: '1' },
+      })
+
       expect(result.result).toMatchObject({ statusCode: 204, body: null })
     })
   })
@@ -569,6 +628,39 @@ describe('sendByApiContract', () => {
           // consume
         }
       }).rejects.toThrow()
+    })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const { visibility: _visibility, ...legacyContract } = defineApiContract({
+        visibility: 'public',
+        summary: 'Test contract',
+        method: 'get',
+        pathResolver: () => '/events',
+        responsesByStatusCode: {
+          200: {
+            content: { 'text/event-stream': sseBody({ update: z.object({ id: z.string() }) }) },
+          },
+        },
+      })
+
+      await mockServer
+        .forGet('/events')
+        .withHeaders({ accept: 'text/event-stream' })
+        .thenReply(200, 'event: update\ndata: {"id":"1"}\n\n', {
+          'content-type': 'text/event-stream',
+        })
+
+      const response = await sendByApiContract(buildClient(), legacyContract, {})
+
+      if (!response.result) throw new Error('Expected result')
+      const events: unknown[] = []
+      for await (const event of response.result.body) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([
+        { type: 'update', data: { id: '1' }, lastEventId: '', retry: undefined },
+      ])
     })
   })
 

--- a/packages/app/frontend-http-client/src/api-contract/sendByApiContract.ts
+++ b/packages/app/frontend-http-client/src/api-contract/sendByApiContract.ts
@@ -4,10 +4,13 @@ import {
   buildRequestPath,
   type ClientRequestParams,
   type DefaultStreaming,
+  type DeleteApiContract,
+  type GetApiContract,
   type HeadersParam,
   hasAnySuccessSseResponse,
   type InferNonSseClientResponse,
   type InferSseClientResponse,
+  type PayloadApiContract,
   type ResponseKind,
   resolveResponseEntry,
   type SseSchemaByEventName,
@@ -16,7 +19,11 @@ import {
 import { stringify } from 'fast-querystring'
 import { ServerSentEventTransformStream } from 'parse-sse'
 import type { ConfiguredMiddleware } from 'wretch'
-import type { WretchInstance } from '../types.ts'
+import type {
+  ClientCompatibleContract,
+  ServerOnlyContractFields,
+  WretchInstance,
+} from '../types.ts'
 import { UnexpectedResponseError } from './UnexpectedResponseError.ts'
 
 export type ContractRequestOptions<DoCaptureAsError extends boolean = boolean> = {
@@ -45,16 +52,33 @@ type Either<TError, TResult> =
   | { error: TError; result?: never }
   | { error?: never; result: TResult }
 
+// `ApiContract` accepted as client input: `ClientCompatibleContract` applied per union member
+// so the method/body discrimination is preserved (an `Omit` over the whole union would
+// collapse it to the common keys).
+type ApiContractInput =
+  | ClientCompatibleContract<GetApiContract>
+  | ClientCompatibleContract<DeleteApiContract>
+  | ClientCompatibleContract<PayloadApiContract>
+
+// Re-tightens a loosened contract type back to a full `ApiContract` by completing the
+// server-only fields, so it satisfies the `extends ApiContract` constraint of the
+// api-contracts infer helpers. The `infer C extends ApiContract` indirection defers the
+// check until instantiation, where the intersection always completes the missing fields.
+type CompleteApiContract<T extends ApiContractInput> = T &
+  ServerOnlyContractFields extends infer C extends ApiContract
+  ? C
+  : never
+
 type AllContractResponses<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
 > = TIsStreaming extends true
-  ? InferSseClientResponse<TApiContract>
-  : InferNonSseClientResponse<TApiContract>
+  ? InferSseClientResponse<CompleteApiContract<TApiContract>>
+  : InferNonSseClientResponse<CompleteApiContract<TApiContract>>
 
 // captureAsError: true → success codes only; captureAsError: false → all codes from contract
 type ContractResultType<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
   TDoCaptureAsError extends boolean,
 > = TDoCaptureAsError extends true
@@ -67,7 +91,7 @@ type ContractResultType<
 // captureAsError: true → UnexpectedResponseError | <error-status-code responses from contract>
 // captureAsError: false → only UnexpectedResponseError (all contract responses go to result)
 type ContractErrorType<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
   TDoCaptureAsError extends boolean,
 > = TDoCaptureAsError extends true
@@ -80,7 +104,7 @@ type ContractErrorType<
   : UnexpectedResponseError
 
 type ReturnTypeForContract<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean,
   TDoCaptureAsError extends boolean,
 > = Either<
@@ -190,15 +214,17 @@ async function parseBody(response: Response, resolvedEntry: ResponseKind) {
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: it is acceptable
 export async function sendByApiContract<
-  TApiContract extends ApiContract,
+  TApiContract extends ApiContractInput,
   TIsStreaming extends boolean = DefaultStreaming<TApiContract['responsesByStatusCode']>,
   TCaptureAsError extends boolean = true,
 >(
   wretch: WretchInstance,
   apiContract: TApiContract,
-  params: ClientRequestParams<TApiContract, TIsStreaming> & ContractRequestOptions<TCaptureAsError>,
+  params: ClientRequestParams<CompleteApiContract<TApiContract>, TIsStreaming> &
+    ContractRequestOptions<TCaptureAsError>,
 ): Promise<ReturnTypeForContract<TApiContract, TIsStreaming, TCaptureAsError>> {
-  const useStreaming: boolean = params.streaming ?? hasAnySuccessSseResponse(apiContract)
+  const useStreaming: boolean =
+    params.streaming ?? hasAnySuccessSseResponse(apiContract as ApiContract)
 
   const captureAsError = params.captureAsError ?? true
   const strictContentType = params.strictContentType ?? true

--- a/packages/app/frontend-http-client/src/client.spec.ts
+++ b/packages/app/frontend-http-client/src/client.spec.ts
@@ -609,6 +609,66 @@ describe('frontend-http-client', () => {
       expectTypeOf(responseBody).toEqualTypeOf<null>()
       expect(responseBody).toBeNull()
     })
+
+    it('accepts GET contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forGet('/users/1').thenJson(200, { data: { code: 99 } })
+
+      const { visibility: _visibility, ...legacyContract } = buildGetRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ data: z.object({ code: z.number() }) }),
+        requestPathParamsSchema: z.object({ userId: z.number() }),
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByGetRoute(client, legacyContract, {
+        pathParams: { userId: 1 },
+      })
+
+      expect(responseBody).toEqual({ data: { code: 99 } })
+    })
+
+    it('accepts POST contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forPost('/users/1').thenJson(200, { data: { code: 99 } })
+
+      const { visibility: _visibility, ...legacyContract } = buildPayloadRoute({
+        visibility: 'public',
+        method: 'post',
+        successResponseBodySchema: z.object({ data: z.object({ code: z.number() }) }),
+        requestPathParamsSchema: z.object({ userId: z.number() }),
+        requestBodySchema: z.object({ isActive: z.boolean() }),
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByPayloadRoute(client, legacyContract, {
+        pathParams: { userId: 1 },
+        body: { isActive: true },
+      })
+
+      expect(responseBody).toEqual({ data: { code: 99 } })
+    })
+
+    it('accepts DELETE contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forDelete('/users/1').thenJson(200, { data: { code: 99 } })
+
+      const { visibility: _visibility, ...legacyContract } = buildDeleteRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ data: z.object({ code: z.number() }) }),
+        requestPathParamsSchema: z.object({ userId: z.number() }),
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByDeleteRoute(client, legacyContract, {
+        pathParams: { userId: 1 },
+      })
+
+      expect(responseBody).toEqual({ data: { code: 99 } })
+    })
   })
 
   describe('sendPost', () => {
@@ -2484,6 +2544,25 @@ describe('frontend-http-client', () => {
 
       expectTypeOf(responseBody).toEqualTypeOf<null>()
       expect(responseBody).toBeNull()
+    })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      const client = wretch(mockServer.url)
+
+      await mockServer.forGet('/users/1').thenJson(200, { data: { code: 99 } })
+
+      const { visibility: _visibility, ...legacyContract } = buildGetRoute({
+        visibility: 'public',
+        successResponseBodySchema: z.object({ data: z.object({ code: z.number() }) }),
+        requestPathParamsSchema: z.object({ userId: z.number() }),
+        pathResolver: (pathParams) => `/users/${pathParams.userId}`,
+      })
+
+      const responseBody = await sendByContract(client, legacyContract, {
+        pathParams: { userId: 1 },
+      })
+
+      expect(responseBody).toEqual({ data: { code: 99 } })
     })
   })
 })

--- a/packages/app/frontend-http-client/src/client.ts
+++ b/packages/app/frontend-http-client/src/client.ts
@@ -10,6 +10,7 @@ import { buildRequestPath } from '@lokalise/api-contracts'
 import type { WretchResponse } from 'wretch'
 import { type ZodSchema, z } from 'zod/v4'
 import type {
+  ClientCompatibleContract,
   DeleteParams,
   FreeDeleteParams,
   FreeHeadersParams,
@@ -410,16 +411,18 @@ export function sendByPayloadRoute<
     | undefined = undefined,
 >(
   wretch: T,
-  routeDefinition: PayloadRouteDefinition<
-    RequestBodySchema,
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    PayloadRouteDefinition<
+      RequestBodySchema,
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -472,15 +475,17 @@ export function sendByGetRoute<
     | undefined = undefined,
 >(
   wretch: T,
-  routeDefinition: GetRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    GetRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -528,15 +533,17 @@ export function sendByDeleteRoute<
     | undefined = undefined,
 >(
   wretch: T,
-  routeDefinition: DeleteRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    DeleteRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -597,15 +604,17 @@ export function sendByContract<
     | undefined = undefined,
 >(
   wretch: T,
-  routeDefinition: GetRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    GetRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -636,16 +645,18 @@ export function sendByContract<
     | undefined = undefined,
 >(
   wretch: T,
-  routeDefinition: PayloadRouteDefinition<
-    RequestBodySchema,
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    PayloadRouteDefinition<
+      RequestBodySchema,
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: PayloadRouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -676,15 +687,17 @@ export function sendByContract<
     | undefined = undefined,
 >(
   wretch: T,
-  routeDefinition: DeleteRouteDefinition<
-    ResponseBodySchema,
-    PathParamsSchema,
-    RequestQuerySchema,
-    RequestHeaderSchema,
-    ResponseHeaderSchema,
-    IsNonJSONResponseExpected,
-    IsEmptyResponseExpected,
-    ResponseSchemasByStatusCode
+  routeDefinition: ClientCompatibleContract<
+    DeleteRouteDefinition<
+      ResponseBodySchema,
+      PathParamsSchema,
+      RequestQuerySchema,
+      RequestHeaderSchema,
+      ResponseHeaderSchema,
+      IsNonJSONResponseExpected,
+      IsEmptyResponseExpected,
+      ResponseSchemasByStatusCode
+    >
   >,
   params: RouteRequestParams<
     InferSchemaInput<PathParamsSchema>,
@@ -703,11 +716,11 @@ export function sendByContract<
 export function sendByContract(
   wretch: WretchInstance,
   routeDefinition: // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | GetRouteDefinition<any, any, any, any, any, any, any, any>
+    | ClientCompatibleContract<GetRouteDefinition<any, any, any, any, any, any, any, any>>
     // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | PayloadRouteDefinition<any, any, any, any, any, any, any, any, any>
+    | ClientCompatibleContract<PayloadRouteDefinition<any, any, any, any, any, any, any, any, any>>
     // biome-ignore lint/suspicious/noExplicitAny: union of all route definition types
-    | DeleteRouteDefinition<any, any, any, any, any, any, any, any>,
+    | ClientCompatibleContract<DeleteRouteDefinition<any, any, any, any, any, any, any, any>>,
   // biome-ignore lint/suspicious/noExplicitAny: params type depends on overload
   params: any,
   // biome-ignore lint/suspicious/noExplicitAny: return type depends on overload

--- a/packages/app/frontend-http-client/src/sse.spec.ts
+++ b/packages/app/frontend-http-client/src/sse.spec.ts
@@ -759,4 +759,34 @@ describe('connectSseByContract', () => {
     expect(onItemUpdated).toHaveBeenCalledWith({ items: [{ id: '1' }] })
     connection.close()
   })
+
+  it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+    const { visibility: _visibility, ...legacyContract } = buildSseContract({
+      visibility: 'public',
+      method: 'get',
+      pathResolver: () => '/events/stream',
+      serverSentEventSchemas: { done: doneSchema },
+    })
+
+    await mockServer.forGet('/events/stream').thenCallback(() => ({
+      statusCode: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+      body: sseResponse([{ event: 'done', data: JSON.stringify({ total: 1 }) }]),
+    }))
+
+    const onDone = vi.fn()
+    const client = wretch(mockServer.url)
+    const connection = connectSseByContract(
+      client,
+      legacyContract,
+      {},
+      {
+        onEvent: { done: onDone },
+      },
+    )
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalled())
+    expect(onDone).toHaveBeenCalledWith({ total: 1 })
+    connection.close()
+  })
 })

--- a/packages/app/frontend-http-client/src/sse.ts
+++ b/packages/app/frontend-http-client/src/sse.ts
@@ -5,7 +5,12 @@ import type {
 } from '@lokalise/api-contracts'
 import { buildRequestPath } from '@lokalise/api-contracts'
 import type { z } from 'zod/v4'
-import type { HeadersObject, HeadersSource, WretchInstance } from './types.ts'
+import type {
+  ClientCompatibleContract,
+  HeadersObject,
+  HeadersSource,
+  WretchInstance,
+} from './types.ts'
 import { parseRequestBody } from './utils/bodyUtils.ts'
 import { isFailure } from './utils/either.ts'
 import { isError } from './utils/errorUtils.ts'
@@ -31,7 +36,9 @@ export type SseCallbacks<Events extends SSEEventSchemas> = {
   onClose?: () => void
 }
 
-type AnyContract = AnyDualModeContractDefinition | AnySSEContractDefinition
+type AnyContract =
+  | ClientCompatibleContract<AnyDualModeContractDefinition>
+  | ClientCompatibleContract<AnySSEContractDefinition>
 
 // Resolves the input type for a schema field, handling optional properties (T | undefined)
 // and filtering out unspecified schemas that default to z.ZodTypeAny

--- a/packages/app/frontend-http-client/src/types.ts
+++ b/packages/app/frontend-http-client/src/types.ts
@@ -11,7 +11,10 @@ import type { ZodSchema, z } from 'zod/v4'
  * Contract fields that only the serving side acts upon; the HTTP client never reads them.
  * Add future mandatory server-side fields here.
  */
-export type ServerOnlyContractFields = Pick<ApiContract, 'visibility'>
+// The `Extract` keeps this resolvable against pre-visibility `@lokalise/api-contracts` peers
+// (<7.2), where `ApiContract` has no `visibility` key: the type degrades to `{}` there, so
+// `ClientCompatibleContract` becomes a no-op instead of a compile error.
+export type ServerOnlyContractFields = Pick<ApiContract, Extract<keyof ApiContract, 'visibility'>>
 
 /**
  * Loosens a route definition's server-only fields to optional, so contracts compiled against

--- a/packages/app/frontend-http-client/src/types.ts
+++ b/packages/app/frontend-http-client/src/types.ts
@@ -1,5 +1,31 @@
+import type {
+  AnyDualModeContractDefinition,
+  AnySSEContractDefinition,
+  ApiContract,
+  CommonRouteDefinition,
+} from '@lokalise/api-contracts'
 import type { Wretch, WretchResponse } from 'wretch'
 import type { ZodSchema, z } from 'zod/v4'
+
+/**
+ * Contract fields that only the serving side acts upon; the HTTP client never reads them.
+ * Add future mandatory server-side fields here.
+ */
+export type ServerOnlyContractFields = Pick<ApiContract, 'visibility'>
+
+/**
+ * Loosens a route definition's server-only fields to optional, so contracts compiled against
+ * older `@lokalise/api-contracts` — whose types lack them (e.g. `visibility` before 7.2) — are
+ * still accepted. The HTTP client never reads those fields; they only matter on server side.
+ */
+export type ClientCompatibleContract<
+  T extends
+    | ApiContract
+    | AnyDualModeContractDefinition
+    | AnySSEContractDefinition
+    // biome-ignore lint/suspicious/noExplicitAny: accepts any route definition shape
+    | CommonRouteDefinition<any, any, any, any, any, any, any, any>,
+> = Omit<T, keyof ServerOnlyContractFields> & Partial<ServerOnlyContractFields>
 
 export type HeadersObject = Record<string, string>
 export type HeadersSource = HeadersObject | (() => HeadersObject) | (() => Promise<HeadersObject>)

--- a/packages/app/universal-testing-utils/src/MockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/MockttpHelper.spec.ts
@@ -151,6 +151,21 @@ describe('MockttpHelper', () => {
         }
       `)
     })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      // the shape of a contract compiled against pre-visibility api-contracts (<7.2)
+      const { visibility: _visibility, ...legacyContract } = postContract
+
+      await mockttpHelper.mockValidResponse(legacyContract, {
+        responseBody: { id: '1' },
+      })
+
+      const response = await sendByContract(wretchClient, legacyContract, {
+        body: { name: 'frf' },
+      })
+
+      expect(response).toEqual({ id: '1' })
+    })
   })
 
   describe('mockAnyResponse', () => {

--- a/packages/app/universal-testing-utils/src/MockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/MockttpHelper.ts
@@ -4,12 +4,12 @@ import {
   type DualModeContractDefinition,
   type InferSchemaInput,
   mapRouteToPath,
-  type PayloadRouteDefinition,
   type SSEContractDefinition,
   type SSEEventSchemas,
 } from '@lokalise/api-contracts'
 import type { Mockttp, RequestRuleBuilder } from 'mockttp'
 import type { z } from 'zod/v4'
+import type { ClientCompatibleContract } from './apiContractTypes.ts'
 
 export type PayloadMockParams<PathParams, QueryParams, ResponseBody> = {
   pathParams: PathParams
@@ -93,16 +93,18 @@ export class MockttpHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      any,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        any,
+        Events,
+        any,
+        any
+      >
     >,
     params: PathParamsSchema extends z.Schema
       ? DualModeMockParams<
@@ -120,28 +122,18 @@ export class MockttpHelper {
     PathParamsSchema extends z.Schema | undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract:
-      | CommonRouteDefinition<
-          ResponseBodySchema,
-          PathParamsSchema,
-          RequestQuerySchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >
-      | PayloadRouteDefinition<
-          z.Schema | undefined,
-          ResponseBodySchema,
-          PathParamsSchema,
-          RequestQuerySchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<
+        ResponseBodySchema,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        boolean,
+        boolean,
+        any
+      >
+    >,
     params: PathParamsSchema extends undefined
       ? PayloadMockParamsNoPath<InferSchemaInput<RequestQuerySchema>, any>
       : PayloadMockParams<
@@ -196,7 +188,7 @@ export class MockttpHelper {
     const path =
       contract.requestPathParamsSchema && pathParams && contract.pathResolver
         ? contract.pathResolver(pathParams)
-        : mapRouteToPath(contract)
+        : mapRouteToPath(contract as CommonRouteDefinition<any, any, any, any, any, any, any, any>)
 
     const method = ('method' in contract ? contract.method : 'get') as HttpMethod
     let mockttp = this.resolveMethodBuilder(method, path)
@@ -216,16 +208,18 @@ export class MockttpHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      ResponseBodySchema,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        ResponseBodySchema,
+        Events,
+        any,
+        any
+      >
     >,
     params: PathParamsSchema extends z.Schema
       ? DualModeMockParams<
@@ -247,14 +241,8 @@ export class MockttpHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: SSEContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      Events,
-      any
+    contract: ClientCompatibleContract<
+      SSEContractDefinition<any, PathParamsSchema, RequestQuerySchema, any, any, Events, any>
     >,
     params: PathParamsSchema extends z.Schema
       ? SseMockParams<
@@ -271,28 +259,18 @@ export class MockttpHelper {
     PathParamsSchema extends z.Schema | undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract:
-      | CommonRouteDefinition<
-          ResponseBodySchema,
-          PathParamsSchema,
-          RequestQuerySchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >
-      | PayloadRouteDefinition<
-          z.Schema | undefined,
-          ResponseBodySchema,
-          PathParamsSchema,
-          RequestQuerySchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<
+        ResponseBodySchema,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        boolean,
+        boolean,
+        any
+      >
+    >,
     params: PathParamsSchema extends undefined
       ? PayloadMockParamsNoPath<
           InferSchemaInput<RequestQuerySchema>,

--- a/packages/app/universal-testing-utils/src/MswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.spec.ts
@@ -126,6 +126,21 @@ describe('MswHelper', () => {
               }
             `)
     })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      // the shape of a contract compiled against pre-visibility api-contracts (<7.2)
+      const { visibility: _visibility, ...legacyContract } = postContract
+
+      mswHelper.mockValidResponse(legacyContract, server, {
+        responseBody: { id: '1' },
+      })
+
+      const response = await sendByContract(wretchClient, legacyContract, {
+        body: { name: 'frf' },
+      })
+
+      expect(response).toEqual({ id: '1' })
+    })
   })
 
   describe('mockValidResponseWithAnyPath', () => {

--- a/packages/app/universal-testing-utils/src/MswHelper.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.ts
@@ -5,7 +5,6 @@ import {
   type InferSchemaInput,
   type InferSchemaOutput,
   mapRouteToPath,
-  type PayloadRouteDefinition,
   type SSEContractDefinition,
   type SSEEventSchemas,
 } from '@lokalise/api-contracts'
@@ -19,6 +18,7 @@ import {
 } from 'msw'
 import type { SetupServer } from 'msw/node'
 import type { ZodObject, z } from 'zod/v4'
+import type { ClientCompatibleContract } from './apiContractTypes.ts'
 import { formatSseResponse, type SseMockEvent } from './MockttpHelper.ts'
 
 export type CommonMockParams = {
@@ -97,9 +97,9 @@ function joinURL(base: string, path: string): string {
 
 export type MockEndpointParams<PathParamsSchema extends z.Schema | undefined> = {
   server: SetupServer
-  contract:
-    | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
-    | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any, any>
+  contract: ClientCompatibleContract<
+    CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
+  >
   pathParams: InferSchemaOutput<PathParamsSchema>
   responseBody: any
   responseCode: number
@@ -138,14 +138,14 @@ export class MswHelper {
   }
 
   private resolveParams<PathParamsSchema extends z.Schema | undefined>(
-    contract:
-      | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
-      | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any, any>,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
+    >,
     pathParams: InferSchemaOutput<PathParamsSchema>,
   ) {
     const path = contract.requestPathParamsSchema
       ? contract.pathResolver(pathParams)
-      : mapRouteToPath(contract)
+      : mapRouteToPath(contract as CommonRouteDefinition<any, any, any, any, any, any, any, any>)
 
     const resolvedPath = joinURL(this.baseUrl, path)
     const method = ('method' in contract ? contract.method : 'get') as HttpMethod
@@ -202,16 +202,18 @@ export class MswHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      ResponseBodySchema,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        ResponseBodySchema,
+        Events,
+        any,
+        any
+      >
     >,
     server: SetupServer,
     params: PathParamsSchema extends z.Schema
@@ -234,14 +236,8 @@ export class MswHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: SSEContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      Events,
-      any
+    contract: ClientCompatibleContract<
+      SSEContractDefinition<any, PathParamsSchema, RequestQuerySchema, any, any, Events, any>
     >,
     server: SetupServer,
     params: PathParamsSchema extends z.Schema
@@ -258,28 +254,18 @@ export class MswHelper {
     ResponseBodySchema extends z.Schema<JsonBodyType>,
     PathParamsSchema extends z.Schema | undefined,
   >(
-    contract:
-      | CommonRouteDefinition<
-          ResponseBodySchema,
-          PathParamsSchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >
-      | PayloadRouteDefinition<
-          z.Schema | undefined,
-          ResponseBodySchema,
-          PathParamsSchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<
+        ResponseBodySchema,
+        PathParamsSchema,
+        any,
+        any,
+        any,
+        boolean,
+        boolean,
+        any
+      >
+    >,
     server: SetupServer,
     params: PathParamsSchema extends undefined
       ? MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>
@@ -340,16 +326,18 @@ export class MswHelper {
     Events extends SSEEventSchemas,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      z.Schema | undefined,
-      RequestQuerySchema,
-      any,
-      any,
-      ResponseBodySchema,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        any,
+        RequestQuerySchema,
+        any,
+        any,
+        ResponseBodySchema,
+        Events,
+        any,
+        any
+      >
     >,
     server: SetupServer,
     params: MswDualModeMockParamsNoPath<
@@ -364,14 +352,8 @@ export class MswHelper {
     Events extends SSEEventSchemas,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: SSEContractDefinition<
-      any,
-      z.Schema | undefined,
-      RequestQuerySchema,
-      any,
-      any,
-      Events,
-      any
+    contract: ClientCompatibleContract<
+      SSEContractDefinition<any, any, RequestQuerySchema, any, any, Events, any>
     >,
     server: SetupServer,
     params: MswSseMockParamsNoPath<InferSchemaInput<RequestQuerySchema>, Events>,
@@ -379,28 +361,9 @@ export class MswHelper {
 
   // Overload: REST contract
   mockValidResponseWithAnyPath<ResponseBodySchema extends z.Schema<JsonBodyType>>(
-    contract:
-      | CommonRouteDefinition<
-          ResponseBodySchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >
-      | PayloadRouteDefinition<
-          z.Schema | undefined,
-          ResponseBodySchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<ResponseBodySchema, any, any, any, any, boolean, boolean, any>
+    >,
     server: SetupServer,
     params: MockParamsNoPath<InferSchemaInput<ResponseBodySchema>>,
   ): void
@@ -427,16 +390,18 @@ export class MswHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      ResponseBodySchema,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        ResponseBodySchema,
+        Events,
+        any,
+        any
+      >
     >,
     server: SetupServer,
     params: (PathParamsSchema extends z.Schema
@@ -452,30 +417,19 @@ export class MswHelper {
   mockValidResponseWithImplementation<
     ResponseBodySchema extends z.Schema,
     PathParamsSchema extends z.Schema | undefined,
-    RequestBodySchema extends z.Schema | undefined = undefined,
   >(
-    contract:
-      | CommonRouteDefinition<
-          ResponseBodySchema,
-          PathParamsSchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >
-      | PayloadRouteDefinition<
-          RequestBodySchema,
-          ResponseBodySchema,
-          PathParamsSchema,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          z.Schema | undefined,
-          boolean,
-          boolean,
-          any
-        >,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<
+        ResponseBodySchema,
+        PathParamsSchema,
+        any,
+        any,
+        any,
+        boolean,
+        boolean,
+        any
+      >
+    >,
     server: SetupServer,
     params: PathParamsSchema extends undefined
       ? MockWithImplementationParamsNoPath<any, any, any>
@@ -528,16 +482,18 @@ export class MswHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      any,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        any,
+        Events,
+        any,
+        any
+      >
     >,
     server: SetupServer,
     params: PathParamsSchema extends z.Schema
@@ -552,9 +508,9 @@ export class MswHelper {
 
   // Overload: REST contract — requires responseBody, no validation
   mockAnyResponse<PathParamsSchema extends z.Schema | undefined>(
-    contract:
-      | CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
-      | PayloadRouteDefinition<any, any, PathParamsSchema, any, any, any, any, any, any>,
+    contract: ClientCompatibleContract<
+      CommonRouteDefinition<any, PathParamsSchema, any, any, any, any, any, any>
+    >,
     server: SetupServer,
     params: PathParamsSchema extends undefined
       ? MockParamsNoPath<InferSchemaInput<any>>
@@ -601,16 +557,18 @@ export class MswHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: DualModeContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      ResponseBodySchema,
-      Events,
-      any,
-      any
+    contract: ClientCompatibleContract<
+      DualModeContractDefinition<
+        any,
+        PathParamsSchema,
+        RequestQuerySchema,
+        any,
+        any,
+        ResponseBodySchema,
+        Events,
+        any,
+        any
+      >
     >,
     server: SetupServer,
     params: (PathParamsSchema extends z.Schema
@@ -629,14 +587,8 @@ export class MswHelper {
     PathParamsSchema extends z.Schema | undefined = undefined,
     RequestQuerySchema extends z.Schema | undefined = undefined,
   >(
-    contract: SSEContractDefinition<
-      any,
-      PathParamsSchema,
-      RequestQuerySchema,
-      any,
-      any,
-      Events,
-      any
+    contract: ClientCompatibleContract<
+      SSEContractDefinition<any, PathParamsSchema, RequestQuerySchema, any, any, Events, any>
     >,
     server: SetupServer,
     params?: (PathParamsSchema extends z.Schema

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
@@ -129,6 +129,19 @@ describe('ApiContractMockttpHelper', () => {
       })
       expect(result.result?.body).toBeNull()
     })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      // the shape of a contract compiled against pre-visibility api-contracts (<7.2)
+      const { visibility: _visibility, ...legacyContract } = getApiContract
+
+      await helper.mockResponse(legacyContract, {
+        responseStatus: 200,
+        responseJson: { id: '1' },
+      })
+
+      const result = await sendByApiContract(client(), legacyContract, {})
+      expect(result.result?.body).toEqual({ id: '1' })
+    })
   })
 
   describe('mockResponse — SSE contracts', () => {

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -9,6 +9,7 @@ import {
 import type { Mockttp, RequestRuleBuilder } from 'mockttp'
 import type { z } from 'zod/v4'
 import {
+  type ApiContractInput,
   formatSseResponse,
   type MockResponseParams,
   resolveContractEntry,
@@ -41,13 +42,13 @@ export class ApiContractMockttpHelper {
     }
   }
 
-  private resolvePath(contract: ApiContract, pathParams: unknown): string {
+  private resolvePath(contract: ApiContractInput, pathParams: unknown): string {
     return contract.requestPathParamsSchema && pathParams
       ? contract.pathResolver(pathParams)
-      : mapApiContractToPath(contract)
+      : mapApiContractToPath(contract as ApiContract)
   }
 
-  async mockResponse<TContract extends ApiContract>(
+  async mockResponse<TContract extends ApiContractInput>(
     contract: TContract,
     params: MockResponseParams<TContract>,
   ): Promise<void> {

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
@@ -136,6 +136,16 @@ describe('ApiContractMswHelper', () => {
       })
       expect(result.result?.body).toBeNull()
     })
+
+    it('accepts contracts typed without visibility (pre-visibility api-contracts)', async () => {
+      // the shape of a contract compiled against pre-visibility api-contracts (<7.2)
+      const { visibility: _visibility, ...legacyContract } = getApiContract
+
+      helper.mockResponse(legacyContract, { responseStatus: 200, responseJson: { id: '1' } })
+
+      const result = await sendByApiContract(client(), legacyContract, {})
+      expect(result.result?.body).toEqual({ id: '1' })
+    })
   })
 
   describe('mockResponse — SSE contracts', () => {

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
@@ -10,6 +10,7 @@ import { HttpResponse, http, type JsonBodyType } from 'msw'
 import type { SetupServer } from 'msw/node'
 import type { z } from 'zod/v4'
 import {
+  type ApiContractInput,
   formatSseResponse,
   type MockResponseParams,
   resolveContractEntry,
@@ -31,16 +32,16 @@ export class ApiContractMswHelper {
     this.baseUrl = baseUrl
   }
 
-  private resolvePath(contract: ApiContract, pathParams: unknown): string {
+  private resolvePath(contract: ApiContractInput, pathParams: unknown): string {
     const path =
       contract.requestPathParamsSchema && pathParams
         ? contract.pathResolver(pathParams)
-        : mapApiContractToPath(contract)
+        : mapApiContractToPath(contract as ApiContract)
 
     return joinURL(this.baseUrl, path)
   }
 
-  mockResponse<TContract extends ApiContract>(
+  mockResponse<TContract extends ApiContractInput>(
     contract: TContract,
     params: MockResponseParams<TContract>,
   ): void {

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -1,12 +1,14 @@
 import {
-  type ApiContract,
   type ApiContractResponse,
   type BodyDescriptor,
+  type DeleteApiContract,
   type ExpandStatusRangeKey,
+  type GetApiContract,
   type HttpStatusCode,
   type InferSchemaInput,
   isBlobBody,
   isSseBody,
+  type PayloadApiContract,
   type RequestPathParamsSchema,
   type ResponseEntry,
   type ResponsesByStatusCode,
@@ -14,6 +16,7 @@ import {
   type WildcardStatusCodeKey,
 } from '@lokalise/api-contracts'
 import type { z } from 'zod/v4'
+import type { ClientCompatibleContract } from '../apiContractTypes.ts'
 
 export type SseMockEventInput<S extends SseSchemaByEventName> = {
   [K in keyof S & string]: { event: K; data: z.input<NonNullable<S[K]>> }
@@ -107,13 +110,21 @@ type InferBodyParam<T> = T extends z.ZodType
     ? ({ contentType?: never } & InferContentBodyParam<C>) | PerContentTypeBodyParam<C>
     : object
 
-type ExactStatusCodePairs<TContract extends ApiContract> = {
+// `ApiContract` accepted as mock-helper input: `ClientCompatibleContract` applied per union
+// member so the method/body discrimination is preserved (an `Omit` over the whole union would
+// collapse it to the common keys).
+export type ApiContractInput =
+  | ClientCompatibleContract<GetApiContract>
+  | ClientCompatibleContract<DeleteApiContract>
+  | ClientCompatibleContract<PayloadApiContract>
+
+type ExactStatusCodePairs<TContract extends ApiContractInput> = {
   [K in keyof TContract['responsesByStatusCode'] & HttpStatusCode]: {
     responseStatus: K
   } & InferBodyParam<NonNullable<TContract['responsesByStatusCode'][K]>>
 }[keyof TContract['responsesByStatusCode'] & HttpStatusCode]
 
-type RangeStatusCodePairs<TContract extends ApiContract> = {
+type RangeStatusCodePairs<TContract extends ApiContractInput> = {
   [K in keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]: {
     responseStatus: Exclude<
       ExpandStatusRangeKey<K>,
@@ -122,14 +133,14 @@ type RangeStatusCodePairs<TContract extends ApiContract> = {
   } & InferBodyParam<NonNullable<TContract['responsesByStatusCode'][K]>>
 }[keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]
 
-type StatusCodeBodyPair<TContract extends ApiContract> =
+type StatusCodeBodyPair<TContract extends ApiContractInput> =
   | ExactStatusCodePairs<TContract>
   | RangeStatusCodePairs<TContract>
 
-type PathParamsField<TContract extends ApiContract> =
+type PathParamsField<TContract extends ApiContractInput> =
   TContract['requestPathParamsSchema'] extends RequestPathParamsSchema
     ? { pathParams: InferSchemaInput<TContract['requestPathParamsSchema']> }
     : { pathParams?: never }
 
-export type MockResponseParams<TContract extends ApiContract> = PathParamsField<TContract> &
+export type MockResponseParams<TContract extends ApiContractInput> = PathParamsField<TContract> &
   StatusCodeBodyPair<TContract>

--- a/packages/app/universal-testing-utils/src/apiContractTypes.ts
+++ b/packages/app/universal-testing-utils/src/apiContractTypes.ts
@@ -9,7 +9,10 @@ import type {
  * Contract fields that only the serving side acts upon; the testing helpers never read them.
  * Add future mandatory server-side fields here.
  */
-export type ServerOnlyContractFields = Pick<ApiContract, 'visibility'>
+// The `Extract` keeps this resolvable against pre-visibility `@lokalise/api-contracts` peers
+// (<7.2), where `ApiContract` has no `visibility` key: the type degrades to `{}` there, so
+// `ClientCompatibleContract` becomes a no-op instead of a compile error.
+export type ServerOnlyContractFields = Pick<ApiContract, Extract<keyof ApiContract, 'visibility'>>
 
 /**
  * Loosens a route definition's server-only fields to optional, so contracts compiled against

--- a/packages/app/universal-testing-utils/src/apiContractTypes.ts
+++ b/packages/app/universal-testing-utils/src/apiContractTypes.ts
@@ -1,0 +1,26 @@
+import type {
+  AnyDualModeContractDefinition,
+  AnySSEContractDefinition,
+  ApiContract,
+  CommonRouteDefinition,
+} from '@lokalise/api-contracts'
+
+/**
+ * Contract fields that only the serving side acts upon; the testing helpers never read them.
+ * Add future mandatory server-side fields here.
+ */
+export type ServerOnlyContractFields = Pick<ApiContract, 'visibility'>
+
+/**
+ * Loosens a route definition's server-only fields to optional, so contracts compiled against
+ * older `@lokalise/api-contracts` — whose types lack them (e.g. `visibility` before 7.2) — are
+ * still accepted. The testing helpers never read those fields; they only matter on server side.
+ */
+export type ClientCompatibleContract<
+  T extends
+    | ApiContract
+    | AnyDualModeContractDefinition
+    | AnySSEContractDefinition
+    // biome-ignore lint/suspicious/noExplicitAny: accepts any route definition shape
+    | CommonRouteDefinition<any, any, any, any, any, any, any, any>,
+> = Omit<T, keyof ServerOnlyContractFields> & Partial<ServerOnlyContractFields>


### PR DESCRIPTION
## Changes

Follow-up to #1202. Makes `backend-http-client`, `frontend-http-client` and
`universal-testing-utils` accept contracts from both api-contracts generations, so services can
upgrade without waiting for every upstream contract package to migrate to v8.

Every contract input now goes through `ClientCompatibleContract`, which loosens the server-only
`visibility` field to optional (clients and testing helpers never read it). The set of
server-only fields lives in one place (`ServerOnlyContractFields`), so future mandatory
server-side fields are a one-line extension. Pinned with one legacy-contract test per entry point.

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
