### PR TITLE
fix(fastify-api-contracts): keep committed SSE stream open when handler errors

### DIFF
--- a/.changeset/sse-error-keeps-stream-open.md
+++ b/.changeset/sse-error-keeps-stream-open.md
@@ -2,4 +2,6 @@
 "@lokalise/fastify-api-contracts": patch
 ---
 
-Keep a committed SSE stream open when an error escapes the route handler after `sse.start()`, instead of letting `@fastify/sse` close the connection before rethrowing. The error now reaches the global error handler with the stream still connected, so an SSE-aware error handler can serialize it into a terminal error event and close the stream (reported as a server-initiated close to `onClose`). Errors thrown before the stream starts still produce a regular HTTP error response.
+Keep a committed SSE stream open when an error escapes the route handler after `sse.start()`, instead of letting `@fastify/sse` close the connection before rethrowing. The error now reaches the global error handler with the stream still connected, so an SSE-aware error handler can serialize it into a terminal error event and close the stream. Errors thrown before the stream starts still produce a regular HTTP error response.
+
+The `onClose` initiator is now attributed when the stream actually closes: any server-initiated close — `session.close()`, an error handler calling `reply.sse.close()`, or `@fastify/sse` closing an `autoClose` session after the handler completes — reports `'server'` (previously a direct `reply.sse.close()` reported `'client'`), while a client disconnect keeps reporting `'client'` even after a handler error.

--- a/.changeset/sse-error-keeps-stream-open.md
+++ b/.changeset/sse-error-keeps-stream-open.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/fastify-api-contracts": patch
+---
+
+Keep a committed SSE stream open when an error escapes the route handler after `sse.start()`, instead of letting `@fastify/sse` close the connection before rethrowing. The error now reaches the global error handler with the stream still connected, so an SSE-aware error handler can serialize it into a terminal error event and close the stream (reported as a server-initiated close to `onClose`). Errors thrown before the stream starts still produce a regular HTTP error response.

--- a/packages/app/fastify-api-contracts/README.md
+++ b/packages/app/fastify-api-contracts/README.md
@@ -30,6 +30,9 @@ import fastifySSE from '@fastify/sse'
 await app.register(fastifySSE)
 ```
 
+> [!IMPORTANT]
+> SSE-capable routes also require an **SSE-aware global error handler**: once a stream is committed, an error can only be reported as a terminal event over the stream — a plain `reply.status().send()` error handler runs into already-sent headers and leaves the response unfinished. See [Error handling](#error-handling); the [`errorHandler` in `fastify-extras`](https://github.com/lokalise/fastify-extras/blob/main/lib/errors/errorHandler.ts) supports this out of the box.
+
 Register the Zod compilers on your Fastify instance and use the `ZodTypeProvider` when adding routes:
 
 ```ts
