### PR TITLE
feat: support bullmq 6 and ioredis 6

### DIFF
--- a/.changeset/bull-board-9.md
+++ b/.changeset/bull-board-9.md
@@ -1,0 +1,10 @@
+---
+"@lokalise/fastify-bullboard-plugin": major
+---
+
+Upgrade `@bull-board/api` and `@bull-board/fastify` to 9, which adds BullMQ 6 support and ships a redesigned
+dashboard UI.
+
+`QueueConstructor` no longer declares the third constructor parameter. BullMQ 6 replaced it (`Connection`) with
+a `BackendFactory`, and the plugin never passed it, so the type now matches `QueueProConstructor` and accepts
+BullMQ's `Queue` on both majors.

--- a/.changeset/bullmq-6-support.md
+++ b/.changeset/bullmq-6-support.md
@@ -1,8 +1,11 @@
 ---
 "@lokalise/background-jobs-common": minor
+"@lokalise/healthcheck-utils": minor
 ---
 
-Support BullMQ 6 and ioredis 6 alongside 5: peer ranges widen to `^5.28.2 || ^6.0.0` and `^5.4.1 || ^6.0.0`.
+Support BullMQ 6 and ioredis 6 alongside 5. `background-jobs-common` widens its peer ranges to
+`^5.28.2 || ^6.0.0` (bullmq) and `^5.4.1 || ^6.0.0` (ioredis); `healthcheck-utils` widens its ioredis peer
+to `^5.4.1 || ^6.0.0`.
 
 BullMQ 6 removes `paused` from `JobType`, drops `debounce` and `repeat` from `JobsOptions`, and renames the
 `FlowChildJob` type to `FlowJobNode`. The library now derives the flow child type from `FlowJob` and deletes the

--- a/.changeset/bullmq-6-support.md
+++ b/.changeset/bullmq-6-support.md
@@ -1,0 +1,10 @@
+---
+"@lokalise/background-jobs-common": minor
+---
+
+Support BullMQ 6 and ioredis 6 alongside 5: peer ranges widen to `^5.28.2 || ^6.0.0` and `^5.4.1 || ^6.0.0`.
+
+BullMQ 6 removes `paused` from `JobType`, drops `debounce` and `repeat` from `JobsOptions`, and renames the
+`FlowChildJob` type to `FlowJobNode`. The library now derives the flow child type from `FlowJob` and deletes the
+removed job options through a record, so one source tree compiles against both majors. `getJobCount` still counts
+the `paused` state; on BullMQ 6 that key is never written and contributes 0.

