### PR TITLE
feat(backend-http-client): export TRANSPORT_ERROR_CODES and HttpClient type

### DIFF
--- a/.changeset/expose-transport-codes-and-http-client-type.md
+++ b/.changeset/expose-transport-codes-and-http-client-type.md
@@ -1,0 +1,5 @@
+---
+'@lokalise/backend-http-client': minor
+---
+
+Export `TRANSPORT_ERROR_CODES` (the authoritative transport-error code list, previously internal) and the `HttpClient` type (the handle returned by `buildClient`), so consumers can iterate the code list instead of copying it and can type client instances without importing `Client` from `undici` directly.

--- a/packages/app/backend-http-client/README.md
+++ b/packages/app/backend-http-client/README.md
@@ -6,7 +6,7 @@ Opinionated HTTP client for the Node.js backend
 
 The library provides methods to implement the client side of HTTP protocols. Public methods available are:
 
-- `buildClient()`, which returns a [Client](https://undici.nodejs.org/#/docs/api/Client) instance and should be called before any of the following methods with parameters:
+- `buildClient()`, which returns a [Client](https://undici.nodejs.org/#/docs/api/Client) instance and should be called before any of the following methods. Type client handles with the exported `HttpClient` type instead of importing `Client` from `undici`, so the undici major version stays an implementation detail of this package. Parameters:
   - `baseUrl`;
   - `clientOptions` – set of [ClientOptions](https://undici.nodejs.org/#/docs/api/Client?id=parameter-clientoptions) (optional). If none are provided, the following default options will be used to instantiate the client:
     ```
@@ -426,7 +426,7 @@ try {
 }
 ```
 
-Recognized codes: `UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_SOCKET`, `UND_ERR_PRX_CONN`, `ECONNREFUSED`, `ECONNRESET`, `EHOSTUNREACH`, `EHOSTDOWN`, `ENETUNREACH`, `ENETDOWN`, `EADDRNOTAVAIL`, `ETIMEDOUT`, `EPIPE`, `EAI_AGAIN`, `ERR_SOCKET_CONNECTION_TIMEOUT`. Detection also walks the error's `cause` chain (depth-capped), so errors wrapped by `InternalRequestError` or `fetch` are recognized too.
+Recognized codes: `UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_SOCKET`, `UND_ERR_PRX_CONN`, `ECONNREFUSED`, `ECONNRESET`, `EHOSTUNREACH`, `EHOSTDOWN`, `ENETUNREACH`, `ENETDOWN`, `EADDRNOTAVAIL`, `ETIMEDOUT`, `EPIPE`, `EAI_AGAIN`, `ERR_SOCKET_CONNECTION_TIMEOUT`. The list is exported as `TRANSPORT_ERROR_CODES` (with the `TransportErrorCode` union type), so consumers and their tests can iterate the authoritative list instead of copying it. Detection also walks the error's `cause` chain (depth-capped), so errors wrapped by `InternalRequestError` or `fetch` are recognized too.
 
 ### Options
 

--- a/packages/app/backend-http-client/src/client/httpClient.ts
+++ b/packages/app/backend-http-client/src/client/httpClient.ts
@@ -37,6 +37,13 @@ export function buildClient(baseUrl: string, clientOptions?: Client.Options) {
   })
 }
 
+/**
+ * The HTTP client handle returned by `buildClient`. Type client instances with
+ * this instead of importing `Client` from `undici` directly, so the undici
+ * major version stays an implementation detail of this package.
+ */
+export type HttpClient = ReturnType<typeof buildClient>
+
 export async function sendGet<
   T extends ZodSchema,
   IsEmptyResponseExpected extends boolean = false,

--- a/packages/app/backend-http-client/src/errors/transportError.spec.ts
+++ b/packages/app/backend-http-client/src/errors/transportError.spec.ts
@@ -1,26 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { InternalRequestError } from './InternalRequestError.ts'
-import { getTransportErrorCode, isTransportError } from './transportError.ts'
+import { getTransportErrorCode, isTransportError, TRANSPORT_ERROR_CODES } from './transportError.ts'
 
 describe('getTransportErrorCode', () => {
-  it.each([
-    'UND_ERR_HEADERS_TIMEOUT',
-    'UND_ERR_BODY_TIMEOUT',
-    'UND_ERR_CONNECT_TIMEOUT',
-    'UND_ERR_SOCKET',
-    'UND_ERR_PRX_CONN',
-    'ECONNREFUSED',
-    'ECONNRESET',
-    'EHOSTUNREACH',
-    'EHOSTDOWN',
-    'ENETUNREACH',
-    'ENETDOWN',
-    'EADDRNOTAVAIL',
-    'ETIMEDOUT',
-    'EPIPE',
-    'EAI_AGAIN',
-    'ERR_SOCKET_CONNECTION_TIMEOUT',
-  ])('detects %s on the error itself', (code) => {
+  it.each(TRANSPORT_ERROR_CODES)('detects %s on the error itself', (code) => {
     const error = Object.assign(new Error('request failed'), { code })
 
     expect(getTransportErrorCode(error)).toBe(code)

--- a/packages/app/backend-http-client/src/errors/transportError.ts
+++ b/packages/app/backend-http-client/src/errors/transportError.ts
@@ -1,9 +1,10 @@
 /**
  * Transport-level failures without an HTTP response: undici timeouts/socket
  * errors and node connection errors. Typically temporary, so callers usually
- * want to retry them.
+ * want to retry them. Exported so consumers can iterate the authoritative
+ * list instead of copying it.
  */
-const TRANSPORT_ERROR_CODES = [
+export const TRANSPORT_ERROR_CODES = [
   'UND_ERR_HEADERS_TIMEOUT',
   'UND_ERR_BODY_TIMEOUT',
   'UND_ERR_CONNECT_TIMEOUT',

--- a/packages/app/backend-http-client/src/index.ts
+++ b/packages/app/backend-http-client/src/index.ts
@@ -18,6 +18,7 @@ export {
   TEST_OPTIONS,
   UNKNOWN_RESPONSE_SCHEMA,
 } from './client/constants.ts'
+export type { HttpClient } from './client/httpClient.ts'
 export {
   buildClient,
   httpClient,
@@ -49,4 +50,8 @@ export {
   ResponseStatusError,
 } from './errors/ResponseStatusError.ts'
 export type { TransportErrorCode } from './errors/transportError.ts'
-export { getTransportErrorCode, isTransportError } from './errors/transportError.ts'
+export {
+  getTransportErrorCode,
+  isTransportError,
+  TRANSPORT_ERROR_CODES,
+} from './errors/transportError.ts'


### PR DESCRIPTION
## Changes

- TRANSPORT_ERROR_CODES exported - the authoritative code list is public; the lib's own spec now iterates it (it.each(TRANSPORT_ERROR_CODES)) instead of a copy
- HttpClient type exported from client/httpClient.ts (ReturnType<typeof buildClient>)

## Checklist

- [x] I've added a changeset, or no published packages were changed
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support,
explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