@@ -170,6 +173,8 @@ To respond without streaming, return `{ status, body }` with a non-SSE body (the
 
 SSE-capable routes are registered in `@fastify/sse` `'manual'` mode: there is no `Accept`-header negotiation — the handler alone decides at runtime whether to stream or send a regular HTTP response. This also supports clients that signal streaming via the request body (e.g. OpenAI-style `{ stream: true }`) instead of an `Accept: text/event-stream` header.
 
+An error thrown after the stream started reaches the global error handler with the stream still open, so the Fastify instance **must** register an SSE-aware `setErrorHandler` — see [Error handling](#error-handling).
+
 ```ts
 import { sseBody } from '@lokalise/api-contracts'
 
@@ -282,8 +287,12 @@ const routes = [buildFastifyApiRoute(contract, createUser)]
 
 Errors from contract routes go through the regular Fastify error handling chain (`fastify.setErrorHandler` or the default handler) — contract routes behave exactly like any other route. The exception is a **live SSE stream**: once the stream started, the status line and headers are on the wire, so a standard `reply.status().send()` can no longer work.
 
-- For an `autoClose` session (including the declarative `{ status, body: asyncIterable }` form), a handler error closes the stream without reaching the error handler — the client detects the failure by the missing terminal event (e.g. `done`).
-- For a `keepAlive` session, a handler rejection reaches the error handler with the stream still open. The only correct error signal there is a terminal `error` event sent over the stream before closing it, so a global `setErrorHandler` serving SSE routes must branch on the stream state:
+An error escaping the handler after the stream started — whether the session is `autoClose` or `keepAlive`, imperative (`sse.start()`) or declarative (`{ status, body: asyncIterable }`) — reaches the global error handler with the stream **still open**. Errors thrown before the stream starts take the regular HTTP error path.
+
+> [!IMPORTANT]
+> A Fastify instance serving SSE-capable routes **must** set an SSE-aware `setErrorHandler`. The only correct error signal on a committed stream is a terminal `error` event sent over the stream before closing it; an error handler that unconditionally calls `reply.status().send()` runs into already-sent headers, leaving the stream open and the error unreported to the client. The [`errorHandler` in `fastify-extras`](https://github.com/lokalise/fastify-extras/blob/main/lib/errors/errorHandler.ts) is a ready-made SSE-aware implementation.
+
+An SSE-aware error handler branches on the stream state:
 
 ```ts
 app.setErrorHandler(async (error, request, reply) => {

--- a/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.spec.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.spec.ts
@@ -1090,8 +1090,8 @@ describe('buildFastifyApiRoute — runtime', () => {
 
   it('keeps the stream open for the global error handler when the handler throws after sse.start()', async () => {
     app = await buildApp()
-    // Mimics an SSE-aware global error handler (fastify-extras): the stream is still
-    // connected when the error arrives, so it goes out as a terminal SSE event.
+    // Mimics an SSE-aware global error handler: the stream is still connected when the
+    // error arrives, so it goes out as a terminal SSE event.
     app.setErrorHandler<Error>(async (error, _request, reply) => {
       expect(reply.sse.isConnected).toBe(true)
       await reply.sse.send({ event: 'error', data: { message: error.message } })

--- a/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.spec.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.spec.ts
@@ -1088,6 +1088,117 @@ describe('buildFastifyApiRoute — runtime', () => {
     await vi.waitFor(() => expect(closeInitiator).toBe('server'))
   })
 
+  it('keeps the stream open for the global error handler when the handler throws after sse.start()', async () => {
+    app = await buildApp()
+    // Mimics an SSE-aware global error handler (fastify-extras): the stream is still
+    // connected when the error arrives, so it goes out as a terminal SSE event.
+    app.setErrorHandler<Error>(async (error, _request, reply) => {
+      expect(reply.sse.isConnected).toBe(true)
+      await reply.sse.send({ event: 'error', data: { message: error.message } })
+      reply.sse.close()
+    })
+    app.route(
+      buildFastifyApiRoute(sseOnlyContract, async (_request, _reply, { sse }) => {
+        const session = sse.start('autoClose')
+        await session.send('update', { value: 1 })
+        throw new Error('stream blew up')
+      }),
+    )
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/stream',
+      headers: { accept: 'text/event-stream' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toContain('event: update')
+    expect(response.body).toContain('event: error')
+    expect(response.body).toContain('stream blew up')
+  })
+
+  it('keeps the stream open for the global error handler when an async-iterable body throws mid-stream', async () => {
+    app = await buildApp()
+    app.setErrorHandler<Error>(async (error, _request, reply) => {
+      expect(reply.sse.isConnected).toBe(true)
+      await reply.sse.send({ event: 'error', data: { message: error.message } })
+      reply.sse.close()
+    })
+    app.route(
+      buildFastifyApiRoute(sseOnlyContract, (_request, _reply) => ({
+        status: 200,
+        // biome-ignore lint/suspicious/useAwait: async is required to satisfy AsyncIterable
+        body: (async function* (): AsyncGenerator<SSEStreamMessage<typeof sseEventsSchema>> {
+          yield { event: 'update', data: { value: 1 } }
+          throw new Error('source failed')
+        })(),
+      })),
+    )
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/stream',
+      headers: { accept: 'text/event-stream' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toContain('event: update')
+    expect(response.body).toContain('event: error')
+    expect(response.body).toContain('source failed')
+  })
+
+  it("reports 'server' as the close initiator when the global error handler closes an errored stream", async () => {
+    let closeInitiator: string | undefined
+    app = await buildApp()
+    app.setErrorHandler<Error>(async (error, _request, reply) => {
+      await reply.sse.send({ event: 'error', data: { message: error.message } })
+      reply.sse.close()
+    })
+    app.route(
+      buildFastifyApiRoute(
+        sseOnlyContract,
+        async (_request, _reply, { sse }) => {
+          const session = sse.start('autoClose')
+          await session.send('update', { value: 1 })
+          throw new Error('stream blew up')
+        },
+        {
+          onClose: (_session, initiator) => {
+            closeInitiator = initiator
+          },
+        },
+      ),
+    )
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/stream',
+      headers: { accept: 'text/event-stream' },
+    })
+    expect(response.statusCode).toBe(200)
+    await vi.waitFor(() => expect(closeInitiator).toBe('server'))
+  })
+
+  it('returns a regular 500 when an SSE-capable handler throws before sse.start()', async () => {
+    app = await buildApp()
+    app.route(
+      buildFastifyApiRoute(sseOnlyContract, () => {
+        throw new Error('failed before streaming')
+      }),
+    )
+    await app.ready()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/stream',
+      headers: { accept: 'text/event-stream' },
+    })
+    expect(response.statusCode).toBe(500)
+    expect(response.headers['content-type']).toContain('application/json')
+    expect(response.json()).toMatchObject({ message: 'failed before streaming' })
+  })
+
   it('shares a 404 then streams via async iterable for an SSE-capable contract', async () => {
     const contract = defineApiContract({
       visibility: 'public',

--- a/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.ts
@@ -260,7 +260,6 @@ async function handleApiRoute({
     if (apiSSEContext?.isStarted()) {
       // The handler drove the session imperatively via sse.start(); @fastify/sse manages
       // the rest of the connection lifecycle.
-      apiSSEContext.markHandlerDone()
       return
     }
 
@@ -278,7 +277,6 @@ async function handleApiRoute({
           contentType: resolved.contentType as string,
         })
         await session.sendStream(resolved.body as AsyncIterable<SSEStreamMessage>)
-        apiSSEContext.markHandlerDone()
         return
       }
       // Any other status/body is sent as a regular HTTP response.

--- a/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/buildFastifyApiRoute.ts
@@ -254,42 +254,50 @@ async function handleApiRoute({
     ...(apiSSEContext ? { sse: apiSSEContext.sseContext } : {}),
   }
 
-  const result = await handler(request, reply, context)
+  try {
+    const result = await handler(request, reply, context)
 
-  if (apiSSEContext?.isStarted()) {
-    // The handler drove the session imperatively via sse.start(); @fastify/sse manages
-    // the rest of the connection lifecycle.
-    apiSSEContext.markHandlerDone()
-    return
-  }
-
-  if (isApiHandlerResult(result)) {
-    const resolved = resolveResponseRepresentation(contract, result)
-
-    // An SSE representation carries an async iterable of events as its body: open the
-    // connection and pipe each event, validated against the event schemas of exactly the
-    // representation the handler result selected.
-    if (apiSSEContext && resolved.isSse) {
-      const session = apiSSEContext.sseContext.start('autoClose', {
-        statusCode: resolved.status,
-        // An SSE representation always carries a media type — `contentType` is only null
-        // for a no-body response, which resolves with `isSse: false`.
-        contentType: resolved.contentType as string,
-      })
-      await session.sendStream(resolved.body as AsyncIterable<SSEStreamMessage>)
+    if (apiSSEContext?.isStarted()) {
+      // The handler drove the session imperatively via sse.start(); @fastify/sse manages
+      // the rest of the connection lifecycle.
       apiSSEContext.markHandlerDone()
       return
     }
-    // Any other status/body is sent as a regular HTTP response.
-    await sendResponse(contract, reply, resolved)
-    return
-  }
 
-  // The handler neither returned { status, body } nor called sse.start().
-  throw new InternalError({
-    message: 'Internal Server Error',
-    errorCode: 'INVALID_HANDLER_RESULT',
-  })
+    if (isApiHandlerResult(result)) {
+      const resolved = resolveResponseRepresentation(contract, result)
+
+      // An SSE representation carries an async iterable of events as its body: open the
+      // connection and pipe each event, validated against the event schemas of exactly the
+      // representation the handler result selected.
+      if (apiSSEContext && resolved.isSse) {
+        const session = apiSSEContext.sseContext.start('autoClose', {
+          statusCode: resolved.status,
+          // An SSE representation always carries a media type — `contentType` is only null
+          // for a no-body response, which resolves with `isSse: false`.
+          contentType: resolved.contentType as string,
+        })
+        await session.sendStream(resolved.body as AsyncIterable<SSEStreamMessage>)
+        apiSSEContext.markHandlerDone()
+        return
+      }
+      // Any other status/body is sent as a regular HTTP response.
+      await sendResponse(contract, reply, resolved)
+      return
+    }
+
+    // The handler neither returned { status, body } nor called sse.start().
+    throw new InternalError({
+      message: 'Internal Server Error',
+      errorCode: 'INVALID_HANDLER_RESULT',
+    })
+  } catch (err) {
+    // When the stream is already committed, keep the connection open while the error
+    // propagates — the global error handler is responsible for serializing the error into
+    // a terminal SSE event and closing the stream. A no-op before sse.start().
+    apiSSEContext?.preserveStreamOnError()
+    throw err
+  }
 }
 
 /**

--- a/packages/app/fastify-api-contracts/src/api-contracts/sseUtils.spec.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/sseUtils.spec.ts
@@ -495,22 +495,30 @@ describe('buildApiSSEContext', () => {
     const startWithOnClose = (onClose: (s: SSESession, i: SSECloseInitiator) => void) => {
       const request = requestWithAccept()
       const { reply, sse } = buildSseReply()
-      const { sseContext, markHandlerDone } = buildApiSSEContext(request, reply, sseSelections, {
-        onClose,
-      })
+      const { sseContext, preserveStreamOnError } = buildApiSSEContext(
+        request,
+        reply,
+        sseSelections,
+        {
+          onClose,
+        },
+      )
+      // start() wraps reply.sse.close to attribute server-initiated closes — keep a handle
+      // on the underlying plugin mock for call assertions.
+      const pluginClose = sse.close
       const session = sseContext.start('keepAlive')
       const fireClose = sse.onClose.mock.calls[0]?.[0] as () => void
-      return { session, sse, markHandlerDone, fireClose, request }
+      return { session, sse, pluginClose, preserveStreamOnError, fireClose, request }
     }
 
     it("session.close() closes the reply and reports 'server' as the initiator", () => {
       const onClose = vi.fn()
-      const { session, sse, fireClose } = startWithOnClose(onClose)
+      const { session, pluginClose, fireClose } = startWithOnClose(onClose)
 
       session.close()
       fireClose()
 
-      expect(sse.close).toHaveBeenCalled()
+      expect(pluginClose).toHaveBeenCalled()
       expect(onClose).toHaveBeenCalledWith(session, 'server')
     })
 
@@ -523,31 +531,72 @@ describe('buildApiSSEContext', () => {
       expect(onClose).toHaveBeenCalledWith(session, 'client')
     })
 
-    it('markHandlerDone() marks an autoClose session close as server-initiated', () => {
+    it("attributes @fastify/sse's autoClose close after handler completion as server-initiated", () => {
       const onClose = vi.fn()
       const { reply, sse } = buildSseReply()
-      const { sseContext, markHandlerDone } = buildApiSSEContext(
-        requestWithAccept(),
-        reply,
-        sseSelections,
-        { onClose },
-      )
+      const { sseContext } = buildApiSSEContext(requestWithAccept(), reply, sseSelections, {
+        onClose,
+      })
       const session = sseContext.start('autoClose')
 
-      markHandlerDone()
+      // After the route handler resolves, @fastify/sse closes the non-keepAlive session
+      // via context.close() — which goes through the wrapper installed at start().
+      sse.close()
       ;(sse.onClose.mock.calls[0]![0] as () => void)()
 
       expect(onClose).toHaveBeenCalledWith(session, 'server')
     })
 
-    it('markHandlerDone() leaves a keepAlive session close client-initiated', () => {
+    it("reports 'server' when server-side code closes via reply.sse.close() directly", () => {
       const onClose = vi.fn()
-      const { markHandlerDone, fireClose, session } = startWithOnClose(onClose)
+      const { session, sse, fireClose } = startWithOnClose(onClose)
 
-      markHandlerDone()
+      // A global error handler (or any hook holding the reply) ends the stream through
+      // the plugin API, not session.close().
+      sse.close()
+      fireClose()
+
+      expect(onClose).toHaveBeenCalledWith(session, 'server')
+    })
+
+    it("preserveStreamOnError() keeps a later client disconnect reported as 'client'", () => {
+      const onClose = vi.fn()
+      const { session, preserveStreamOnError, fireClose } = startWithOnClose(onClose)
+
+      preserveStreamOnError()
+      // The error handler left the stream open; the client disconnects afterwards.
       fireClose()
 
       expect(onClose).toHaveBeenCalledWith(session, 'client')
+    })
+
+    it('preserveStreamOnError() flags an autoClose session keep-alive so the plugin skips its error-path close', () => {
+      const { reply, sse } = buildSseReply()
+      const { sseContext, preserveStreamOnError } = buildApiSSEContext(
+        requestWithAccept(),
+        reply,
+        sseSelections,
+        undefined,
+      )
+      sseContext.start('autoClose')
+
+      expect(sse.keepAlive).not.toHaveBeenCalled()
+      preserveStreamOnError()
+      expect(sse.keepAlive).toHaveBeenCalled()
+    })
+
+    it('preserveStreamOnError() is a no-op before the stream starts', () => {
+      const { reply, sse } = buildSseReply()
+      const { preserveStreamOnError } = buildApiSSEContext(
+        requestWithAccept(),
+        reply,
+        sseSelections,
+        undefined,
+      )
+
+      preserveStreamOnError()
+
+      expect(sse.keepAlive).not.toHaveBeenCalled()
     })
 
     it('logs a rejecting onClose hook without tearing down the stream', async () => {

--- a/packages/app/fastify-api-contracts/src/api-contracts/sseUtils.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/sseUtils.ts
@@ -117,7 +117,7 @@ function resolveSseSelection(
 
 /**
  * Build the `sse` context passed to SSE-capable handlers, plus the lifecycle probes the
- * route runtime needs (`isStarted`, `markHandlerDone`, `preserveStreamOnError`).
+ * route runtime needs (`isStarted`, `preserveStreamOnError`).
  *
  * `start()` validates the reply's headers against `responseHeaderSchema` before flushing
  * them — the only moment a violation can still become a 500 instead of going out on an
@@ -133,7 +133,6 @@ export function buildApiSSEContext(
   // biome-ignore lint/suspicious/noExplicitAny: SSE event schemas are contract-specific, cast at call site
   sseContext: SSEContext<any>
   isStarted: () => boolean
-  markHandlerDone: () => void
   preserveStreamOnError: () => void
 } {
   // @fastify/sse is an optional peer and Fastify silently ignores the unknown `sse` route
@@ -146,7 +145,6 @@ export function buildApiSSEContext(
   }
 
   let started = false
-  let sessionMode: SSESessionMode | undefined
   let closedByServer = false
 
   const sseContext: SSEContext = {
@@ -161,7 +159,18 @@ export function buildApiSSEContext(
       validateApiResponseHeaders(responseHeaderSchema, reply)
 
       started = true
-      sessionMode = mode
+
+      // Every server-initiated close funnels through reply.sse.close() — session.close(),
+      // a global error handler ending an errored stream, and @fastify/sse's own close of a
+      // non-keepAlive session after the handler completes. Wrapping it attributes the close
+      // to the server at the moment it actually happens. A client disconnect never calls
+      // close() (the plugin reacts to the raw socket 'close' event directly), so it keeps
+      // reporting 'client'.
+      const pluginClose = reply.sse.close.bind(reply.sse)
+      reply.sse.close = () => {
+        closedByServer = true
+        pluginClose()
+      }
 
       if (mode === 'keepAlive') {
         reply.sse.keepAlive()
@@ -226,7 +235,6 @@ export function buildApiSSEContext(
           }
         },
         close: () => {
-          closedByServer = true
           reply.sse.close()
         },
       }
@@ -272,27 +280,16 @@ export function buildApiSSEContext(
   return {
     sseContext,
     isStarted: () => started,
-    // An autoClose session is closed by @fastify/sse when the handler completes — that close
-    // is server-initiated. Called after the handler resolves, before the close fires; if the
-    // client already disconnected mid-stream, onClose has fired with 'client' and this is moot.
-    markHandlerDone: () => {
-      if (sessionMode === 'autoClose') {
-        closedByServer = true
-      }
-    },
     // An error escaping the handler after the stream is committed must not tear the
     // connection down: @fastify/sse closes non-keepAlive sessions before rethrowing, so
     // the error would reach the global error handler on an already-ended stream. Flagging
     // keep-alive hands the still-open stream to the error handler, which owns serializing
-    // the error into a terminal SSE event and closing the connection (a server-initiated
-    // close). A no-op before `start()` — an uncommitted reply goes through the regular
-    // HTTP error path.
+    // the error into a terminal SSE event and closing the stream. A no-op before `start()`
+    // — an uncommitted reply goes through the regular HTTP error path.
     preserveStreamOnError: () => {
-      if (!started) {
-        return
+      if (started) {
+        reply.sse.keepAlive()
       }
-      closedByServer = true
-      reply.sse.keepAlive()
     },
   }
 }

--- a/packages/app/fastify-api-contracts/src/api-contracts/sseUtils.ts
+++ b/packages/app/fastify-api-contracts/src/api-contracts/sseUtils.ts
@@ -117,7 +117,7 @@ function resolveSseSelection(
 
 /**
  * Build the `sse` context passed to SSE-capable handlers, plus the lifecycle probes the
- * route runtime needs (`isStarted`, `markHandlerDone`).
+ * route runtime needs (`isStarted`, `markHandlerDone`, `preserveStreamOnError`).
  *
  * `start()` validates the reply's headers against `responseHeaderSchema` before flushing
  * them — the only moment a violation can still become a 500 instead of going out on an
@@ -134,6 +134,7 @@ export function buildApiSSEContext(
   sseContext: SSEContext<any>
   isStarted: () => boolean
   markHandlerDone: () => void
+  preserveStreamOnError: () => void
 } {
   // @fastify/sse is an optional peer and Fastify silently ignores the unknown `sse` route
   // option when it is not registered — without this guard the request dies on an opaque
@@ -278,6 +279,20 @@ export function buildApiSSEContext(
       if (sessionMode === 'autoClose') {
         closedByServer = true
       }
+    },
+    // An error escaping the handler after the stream is committed must not tear the
+    // connection down: @fastify/sse closes non-keepAlive sessions before rethrowing, so
+    // the error would reach the global error handler on an already-ended stream. Flagging
+    // keep-alive hands the still-open stream to the error handler, which owns serializing
+    // the error into a terminal SSE event and closing the connection (a server-initiated
+    // close). A no-op before `start()` — an uncommitted reply goes through the regular
+    // HTTP error path.
+    preserveStreamOnError: () => {
+      if (!started) {
+        return
+      }
+      closedByServer = true
+      reply.sse.keepAlive()
     },
   }
 }


### PR DESCRIPTION
## Summary

When an error escaped an SSE-capable route handler after `sse.start()`, `@fastify/sse` closed the committed stream before rethrowing (its handler wrapper calls `context.close()` for non-keepAlive sessions on the error path). By the time the error reached the global error handler, the connection was already gone, so an SSE-aware error handler (fastify-extras) could not serialize the error into a terminal SSE event.

## Changes

- `buildApiSSEContext` now exposes a `preserveStreamOnError()` probe: once the stream is started, it flags the session keep-alive (making the plugin's error-path close a no-op) and marks the eventual close as server-initiated for `onClose`. It is a no-op before `sse.start()`.
- `handleApiRoute` wraps handler execution (both the imperative `sse.start()` path and the async-iterable body path) in a try/catch that calls the probe and rethrows, so the error propagates to the global error handler with the stream still connected. The error handler is then responsible for sending a terminal error event and closing the stream.
- Errors thrown before the stream starts keep the regular HTTP error response path.

## Tests

- Error after `sse.start()` reaches a global error handler with the stream still connected; the error event goes out on the open stream.
- Same for an async-iterable body that throws mid-stream.
- `onClose` reports `'server'` as the initiator when the error handler closes the errored stream.
- A throw before `sse.start()` still returns a regular JSON 500.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**