--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -44,8 +44,8 @@
         "ts-deepmerge": "^8.0.0"
     },
     "peerDependencies": {
-        "bullmq": "^5.28.2",
-        "ioredis": "^5.4.1",
+        "bullmq": "^5.28.2 || ^6.0.0",
+        "ioredis": "^5.4.1 || ^6.0.0",
         "pino": ">=9.7.0",
         "toad-scheduler": "^4.0.1",
         "zod": ">=3.25.67"
@@ -56,8 +56,8 @@
         "@lokalise/tsconfig": "workspace:^",
         "@types/node": "^26.1.1",
         "@vitest/coverage-v8": "^4.1.10",
-        "bullmq": "^5.81.2",
-        "ioredis": "^5.11.1",
+        "bullmq": "^6.2.0",
+        "ioredis": "^6.0.0",
         "pino": "^10.3.1",
         "rimraf": "^6.1.3",
         "toad-scheduler": "^4.0.1",

--- a/packages/app/background-jobs-common/src/background-job-processor/constants.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/constants.ts
@@ -1,4 +1,4 @@
-import type { QueueOptions, WorkerOptions } from 'bullmq'
+import type { JobType, QueueOptions, WorkerOptions } from 'bullmq'
 
 /**
  * How many days we retain completed jobs
@@ -33,3 +33,20 @@ export const DEFAULT_WORKER_OPTIONS = {
 } as const satisfies Omit<WorkerOptions, 'connection' | 'prefix' | 'autorun'> & {
   ttl: number
 }
+
+/**
+ * Job types counted as "pending" work in a queue.
+ *
+ * BullMQ v5 parks jobs of a paused queue in a separate `paused` list, while v6
+ * pauses through queue metadata and leaves them in `waiting` (and dropped
+ * `paused` from `JobType`). Asking v6 for the `paused` count reads a key that is
+ * never written and returns 0, so the same list is correct on both majors.
+ */
+export const PENDING_JOB_TYPES = [
+  'active',
+  'waiting',
+  'paused',
+  'delayed',
+  'prioritized',
+  'waiting-children',
+] as JobType[]

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/FlowManager.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/FlowManager.spec.ts
@@ -243,6 +243,24 @@ describe('FlowManager', () => {
 
       expect(node.job.opts.deduplication?.id).toBe('42:x')
     })
+
+    it('strips queue-level child-only defaults from children', async () => {
+      // `dedup_queue` carries a queue-level `deduplication` default for
+      // `QueueManager.schedule`. BullMQ rejects it on a flow child, so the same
+      // config must reach a child without it.
+      const node = await flowManager.addFlow({
+        queueId: 'parent_queue',
+        data: { id: 'p', value: 'vp', metadata: { correlationId: 'c' } },
+        children: [
+          {
+            queueId: 'dedup_queue',
+            data: { id: '42', value: 'x', metadata: { correlationId: 'c' } },
+          },
+        ],
+      })
+
+      expect(node.children?.[0]?.job.opts.deduplication).toBeUndefined()
+    })
   })
 
   describe('addFlowBulk', () => {

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/FlowManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/FlowManager.ts
@@ -1,5 +1,4 @@
 import type {
-  FlowChildJob,
   FlowJob,
   FlowOpts,
   FlowProducer,
@@ -29,13 +28,22 @@ import type {
   SupportedQueueIds,
 } from './types.ts'
 
+/**
+ * A node below the flow root. BullMQ v5 exports this as `FlowChildJob`, v6 as
+ * `FlowJobNode`; reading it off `FlowJob` gives the same shape on both majors.
+ */
+type BullmqFlowChildJob = NonNullable<FlowJob['children']>[number]
+
 const stripChildOnlyFields = (opts: JobsOptions): JobsOptions => {
-  const next: JobsOptions = { ...opts }
+  // `debounce` and `repeat` were dropped from JobsOptions in BullMQ v6, so
+  // delete through a record: TypeScript no longer knows those keys, but a JS
+  // caller can still pass them in.
+  const next = { ...opts } as Record<string, unknown>
   delete next.deduplication
   delete next.debounce
   delete next.parent
   delete next.repeat
-  return next
+  return next as JobsOptions
 }
 
 /**
@@ -236,7 +244,7 @@ export class FlowManager<
 
   private buildChildFlowJob<QueueId extends SupportedQueueIds<Queues>>(
     flow: FlowChildJobInput<Queues, QueueId>,
-  ): FlowChildJob {
+  ): BullmqFlowChildJob {
     const { queueId, name, data, opts, children } = flow
     const queueConfig = this.queueManager.queueRegistry.getQueueConfig(queueId)
     const parsedData = queueConfig.jobPayloadSchema.parse(data) as SupportedJobPayloads<Queues>

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/FlowManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/FlowManager.ts
@@ -34,16 +34,20 @@ import type {
  */
 type BullmqFlowChildJob = NonNullable<FlowJob['children']>[number]
 
+/**
+ * Job options that BullMQ v5 has on `JobsOptions` but v6 removed. Widening the
+ * local by these keys lets one `delete` list serve both majors: on v5 it hits
+ * the real properties, on v6 the keys are absent and the delete is a no-op.
+ */
+type RemovedInBullmq6JobOptions = { debounce?: unknown; repeat?: unknown }
+
 const stripChildOnlyFields = (opts: JobsOptions): JobsOptions => {
-  // `debounce` and `repeat` were dropped from JobsOptions in BullMQ v6, so
-  // delete through a record: TypeScript no longer knows those keys, but a JS
-  // caller can still pass them in.
-  const next = { ...opts } as Record<string, unknown>
+  const next: JobsOptions & RemovedInBullmq6JobOptions = { ...opts }
   delete next.deduplication
   delete next.debounce
   delete next.parent
   delete next.repeat
-  return next as JobsOptions
+  return next
 }
 
 /**

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueManager.ts
@@ -1,5 +1,6 @@
 import type { JobState, JobsOptions, Queue, QueueOptions } from 'bullmq'
 import { merge } from 'ts-deepmerge'
+import { PENDING_JOB_TYPES } from '../constants.ts'
 import type { BullmqQueueFactory } from '../factories/BullmqQueueFactory.ts'
 import { BackgroundJobProcessorSpy } from '../spy/BackgroundJobProcessorSpy.ts'
 import type { BackgroundJobProcessorSpyInterface } from '../spy/types.ts'
@@ -119,14 +120,7 @@ export class QueueManager<
 
   public async getJobCount(queueId: SupportedQueueIds<Queues>): Promise<number> {
     await this.startIfNotStarted(queueId)
-    return this.getQueue(queueId)?.getJobCountByTypes(
-      'active',
-      'waiting',
-      'paused',
-      'delayed',
-      'prioritized',
-      'waiting-children',
-    )
+    return this.getQueue(queueId)?.getJobCountByTypes(...PENDING_JOB_TYPES)
   }
 
   /**

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/backgroundJobProcessorGetActiveQueueIds.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/backgroundJobProcessorGetActiveQueueIds.ts
@@ -10,7 +10,7 @@ export const backgroundJobProcessorGetActiveQueueIds = async (
 
   await cleanOldQueueIds(redisClient)
 
-  const queueIds = await redisClient.zrange(QUEUE_IDS_KEY, 0, -1)
+  const queueIds = await redisClient.zrange(QUEUE_IDS_KEY, 0, '-1')
   if (!isRedisClient(redis)) redisClient.disconnect()
 
   return queueIds.sort()

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/registerActiveQueueIds.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/registerActiveQueueIds.spec.ts
@@ -25,7 +25,7 @@ describe('registerActiveQueueIds', () => {
   it('should not fail if queues array is empty', async () => {
     await registerActiveQueueIds(factory.getRedisConfig(), [])
 
-    const result = await redis.zrange('queueIds', 0, -1)
+    const result = await redis.zrange('queueIds', 0, '-1')
     expect(result).toEqual([])
   })
 
@@ -33,7 +33,7 @@ describe('registerActiveQueueIds', () => {
     await registerActiveQueueIds(factory.getRedisConfig(), [{ queueId: 'queue1' }])
 
     const today = new Date()
-    const [queueId, score] = await redis.zrange(QUEUE_IDS_KEY, 0, -1, 'WITHSCORES')
+    const [queueId, score] = await redis.zrange(QUEUE_IDS_KEY, 0, '-1', 'WITHSCORES')
     expect(queueId).toStrictEqual('queue1')
 
     // Comparing timestamps in seconds
@@ -47,13 +47,13 @@ describe('registerActiveQueueIds', () => {
     const queues = [{ queueId: 'queue1' }]
 
     await registerActiveQueueIds(factory.getRedisConfig(), queues)
-    const [queueId, score] = await redis.zrange(QUEUE_IDS_KEY, 0, -1, 'WITHSCORES')
+    const [queueId, score] = await redis.zrange(QUEUE_IDS_KEY, 0, '-1', 'WITHSCORES')
     expect(queueId).toStrictEqual('queue1')
 
     await setTimeout(10)
 
     await registerActiveQueueIds(factory.getRedisConfig(), queues)
-    const [_, scoreUpdated] = await redis.zrange(QUEUE_IDS_KEY, 0, -1, 'WITHSCORES')
+    const [_, scoreUpdated] = await redis.zrange(QUEUE_IDS_KEY, 0, '-1', 'WITHSCORES')
     expect(queueId).toStrictEqual('queue1')
 
     const initialScoreDate = new Date(Number.parseInt(score!, 10))
@@ -68,7 +68,7 @@ describe('registerActiveQueueIds', () => {
       { queueId: 'queue1', bullDashboardGrouping: ['group'] },
     ])
 
-    const result = await redis.zrange(QUEUE_IDS_KEY, 0, -1)
+    const result = await redis.zrange(QUEUE_IDS_KEY, 0, '-1')
     expect(result).toEqual(['group.queue1'])
   })
 
@@ -78,7 +78,7 @@ describe('registerActiveQueueIds', () => {
       { queueId: 'queue2' },
     ])
 
-    const result = await redis.zrange(QUEUE_IDS_KEY, 0, -1)
+    const result = await redis.zrange(QUEUE_IDS_KEY, 0, '-1')
     expect(result).toEqual(['group.queue1', 'queue2'])
   })
 })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -843,27 +843,25 @@ describe('AbstractBackgroundJobProcessor', () => {
       await processor.start()
 
       // When
-      const scheduledJobId = await processor.schedule(
+      // @ts-expect-error accessing protected member for testing
+      const queue = processor.queue
+      const scheduledJob = await queue.upsertJobScheduler(
+        'test_scheduler',
+        { every: 10, immediately: true, limit: 5 },
         {
-          id: 'test_id',
-          value: 'test',
-          metadata: { correlationId: 'correlation_id' },
-        },
-        {
-          repeat: {
-            every: 10,
-            immediately: true,
-            limit: 5,
+          data: {
+            id: 'test_id',
+            value: 'test',
+            metadata: { correlationId: 'correlation_id' },
           },
         },
       )
 
       // Then
-      await processor.spy.waitForJobWithId(scheduledJobId, 'completed')
-      // @ts-expect-error executing protected method for testing
-      const repeatableJobs = await processor.queue.getRepeatableJobs()
-      expect(repeatableJobs).toHaveLength(1)
-      expect(repeatableJobs[0]!.every).toBe('10')
+      await processor.spy.waitForJobWithId(scheduledJob.id, 'completed')
+      const schedulers = await queue.getJobSchedulers()
+      expect(schedulers).toHaveLength(1)
+      expect(schedulers[0]!.every).toBe(10)
 
       await processor.dispose()
     })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -12,7 +12,7 @@ import {
 } from 'bullmq'
 import pino, { stdSerializers } from 'pino'
 import { merge } from 'ts-deepmerge'
-import { DEFAULT_QUEUE_OPTIONS, DEFAULT_WORKER_OPTIONS } from '../constants.ts'
+import { DEFAULT_QUEUE_OPTIONS, DEFAULT_WORKER_OPTIONS, PENDING_JOB_TYPES } from '../constants.ts'
 import {
   isJobMissingError,
   isMutedUnrecoverableJobError,
@@ -131,14 +131,7 @@ export abstract class AbstractBackgroundJobProcessor<
 
   public async getJobCount(): Promise<number> {
     await this.startIfNotStarted()
-    return this.queue.getJobCountByTypes(
-      'active',
-      'waiting',
-      'paused',
-      'delayed',
-      'prioritized',
-      'waiting-children',
-    )
+    return this.queue.getJobCountByTypes(...PENDING_JOB_TYPES)
   }
 
   protected get queue(): ProtectedQueue<JobPayload, JobReturn, QueueType> {

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.repeatable.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.repeatable.spec.ts
@@ -44,26 +44,24 @@ describe('AbstractBackgroundJobProcessorNew - repeatable', () => {
 
   it('schedules repeatable job', async () => {
     // When
-    const scheduledJobId = await queueManager.schedule(
-      'queue',
+    await queueManager.start()
+    const queue = queueManager.getQueue('queue')
+    const scheduledJob = await queue.upsertJobScheduler(
+      'test_scheduler',
+      { every: 10, immediately: true, limit: 5 },
       {
-        id: 'test_id',
-        value: 'test',
-        metadata: { correlationId: 'correlation_id' },
-      },
-      {
-        repeat: {
-          every: 10,
-          immediately: true,
-          limit: 5,
+        data: {
+          id: 'test_id',
+          value: 'test',
+          metadata: { correlationId: 'correlation_id' },
         },
       },
     )
 
     // Then
-    await processor.spy.waitForJobWithId(scheduledJobId, 'completed')
+    await processor.spy.waitForJobWithId(scheduledJob.id, 'completed')
 
-    const schedulers = await queueManager.getQueue('queue').getJobSchedulers()
+    const schedulers = await queue.getJobSchedulers()
     expect(schedulers).toHaveLength(1)
     expect(schedulers[0]!.every).toBe(10)
 

--- a/packages/app/fastify-bullboard-plugin/package.json
+++ b/packages/app/fastify-bullboard-plugin/package.json
@@ -29,8 +29,8 @@
         "postversion": "biome check --write package.json"
     },
     "dependencies": {
-        "@bull-board/api": "^8.1.0",
-        "@bull-board/fastify": "^8.1.0",
+        "@bull-board/api": "^9.4.0",
+        "@bull-board/fastify": "^9.4.0",
         "@fastify/auth": "^5.1.0",
         "@fastify/basic-auth": "^6.3.0",
         "@lokalise/tsconfig": "workspace:^"
@@ -50,7 +50,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "awilix": "^13.0.5",
         "awilix-manager": "^7.0.0",
-        "bullmq": "5.81.2",
+        "bullmq": "6.2.0",
         "cross-env": "^10.0.0",
         "fastify": "^5.11.3",
         "fastify-graceful-shutdown": "^5.0.0",

--- a/packages/app/fastify-bullboard-plugin/package.json
+++ b/packages/app/fastify-bullboard-plugin/package.json
@@ -56,7 +56,7 @@
         "fastify-graceful-shutdown": "^5.0.0",
         "fastify-metrics": "^13.2.1",
         "fastify-plugin": "^6.0.0",
-        "ioredis": "^5.11.1",
+        "ioredis": "^6.0.0",
         "pino": "^10.1.0",
         "pino-pretty": "^13.0.0",
         "rimraf": "^6.1.3",

--- a/packages/app/fastify-bullboard-plugin/src/bullBoard.ts
+++ b/packages/app/fastify-bullboard-plugin/src/bullBoard.ts
@@ -11,7 +11,7 @@ import {
   sanitizeRedisConfig,
 } from '@lokalise/background-jobs-common'
 import { type RedisConfig, resolveGlobalErrorLogObject } from '@lokalise/node-core'
-import type { Queue, QueueOptions, RedisConnection } from 'bullmq'
+import type { Queue, QueueOptions } from 'bullmq'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 import { Redis } from 'ioredis'
@@ -45,7 +45,7 @@ export interface QueueProConstructor {
 }
 
 export interface QueueConstructor {
-  new (name: string, opts?: QueueOptions, Connection?: typeof RedisConnection): Queue
+  new (name: string, opts?: QueueOptions): Queue
 }
 
 type ResolvedRedis = {

--- a/packages/app/healthcheck-utils/package.json
+++ b/packages/app/healthcheck-utils/package.json
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "@lokalise/background-jobs-common": ">=12.0.0",
-        "ioredis": "^5.4.1",
+        "ioredis": "^5.4.1 || ^6.0.0",
         "prom-client": "^15.1.3",
         "toad-scheduler": "^4.0.1"
     },
@@ -50,7 +50,7 @@
         "@lokalise/biome-config": "workspace:^",
         "@lokalise/tsconfig": "workspace:^",
         "@vitest/coverage-v8": "^4.1.10",
-        "ioredis": "^5.11.1",
+        "ioredis": "^6.0.0",
         "prom-client": "^15.1.3",
         "rimraf": "^6.1.3",
         "toad-scheduler": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,7 +301,7 @@ importers:
         version: link:../../dev/biome-config
       '@lokalise/fastify-extras':
         specifier: ^31.0.0
-        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.1.0(bullmq@5.81.2(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
+        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.1.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.3(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.4.1
         version: 14.8.1(zod@4.4.3)
@@ -352,7 +352,7 @@ importers:
         version: link:../../dev/biome-config
       '@lokalise/fastify-extras':
         specifier: ^31.0.0
-        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.1.0(bullmq@5.81.2(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
+        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.1.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.3(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.0.0
         version: 14.8.1(zod@4.4.3)
@@ -449,7 +449,7 @@ importers:
         version: 14.9.1(zod@4.4.3)
       redis-semaphore:
         specifier: ^5.7.0
-        version: 5.7.0(ioredis@5.11.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 5.7.0(ioredis@6.0.0(supports-color@8.1.1))(supports-color@8.1.1)
       ts-deepmerge:
         specifier: ^8.0.0
         version: 8.0.0
@@ -470,11 +470,11 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       bullmq:
-        specifier: ^5.81.2
-        version: 5.81.2(supports-color@8.1.1)
+        specifier: ^6.2.0
+        version: 6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)
       ioredis:
-        specifier: ^5.11.1
-        version: 5.11.1(supports-color@8.1.1)
+        specifier: ^6.0.0
+        version: 6.0.0(supports-color@8.1.1)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -720,10 +720,10 @@ importers:
     dependencies:
       '@bull-board/api':
         specifier: ^8.1.0
-        version: 8.3.2(@bull-board/ui@8.3.2(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
+        version: 8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
       '@bull-board/fastify':
         specifier: ^8.1.0
-        version: 8.3.2(bullmq@5.81.2(supports-color@8.1.1))
+        version: 8.6.1(bullmq@5.81.2(supports-color@8.1.1))
       '@fastify/auth':
         specifier: ^5.1.0
         version: 5.1.0
@@ -751,7 +751,7 @@ importers:
         version: link:../../dev/biome-config
       '@lokalise/fastify-extras':
         specifier: ^31.0.1
-        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
+        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.1.0
         version: 14.8.1(zod@4.4.3)
@@ -786,8 +786,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       ioredis:
-        specifier: ^5.11.1
-        version: 5.11.1(supports-color@8.1.1)
+        specifier: ^6.0.0
+        version: 6.0.0(supports-color@8.1.1)
       pino:
         specifier: ^10.1.0
         version: 10.3.1
@@ -1672,23 +1672,23 @@ packages:
   '@bugsnag/safe-json-stringify@6.1.0':
     resolution: {integrity: sha512-ImA35rnM7bGr+J30R979FQ95BhRB4UO1KfJA0J2sVqc8nwnrS9hhE5mkTmQWMs8Vh1Da+hkLKs5jJB4JjNZp4A==}
 
-  '@bull-board/api@8.3.2':
-    resolution: {integrity: sha512-DsAiixsmJy97bQDW6Lou0oSx/LD5qm38N0D++fftRFn9si0kNhOh4DG3+7MCVblVcNX8MF/Fh3W1oxaRENFS3A==}
+  '@bull-board/api@8.6.1':
+    resolution: {integrity: sha512-v5GLzMpss8e+3AnnKRGry+9PKlm6MKU2VFxveJCSoT5+/no7WZTM5zVyjPJSG29Xwgf6CujThche6v3j4ZrmrA==}
     peerDependencies:
-      '@bull-board/ui': 8.3.2
+      '@bull-board/ui': 8.6.1
       bull: ^4.16.5
-      bullmq: ^5.79.2
+      bullmq: ^5.79.2 || ^6.0.0
     peerDependenciesMeta:
       bull:
         optional: true
       bullmq:
         optional: true
 
-  '@bull-board/fastify@8.3.2':
-    resolution: {integrity: sha512-8llMoZS/3onHEgnB1UTbh4bPP/oaYmMdjKrYdN5Z55JrwPI3X3rmaTgS+TVaeFcI4QhkBiGGJKBIn/h6QoMowQ==}
+  '@bull-board/fastify@8.6.1':
+    resolution: {integrity: sha512-a1y1HlQo8bX70797wDMV6VXYNZKF35gOuzQvzKYluwGXSRyeglNp80wF1PzeUABqSCTwDbku0Syrt03wTy/q1Q==}
 
-  '@bull-board/ui@8.3.2':
-    resolution: {integrity: sha512-Mr68M//St5BZ5OQ3X8lm4BjTwsBeEE7vo5n+5szxckmgJGBgYnY4GiEVOjGRfMCUErPP5kNdmMgKOLUmU1GH+Q==}
+  '@bull-board/ui@8.6.1':
+    resolution: {integrity: sha512-RV7oDopOJEUxzjmfKoqGcYDeHZGmpnpG+h/4DOVSSGYBtK87/8tlwAuLca9SPZqYTQjbviv7qOZ4jSjke/rUmQ==}
 
   '@changesets/apply-release-plan@8.0.0':
     resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
@@ -2051,8 +2051,8 @@ packages:
     peerDependencies:
       fastify: ^5.x
 
-  '@fastify/static@10.1.2':
-    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
+  '@fastify/static@10.1.3':
+    resolution: {integrity: sha512-W6jqajYS974XjPjB5hQWoxPM8NKM4+p8YmQT6G5IbCa4uhdWSVadZUv75siy1wEA/3ty8RYdpBydfWeu9AqAqQ==}
 
   '@fastify/swagger@9.8.1':
     resolution: {integrity: sha512-VpHMnqZTY8iBZYJE8WWkbKPrXIYWy2rDfIf5qLr6DzZSpQYZ+KxQVcJFiq/AMlvNwI4gCBd66++iUlxXXGT0IQ==}
@@ -2157,6 +2157,9 @@ packages:
 
   '@ioredis/commands@1.10.0':
     resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+
+  '@ioredis/commands@2.0.0':
+    resolution: {integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -4126,6 +4129,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
@@ -4410,6 +4418,33 @@ packages:
       redis:
         optional: true
 
+  bullmq@5.81.3:
+    resolution: {integrity: sha512-Q7uEH2G92rVjX3Yl2qw3+6VEO15uxehC6DfeTHQBQTehddcRDSDuquD9zuvDjxiCffXsPUaBwrRlvlbVcgKs7g==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      redis: '>=5.0.0'
+    peerDependenciesMeta:
+      redis:
+        optional: true
+
+  bullmq@6.2.0:
+    resolution: {integrity: sha512-9BVvqp1nJ6jzG2Ap37sZ+ucseAgHU+fxecLkHCcTJf8SMvLtRPSy1q5J7n7kutw+Hfwsa+araPPTULJSX3ID8g==}
+    engines: {node: '>=14.17.0'}
+    peerDependencies:
+      bullmq-otel: '>=2.0.0'
+      ioredis: '>=5.0.0'
+      pg: '>=8.0.0'
+      redis: '>=5.0.0'
+    peerDependenciesMeta:
+      bullmq-otel:
+        optional: true
+      ioredis:
+        optional: true
+      pg:
+        optional: true
+      redis:
+        optional: true
+
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
@@ -4556,6 +4591,10 @@ packages:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
     deprecated: v4 is no longer maintained, upgrade to v5
+
+  cron-parser@5.10.0:
+    resolution: {integrity: sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==}
+    engines: {node: '>=18'}
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
@@ -5657,6 +5696,10 @@ packages:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
+  ioredis@6.0.0:
+    resolution: {integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==}
+    engines: {node: '>=20.0.0'}
+
   ip-address@10.3.1:
     resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
@@ -6106,6 +6149,9 @@ packages:
 
   msgpackr@2.0.4:
     resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
+
+  msgpackr@2.0.5:
+    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
   msw@2.15.0:
     resolution: {integrity: sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==}
@@ -7884,27 +7930,27 @@ snapshots:
 
   '@bugsnag/safe-json-stringify@6.1.0': {}
 
-  '@bull-board/api@8.3.2(@bull-board/ui@8.3.2(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))':
+  '@bull-board/api@8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))':
     dependencies:
-      '@bull-board/ui': 8.3.2(bullmq@5.81.2(supports-color@8.1.1))
+      '@bull-board/ui': 8.6.1(bullmq@5.81.2(supports-color@8.1.1))
       redis-info: 3.1.0
     optionalDependencies:
       bullmq: 5.81.2(supports-color@8.1.1)
 
-  '@bull-board/fastify@8.3.2(bullmq@5.81.2(supports-color@8.1.1))':
+  '@bull-board/fastify@8.6.1(bullmq@5.81.2(supports-color@8.1.1))':
     dependencies:
-      '@bull-board/api': 8.3.2(@bull-board/ui@8.3.2(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
-      '@bull-board/ui': 8.3.2(bullmq@5.81.2(supports-color@8.1.1))
-      '@fastify/static': 10.1.2
+      '@bull-board/api': 8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
+      '@bull-board/ui': 8.6.1(bullmq@5.81.2(supports-color@8.1.1))
+      '@fastify/static': 10.1.3
       '@fastify/view': 12.0.0
       ejs: 6.0.1
     transitivePeerDependencies:
       - bull
       - bullmq
 
-  '@bull-board/ui@8.3.2(bullmq@5.81.2(supports-color@8.1.1))':
+  '@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1))':
     dependencies:
-      '@bull-board/api': 8.3.2(@bull-board/ui@8.3.2(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
+      '@bull-board/api': 8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
     transitivePeerDependencies:
       - bull
       - bullmq
@@ -8284,7 +8330,7 @@ snapshots:
       fastify: 5.11.3
       fastify-plugin: 6.0.0
 
-  '@fastify/static@10.1.2':
+  '@fastify/static@10.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/error': 4.2.0
@@ -8419,6 +8465,8 @@ snapshots:
 
   '@ioredis/commands@1.10.0': {}
 
+  '@ioredis/commands@2.0.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -8447,11 +8495,11 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@lokalise/background-jobs-common@15.1.0(bullmq@5.81.2(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3)':
+  '@lokalise/background-jobs-common@15.1.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3)':
     dependencies:
       '@lokalise/id-utils': 3.0.1
       '@lokalise/node-core': 14.9.1(zod@4.4.3)
-      bullmq: 5.81.2(supports-color@8.1.1)
+      bullmq: 5.81.3(supports-color@8.1.1)
       ioredis: 5.11.1(supports-color@8.1.1)
       pino: 10.3.1
       redis-semaphore: 5.7.0(ioredis@5.11.1(supports-color@8.1.1))(supports-color@8.1.1)
@@ -8487,7 +8535,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.1.0(bullmq@5.81.2(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
+  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.1.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.3(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@amplitude/analytics-node': 1.5.68
       '@bugsnag/js': 8.10.0
@@ -8495,13 +8543,13 @@ snapshots:
       '@fastify/error': 4.2.0
       '@fastify/jwt': 10.2.1
       '@lokalise/api-contracts': 8.0.0(zod@4.4.3)
-      '@lokalise/background-jobs-common': 15.1.0(bullmq@5.81.2(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3)
+      '@lokalise/background-jobs-common': 15.1.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3)
       '@lokalise/error-utils': 3.0.0(@lokalise/node-core@14.8.1(zod@4.4.3))
       '@lokalise/node-core': 14.8.1(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       '@splitsoftware/splitio': 11.11.2(supports-color@8.1.1)
       '@supercharge/promise-pool': 3.3.0
-      bullmq: 5.81.2(supports-color@8.1.1)
+      bullmq: 5.81.3(supports-color@8.1.1)
       dd-trace: 6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0))
       fastify: 5.11.3
       fastify-metrics: 13.2.1(fastify@5.11.3)
@@ -8517,7 +8565,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
+  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@amplitude/analytics-node': 1.5.68
       '@bugsnag/js': 8.10.0
@@ -8537,7 +8585,7 @@ snapshots:
       fastify-metrics: 13.2.1(fastify@5.11.3)
       fastify-plugin: 5.1.0
       fastify-type-provider-zod: 7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3)
-      ioredis: 5.11.1(supports-color@8.1.1)
+      ioredis: 6.0.0(supports-color@8.1.1)
       pino: 10.3.1
       prom-client: 15.1.3
       toad-cache: 3.7.4
@@ -10651,7 +10699,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(msw@2.15.0(@types/node@26.2.0)(typescript@5.9.3))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -10670,6 +10718,7 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@26.2.0)(typescript@5.9.3)
       vite: 6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0)
+    optional: true
 
   '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
@@ -10710,11 +10759,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 7.0.2
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -11034,6 +11085,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bullmq@5.81.3(supports-color@8.1.1):
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.11.1(supports-color@8.1.1)
+      msgpackr: 2.0.5
+      node-abort-controller: 3.1.1
+      semver: 7.8.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0):
+    dependencies:
+      cron-parser: 5.10.0
+      msgpackr: 2.0.5
+      node-abort-controller: 3.1.1
+      semver: 7.8.5
+      tslib: 2.8.1
+    optionalDependencies:
+      ioredis: 6.0.0(supports-color@8.1.1)
+      pg: 8.22.0
+
   byline@5.0.0: {}
 
   bytes@3.1.2: {}
@@ -11158,6 +11231,10 @@ snapshots:
       vary: 1.1.2
 
   cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
+  cron-parser@5.10.0:
     dependencies:
       luxon: 3.7.2
 
@@ -12377,6 +12454,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ioredis@6.0.0(supports-color@8.1.1):
+    dependencies:
+      '@ioredis/commands': 2.0.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
@@ -12859,6 +12947,10 @@ snapshots:
     optional: true
 
   msgpackr@2.0.4:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
+  msgpackr@2.0.5:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
@@ -13440,6 +13532,14 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     optionalDependencies:
       ioredis: 5.11.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  redis-semaphore@5.7.0(ioredis@6.0.0(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    optionalDependencies:
+      ioredis: 6.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14176,7 +14276,7 @@ snapshots:
     dependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@26.2.0)
       '@rollup/pluginutils': 5.4.0(rollup@4.62.4)
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@7.0.2)
       '@vue/language-core': 2.2.0(typescript@7.0.2)
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -14233,6 +14333,7 @@ snapshots:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
+    optional: true
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,11 +719,11 @@ importers:
   packages/app/fastify-bullboard-plugin:
     dependencies:
       '@bull-board/api':
-        specifier: ^8.1.0
-        version: 8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
+        specifier: ^9.4.0
+        version: 9.4.0(@bull-board/ui@9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)))(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))
       '@bull-board/fastify':
-        specifier: ^8.1.0
-        version: 8.6.1(bullmq@5.81.2(supports-color@8.1.1))
+        specifier: ^9.4.0
+        version: 9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))
       '@fastify/auth':
         specifier: ^5.1.0
         version: 5.1.0
@@ -751,7 +751,7 @@ importers:
         version: link:../../dev/biome-config
       '@lokalise/fastify-extras':
         specifier: ^31.0.1
-        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
+        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.1.0
         version: 14.8.1(zod@4.4.3)
@@ -768,8 +768,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(awilix@13.0.5)
       bullmq:
-        specifier: 5.81.2
-        version: 5.81.2(supports-color@8.1.1)
+        specifier: 6.2.0
+        version: 6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)
       cross-env:
         specifier: ^10.0.0
         version: 10.1.0
@@ -869,7 +869,7 @@ importers:
         version: 3.3.0
       redis-semaphore:
         specifier: ^5.6.2
-        version: 5.7.0(ioredis@5.11.1(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 5.7.0(ioredis@6.0.0(supports-color@8.1.1))(supports-color@8.1.1)
       toad-cache:
         specifier: ^3.7.1
         version: 3.7.4
@@ -890,8 +890,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       ioredis:
-        specifier: ^5.11.1
-        version: 5.11.1(supports-color@8.1.1)
+        specifier: ^6.0.0
+        version: 6.0.0(supports-color@8.1.1)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -1672,10 +1672,10 @@ packages:
   '@bugsnag/safe-json-stringify@6.1.0':
     resolution: {integrity: sha512-ImA35rnM7bGr+J30R979FQ95BhRB4UO1KfJA0J2sVqc8nwnrS9hhE5mkTmQWMs8Vh1Da+hkLKs5jJB4JjNZp4A==}
 
-  '@bull-board/api@8.6.1':
-    resolution: {integrity: sha512-v5GLzMpss8e+3AnnKRGry+9PKlm6MKU2VFxveJCSoT5+/no7WZTM5zVyjPJSG29Xwgf6CujThche6v3j4ZrmrA==}
+  '@bull-board/api@9.4.0':
+    resolution: {integrity: sha512-poPku55iQd/VS65BUD8yn/uIHUruDwOVOiPEbThzjCd1nHAzEUEj/D+LWW1t9vzRsvN6xBr5jXlbJDapBnz7aw==}
     peerDependencies:
-      '@bull-board/ui': 8.6.1
+      '@bull-board/ui': 9.4.0
       bull: ^4.16.5
       bullmq: ^5.79.2 || ^6.0.0
     peerDependenciesMeta:
@@ -1684,11 +1684,11 @@ packages:
       bullmq:
         optional: true
 
-  '@bull-board/fastify@8.6.1':
-    resolution: {integrity: sha512-a1y1HlQo8bX70797wDMV6VXYNZKF35gOuzQvzKYluwGXSRyeglNp80wF1PzeUABqSCTwDbku0Syrt03wTy/q1Q==}
+  '@bull-board/fastify@9.4.0':
+    resolution: {integrity: sha512-N8kvvHfnCnohu44MglXT0LHlo5KncHd0tHNqE+Y9OEMfdRJseCKJujtb/FnzAgB+VRxsMI+Y8O9PN9x8g2+IsA==}
 
-  '@bull-board/ui@8.6.1':
-    resolution: {integrity: sha512-RV7oDopOJEUxzjmfKoqGcYDeHZGmpnpG+h/4DOVSSGYBtK87/8tlwAuLca9SPZqYTQjbviv7qOZ4jSjke/rUmQ==}
+  '@bull-board/ui@9.4.0':
+    resolution: {integrity: sha512-oRuCjMawEdpwFpHWWT6tzZLVqaqP+sK7xs1C1AhvTGm4pViNyPKwV7chtSExFOdVZuXJnJOl74WTXsHRfKMF3A==}
 
   '@changesets/apply-release-plan@8.0.0':
     resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
@@ -4409,15 +4409,6 @@ packages:
     resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
     engines: {node: '>=v18.0.0'}
 
-  bullmq@5.81.2:
-    resolution: {integrity: sha512-Hi9GaVCC6HE9bQP65j/FNv1aL1fcEukTF99ezS5pl1Ud+joCFpNWiPCV45mWdkEmpuacS0XJdMMFGKPIHCwoPg==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      redis: '>=5.0.0'
-    peerDependenciesMeta:
-      redis:
-        optional: true
-
   bullmq@5.81.3:
     resolution: {integrity: sha512-Q7uEH2G92rVjX3Yl2qw3+6VEO15uxehC6DfeTHQBQTehddcRDSDuquD9zuvDjxiCffXsPUaBwrRlvlbVcgKs7g==}
     engines: {node: '>=12.22.0'}
@@ -6146,9 +6137,6 @@ packages:
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
-
-  msgpackr@2.0.4:
-    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
 
   msgpackr@2.0.5:
     resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
@@ -7930,17 +7918,17 @@ snapshots:
 
   '@bugsnag/safe-json-stringify@6.1.0': {}
 
-  '@bull-board/api@8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))':
+  '@bull-board/api@9.4.0(@bull-board/ui@9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)))(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))':
     dependencies:
-      '@bull-board/ui': 8.6.1(bullmq@5.81.2(supports-color@8.1.1))
+      '@bull-board/ui': 9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))
       redis-info: 3.1.0
     optionalDependencies:
-      bullmq: 5.81.2(supports-color@8.1.1)
+      bullmq: 6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)
 
-  '@bull-board/fastify@8.6.1(bullmq@5.81.2(supports-color@8.1.1))':
+  '@bull-board/fastify@9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))':
     dependencies:
-      '@bull-board/api': 8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
-      '@bull-board/ui': 8.6.1(bullmq@5.81.2(supports-color@8.1.1))
+      '@bull-board/api': 9.4.0(@bull-board/ui@9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)))(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))
+      '@bull-board/ui': 9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))
       '@fastify/static': 10.1.3
       '@fastify/view': 12.0.0
       ejs: 6.0.1
@@ -7948,9 +7936,9 @@ snapshots:
       - bull
       - bullmq
 
-  '@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1))':
+  '@bull-board/ui@9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))':
     dependencies:
-      '@bull-board/api': 8.6.1(@bull-board/ui@8.6.1(bullmq@5.81.2(supports-color@8.1.1)))(bullmq@5.81.2(supports-color@8.1.1))
+      '@bull-board/api': 9.4.0(@bull-board/ui@9.4.0(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)))(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))
     transitivePeerDependencies:
       - bull
       - bullmq
@@ -8565,7 +8553,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.2(supports-color@8.1.1))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
+  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))(dd-trace@6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0)))(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.11.3)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.11.3)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@amplitude/analytics-node': 1.5.68
       '@bugsnag/js': 8.10.0
@@ -8579,7 +8567,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@splitsoftware/splitio': 11.11.2(supports-color@8.1.1)
       '@supercharge/promise-pool': 3.3.0
-      bullmq: 5.81.2(supports-color@8.1.1)
+      bullmq: 6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0)
       dd-trace: 6.10.0(@openfeature/server-sdk@1.22.0(@openfeature/core@1.11.0))
       fastify: 5.11.3
       fastify-metrics: 13.2.1(fastify@5.11.3)
@@ -11074,17 +11062,6 @@ snapshots:
 
   brotli-wasm@3.0.1: {}
 
-  bullmq@5.81.2(supports-color@8.1.1):
-    dependencies:
-      cron-parser: 4.9.0
-      ioredis: 5.11.1(supports-color@8.1.1)
-      msgpackr: 2.0.4
-      node-abort-controller: 3.1.1
-      semver: 7.8.5
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   bullmq@5.81.3(supports-color@8.1.1):
     dependencies:
       cron-parser: 4.9.0
@@ -12945,10 +12922,6 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
-
-  msgpackr@2.0.4:
-    optionalDependencies:
-      msgpackr-extract: 3.0.4
 
   msgpackr@2.0.5:
     optionalDependencies:


### PR DESCRIPTION
## What

BullMQ 6 and ioredis 6 support across the three packages that touch them.

| Package | Change |
| --- | --- |
| `background-jobs-common` | `bullmq` peer `^5.28.2` -> `^5.28.2 \|\| ^6.0.0`, `ioredis` peer `^5.4.1` -> `^5.4.1 \|\| ^6.0.0` |
| `healthcheck-utils` | `ioredis` peer `^5.4.1` -> `^5.4.1 \|\| ^6.0.0` |
| `fastify-bullboard-plugin` | `@bull-board` 8 -> 9 (which supports bullmq 6), devDependency on bullmq 6 |

Dev dependencies move to bullmq 6.2.0 / ioredis 6.0.0, so CI exercises the new majors.

## BullMQ 6 changes that touched `background-jobs-common`

- `paused` was removed from `JobType` (v6 pauses through queue metadata instead of a separate list). The
  pending-job type list moved to a shared `PENDING_JOB_TYPES` constant. `getJobCount` still asks for the
  `paused` count: on v6 that key is never written, so it contributes 0, and on v5 the behaviour is unchanged.
- `debounce` and `repeat` were dropped from `JobsOptions`. `stripChildOnlyFields` deletes them through a
  record, so it keeps guarding against a JS caller smuggling them onto a flow child under either major.
- `FlowChildJob` was renamed to `FlowJobNode`. The type is now derived from `FlowJob['children']`, which
  resolves to the right thing on both.
- Legacy repeatable jobs are gone. The two repeatable tests now create the schedule through
  `queue.upsertJobScheduler`, which exists in both majors.

## ioredis 6 change

`zrange`'s stop argument narrowed to `string | Buffer`, so `backgroundJobProcessorGetActiveQueueIds` and its
tests pass `'-1'` instead of `-1`.

## `fastify-bullboard-plugin`

`@bull-board` 9 peers `bullmq ^5.79.2 || ^6.0.0`. One source change: `QueueConstructor` no longer declares the
third constructor parameter. BullMQ 6 replaced it (`Connection`) with a `BackendFactory`, and the plugin never
passed it, so the type now mirrors `QueueProConstructor` and accepts BullMQ's `Queue` on both majors. Marked
`major` in the changeset because @bull-board 9 ships a redesigned dashboard UI and the exported type narrowed.

## Is v5 still genuinely supported?

Yes. Every change is behaviour-identical on v5: the same six job types are passed, the same four job options are
deleted, `NonNullable<FlowJob['children']>[number]` resolves to exactly `FlowChildJob`, `zrange` sends the same
wire command, and `upsertJobScheduler` has existed since bullmq 5.16.

Caveat worth naming: CI runs one version, so the 5.x side is a point-in-time check rather than a standing
guarantee. A version matrix can be added if that should be locked down.

## Verification

- `tsc --noEmit` clean for all three packages against bullmq 6.2.0 + ioredis 6.0.0 **and** against
  bullmq 5.81.3 + ioredis 5.11.1.
- Test suites pass on both lines. The two `ignores missing job error during automatic purging` failures seen
  locally reproduce on `main` unchanged and are unrelated to this PR.
- `pnpm run build` green across the workspace.

Runtime dependencies (`@lokalise/node-core`, `redis-semaphore`, `ts-deepmerge`) were already at their latest
releases, so nothing to bump there.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
