### PR TITLE
feat(universal-testing-utils): request-derived mocks for defineApiContract

### DIFF
--- a/.changeset/api-contract-mock-implementation.md
+++ b/.changeset/api-contract-mock-implementation.md
@@ -1,0 +1,13 @@
+---
+"@lokalise/universal-testing-utils": minor
+---
+
+Add `mockResponseWithImplementation` to `ApiContractMockttpHelper` and `ApiContractMswHelper`, so
+`defineApiContract` contracts can be mocked with a body computed from the incoming request. Until
+now this only existed as `MswHelper.mockValidResponseWithImplementation`, which is tied to the
+legacy `buildRestContract`/`buildSseContract` definitions, so the only option for a new-style
+contract was a fixed `mockResponse` body.
+
+`responseStatus` selects the contract entry, which types `handleRequest`'s return value and
+supplies the schema its result is validated against. Both helpers also gain a static `response()`
+for overriding the status on a single call, sharing the wrapper with `MswHelper.response()`.

--- a/.changeset/api-contract-mock-implementation.md
+++ b/.changeset/api-contract-mock-implementation.md
@@ -9,5 +9,13 @@ legacy `buildRestContract`/`buildSseContract` definitions, so the only option fo
 contract was a fixed `mockResponse` body.
 
 `responseStatus` selects the contract entry, which types `handleRequest`'s return value and
-supplies the schema its result is validated against. Both helpers also gain a static `response()`
-for overriding the status on a single call, sharing the wrapper with `MswHelper.response()`.
+supplies the schema its result is validated against. `contentType` picks between JSON media types
+when the entry declares more than one, and the reply carries the media type the contract declared
+it under, so an `application/problem+json` entry is not flattened to `application/json`. The
+handler's request argument is typed from the contract's `requestBodySchema`.
+
+Both helpers also gain a static `response()` for overriding the status on a single call, sharing
+the wrapper with `MswHelper.response()`. An overridden status is resolved against its own contract
+entry, so the wrapped body is validated against the schema for the status actually sent. Handler
+and validation failures are reported through `console.error` and a labelled 500 rather than the
+opaque one mockttp and msw produce for a throwing route callback.

--- a/packages/app/universal-testing-utils/README.md
+++ b/packages/app/universal-testing-utils/README.md
@@ -255,14 +255,14 @@ await helper.mockResponse(contract, { responseStatus: 201, responseJson: { id: '
 
 `mockResponse` takes a fixed body. When the response has to depend on what the caller sent, use `mockResponseWithImplementation` and return the body from a handler.
 
-`responseStatus` still selects the contract entry, which is what types `handleRequest`'s return value and supplies the Zod schema the result is validated against. Only JSON entries are addressable this way: SSE and blob responses stay static, via `mockResponse`.
+`responseStatus` still selects the contract entry, which is what types `handleRequest`'s return value and supplies the Zod schema the result is validated against. The handler's request argument is typed from the contract too, so `request.body.getJson()` (mockttp) and `request.json()` (msw) hand back the output of the contract's `requestBodySchema` rather than `unknown`. Only JSON entries are addressable this way: SSE and blob responses stay static, via `mockResponse`.
 
 ```ts
 // mockttp: the handler receives the mockttp CompletedRequest
 await helper.mockResponseWithImplementation(postUserContract, {
   responseStatus: 200,
   handleRequest: async (request) => {
-    const body = await request.body.getJson()
+    const body = await request.body.getJson() // typed by requestBodySchema
     return { id: `id-${body.name}` }
   },
 })
@@ -271,7 +271,7 @@ await helper.mockResponseWithImplementation(postUserContract, {
 helper.mockResponseWithImplementation(postUserContract, {
   responseStatus: 200,
   handleRequest: async ({ request }) => {
-    const body = await request.json()
+    const body = await request.json() // typed by requestBodySchema
     return { id: `id-${body.name}` }
   },
 })
@@ -280,9 +280,36 @@ helper.mockResponseWithImplementation(postUserContract, {
 await helper.mockResponseWithImplementation(getUserContract, {
   pathParams: { userId: '7' },
   responseStatus: 200,
-  handleRequest: (request) => ({ id: request.path.split('/').pop() }),
+  handleRequest: (request) => ({ id: request.path.split('/').pop() ?? '' }),
 })
 ```
+
+#### Picking the media type with `contentType`
+
+The response goes out under the media type the contract declares it for, so an `application/problem+json` entry is served as `application/problem+json` rather than `application/json`. When a status entry declares more than one JSON media type, pass `contentType` to say which one the handler is answering with; the selected descriptor then types the handler's result:
+
+```ts
+const contract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/items',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({ id: z.string() }),
+        'application/problem+json': z.object({ title: z.string(), detail: z.string() }),
+      },
+    },
+  },
+})
+
+await helper.mockResponseWithImplementation(contract, {
+  responseStatus: 200,
+  contentType: 'application/problem+json',
+  handleRequest: () => ({ title: 'Invalid', detail: 'Something went wrong' }),
+})
+```
+
+`contentType` is required whenever the choice would be ambiguous and optional otherwise. It only names JSON entries: pointing it at an SSE or blob descriptor throws, as does a status entry with no JSON body at all. A status that also declares `text/event-stream` still serves JSON here, but a request negotiating the SSE branch through `Accept` gets a 406 rather than a JSON body it cannot read. Mock that branch with `mockResponse`.
 
 #### Per-call status codes with `response()`
 
@@ -295,16 +322,28 @@ await helper.mockResponseWithImplementation(getUserContract, {
   handleRequest: () => {
     callCount++
     if (callCount === 1) {
-      return ApiContractMockttpHelper.response({ id: 'first' }, { status: 500 })
+      return ApiContractMockttpHelper.response({ message: 'nope' }, { status: 404 })
     }
     return { id: 'second' } // a plain body still replies with responseStatus
   },
 })
 ```
 
+An overridden status selects its own contract entry, so the wrapped body is validated against the schema declared for the status actually being sent: `{ message: 'nope' }` above has to satisfy the contract's `'4xx'` entry, not its `200` one. Overriding to a status the contract does not declare is an error.
+
 `ApiContractMswHelper.response()` is the msw equivalent, and both share the wrapper with `MswHelper.response()`.
 
 Status code priority: `response({ status })` > `responseStatus`.
+
+#### When a handler fails
+
+mockttp and msw both turn a throwing route callback into a bare 500, which reaches the test as a client-side parse failure with the cause nowhere in sight. A handler that throws, or that returns a body the contract schema rejects, instead produces a 500 whose body carries the reason, logged through `console.error` alongside the contract it came from:
+
+```
+[ApiContractMockttpHelper.mockResponseWithImplementation] POST /users/:userId: ZodError: ...
+```
+
+Setup-time problems (an unmapped status, a status with no JSON body, an ambiguous or unmatched `contentType`) still throw from `mockResponseWithImplementation` itself, where the stack points at the test that set the mock up.
 
 ### Type safety
 

--- a/packages/app/universal-testing-utils/README.md
+++ b/packages/app/universal-testing-utils/README.md
@@ -16,6 +16,7 @@ Reusable testing utilities that are potentially relevant for both backend and fr
 - [ApiContractMockttpHelper](#apicontractmockttphelper)
   - [Setup](#setup)
   - [mockResponse](#mockresponse)
+  - [mockResponseWithImplementation](#mockresponsewithimplementation)
   - [Type safety](#type-safety)
 - [ApiContractMswHelper](#apicontractmswhelper)
 - [msw integration with API contracts](#msw-integration-with-api-contracts)
@@ -250,6 +251,61 @@ await helper.mockResponse(contract, { responseStatus: 201, responseJson: { id: '
 - **`ExactStatusCodePairs`** — one member per exact numeric key in `responsesByStatusCode`. `responseStatus` is that literal number and the body fields come from the entry at that key.
 - **`RangeStatusCodePairs`** — one member per wildcard key (`'1xx'`–`'5xx'`, `'default'`). `ExpandStatusRangeKey<K>` expands the key to its numeric union (e.g. `'2xx'` → `200|201|…|299`), then exact codes already covered by `ExactStatusCodePairs` are excluded via `Exclude` so the discriminated union stays unambiguous.
 
+### mockResponseWithImplementation
+
+`mockResponse` takes a fixed body. When the response has to depend on what the caller sent, use `mockResponseWithImplementation` and return the body from a handler.
+
+`responseStatus` still selects the contract entry, which is what types `handleRequest`'s return value and supplies the Zod schema the result is validated against. Only JSON entries are addressable this way: SSE and blob responses stay static, via `mockResponse`.
+
+```ts
+// mockttp: the handler receives the mockttp CompletedRequest
+await helper.mockResponseWithImplementation(postUserContract, {
+  responseStatus: 200,
+  handleRequest: async (request) => {
+    const body = await request.body.getJson()
+    return { id: `id-${body.name}` }
+  },
+})
+
+// msw: the handler receives the msw request info
+helper.mockResponseWithImplementation(postUserContract, {
+  responseStatus: 200,
+  handleRequest: async ({ request }) => {
+    const body = await request.json()
+    return { id: `id-${body.name}` }
+  },
+})
+
+// with path params
+await helper.mockResponseWithImplementation(getUserContract, {
+  pathParams: { userId: '7' },
+  responseStatus: 200,
+  handleRequest: (request) => ({ id: request.path.split('/').pop() }),
+})
+```
+
+#### Per-call status codes with `response()`
+
+By default every call replies with `responseStatus`. To vary it per call, wrap the returned body with the helper's static `response()`:
+
+```ts
+let callCount = 0
+await helper.mockResponseWithImplementation(getUserContract, {
+  responseStatus: 200,
+  handleRequest: () => {
+    callCount++
+    if (callCount === 1) {
+      return ApiContractMockttpHelper.response({ id: 'first' }, { status: 500 })
+    }
+    return { id: 'second' } // a plain body still replies with responseStatus
+  },
+})
+```
+
+`ApiContractMswHelper.response()` is the msw equivalent, and both share the wrapper with `MswHelper.response()`.
+
+Status code priority: `response({ status })` > `responseStatus`.
+
 ### Type safety
 
 `MockResponseParams<TContract>` is exported for cases where you need to type the params object separately:
@@ -282,6 +338,8 @@ helper.mockResponse(contract, {
   responseJson: { id: '1' },
 })
 ```
+
+[`mockResponseWithImplementation`](#mockresponsewithimplementation) and the static `response()` are available here too, with `handleRequest` receiving msw's request info instead of a mockttp `CompletedRequest`.
 
 ## msw integration with API contracts
 

--- a/packages/app/universal-testing-utils/src/MswHelper.ts
+++ b/packages/app/universal-testing-utils/src/MswHelper.ts
@@ -20,6 +20,13 @@ import {
 import type { SetupServer } from 'msw/node'
 import type { ZodObject, z } from 'zod/v4'
 import { formatSseResponse, type SseMockEvent } from './MockttpHelper.ts'
+import {
+  type MockResponseWrapper,
+  unwrapMockResponse,
+  wrapMockResponse,
+} from './responseWrapper.ts'
+
+export type { MockResponseWrapper } from './responseWrapper.ts'
 
 export type CommonMockParams = {
   responseCode?: number
@@ -111,14 +118,6 @@ export type SseEventController<Events extends SSEEventSchemas> = {
   close(): void
 }
 
-const RESPONSE_BRAND = Symbol('MswHelperResponse')
-
-export type MockResponseWrapper<T> = {
-  readonly [RESPONSE_BRAND]: true
-  readonly body: T
-  readonly status?: number
-}
-
 export class MswHelper {
   private readonly baseUrl: string
 
@@ -127,14 +126,11 @@ export class MswHelper {
   }
 
   static response<T>(body: T, options?: { status?: number }): MockResponseWrapper<T> {
-    return { [RESPONSE_BRAND]: true, body, status: options?.status }
+    return wrapMockResponse(body, options)
   }
 
   private static unwrapResponse(result: any): { body: any; status?: number } {
-    if (result && typeof result === 'object' && RESPONSE_BRAND in result) {
-      return { body: result.body, status: result.status }
-    }
-    return { body: result }
+    return unwrapMockResponse(result)
   }
 
   private resolveParams<PathParamsSchema extends z.Schema | undefined>(

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
@@ -1,6 +1,6 @@
 import { sendByApiContract } from '@lokalise/frontend-http-client'
 import { getLocal } from 'mockttp'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest'
 import wretch from 'wretch'
 import {
   blobContentApiContract,
@@ -18,6 +18,7 @@ import {
   getApiContractWithPathAndQueryParams,
   getApiContractWithPathParams,
   getApiContractWithQueryParams,
+  getApiContractWithSuccessAndErrorStatuses,
   jsonAndBlobContentApiContract,
   jsonContentApiContract,
   multiJsonContentApiContract,
@@ -26,6 +27,7 @@ import {
   patchApiContract,
   postApiContract,
   postApiContractWithPathParams,
+  problemJsonContentApiContract,
   putApiContract,
   sseContentApiContract,
   sseGetApiContract,
@@ -496,149 +498,318 @@ describe('ApiContractMockttpHelper', () => {
       expect(response.status).toBe(503)
     })
   })
-})
 
-describe('ApiContractMockttpHelper.mockResponseWithImplementation', () => {
-  const mockServer = getLocal()
-  const helper = new ApiContractMockttpHelper(mockServer)
+  describe('mockResponseWithImplementation', () => {
+    // The helper reports handler and validation failures through console.error, since the
+    // frameworks would otherwise bury them in an opaque 500.
+    let failureLog: MockInstance<typeof console.error>
 
-  beforeEach(async () => {
-    await mockServer.start()
-  })
-  afterEach(() => mockServer.stop())
-
-  function client() {
-    return wretch(mockServer.url)
-  }
-
-  it('derives the response body from the request body', async () => {
-    await helper.mockResponseWithImplementation(postApiContract, {
-      responseStatus: 200,
-      handleRequest: async (request) => {
-        const body = (await request.body.getJson()) as { name: string }
-        return { id: `id-${body.name}` }
-      },
+    beforeEach(() => {
+      failureLog = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      vi.restoreAllMocks()
     })
 
-    const result = await sendByApiContract(client(), postApiContract, {
-      body: { name: 'ragnarok' },
-    })
-
-    expect(result.result?.body).toEqual({ id: 'id-ragnarok' })
-  })
-
-  it('derives the response body from the request path', async () => {
-    await helper.mockResponseWithImplementation(getApiContractWithPathParams, {
-      pathParams: { userId: '7' },
-      responseStatus: 200,
-      handleRequest: (request) => ({ id: request.path.split('/').pop() ?? '' }),
-    })
-
-    const result = await sendByApiContract(client(), getApiContractWithPathParams, {
-      pathParams: { userId: '7' },
-    })
-
-    expect(result.result?.body).toEqual({ id: '7' })
-  })
-
-  it('enforces the contract schema on the handler result', async () => {
-    await helper.mockResponseWithImplementation(getApiContract, {
-      responseStatus: 200,
-      // @ts-expect-error handler must return the contract response body
-      handleRequest: () => ({ wrong: 'x' }),
-    })
-
-    const result = await sendByApiContract(client(), getApiContract, {})
-
-    expect(result.error).toBeDefined()
-  })
-
-  it('strips unknown properties from the handler result', async () => {
-    await helper.mockResponseWithImplementation(getApiContract, {
-      responseStatus: 200,
-      handleRequest: () => ({ id: '1', extra: 'x' }),
-    })
-
-    const result = await sendByApiContract(client(), getApiContract, {})
-
-    expect(result.result?.body).toEqual({ id: '1' })
-  })
-
-  it('varies the status code per call via response()', async () => {
-    let callCount = 0
-    await helper.mockResponseWithImplementation(getApiContractWithExactAndRange, {
-      responseStatus: 200,
-      handleRequest: () => {
-        callCount++
-        if (callCount === 1) {
-          return ApiContractMockttpHelper.response({ id: 'first' }, { status: 500 })
-        }
-        return { id: 'second' }
-      },
-    })
-
-    const first = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
-    const second = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
-
-    expect(first.error).toBeDefined()
-    expect(second.result?.statusCode).toBe(200)
-    expect(second.result?.body).toEqual({ id: 'second' })
-  })
-
-  it('resolves the body schema through a range status key', async () => {
-    await helper.mockResponseWithImplementation(getApiContractWith4xxRange, {
-      responseStatus: 404,
-      handleRequest: () => ({ id: 'missing' }),
-    })
-
-    const response = await fetch(`${mockServer.url}/not-found`)
-
-    expect(response.status).toBe(404)
-    await expect(response.json()).resolves.toEqual({ id: 'missing' })
-  })
-
-  it('resolves the body schema from a JSON content map', async () => {
-    await helper.mockResponseWithImplementation(jsonContentApiContract, {
-      responseStatus: 200,
-      handleRequest: () => ({ id: 'from-content-map' }),
-    })
-
-    const result = await sendByApiContract(client(), jsonContentApiContract, {})
-
-    expect(result.result?.body).toEqual({ id: 'from-content-map' })
-  })
-
-  it('rejects a status the contract does not declare', async () => {
-    await expect(
-      helper.mockResponseWithImplementation(getApiContract, {
-        // @ts-expect-error 418 is not declared on the contract
-        responseStatus: 418,
-        handleRequest: () => ({ id: '1' }),
-      }),
-    ).rejects.toThrow('Specified responseStatus cannot be mapped with contract')
-  })
-
-  it('rejects an SSE-only status at the type level', async () => {
-    await expect(
-      helper.mockResponseWithImplementation(
-        sseGetApiContract,
-        // @ts-expect-error an SSE-only status leaves no JSON body for handleRequest to return
-        { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
-      ),
-    ).rejects.toThrow('use mockResponse for SSE and blob responses')
-  })
-
-  it('rejects a status whose body has no JSON representation at runtime', async () => {
-    // Guards untyped callers, for whom the type-level rejection above does not apply.
-    const untypedHelper = helper as unknown as {
-      mockResponseWithImplementation: (contract: unknown, params: unknown) => Promise<void>
+    function loggedFailure(): string {
+      return failureLog.mock.calls.map(([message]) => String(message)).join('\n')
     }
 
-    await expect(
-      untypedHelper.mockResponseWithImplementation(sseGetApiContract, {
+    it('derives the response body from the request body', async () => {
+      await helper.mockResponseWithImplementation(postApiContract, {
         responseStatus: 200,
-        handleRequest: () => ({ id: '1' }),
-      }),
-    ).rejects.toThrow('use mockResponse for SSE and blob responses')
+        handleRequest: async (request) => {
+          const body = await request.body.getJson()
+          return { id: `id-${body.name}` }
+        },
+      })
+
+      const result = await sendByApiContract(client(), postApiContract, {
+        body: { name: 'ragnarok' },
+      })
+
+      expect(result.result?.body).toEqual({ id: 'id-ragnarok' })
+    })
+
+    it('derives the response body from the request path', async () => {
+      await helper.mockResponseWithImplementation(getApiContractWithPathParams, {
+        pathParams: { userId: '7' },
+        responseStatus: 200,
+        handleRequest: (request) => ({ id: request.path.split('/').pop() ?? '' }),
+      })
+
+      const result = await sendByApiContract(client(), getApiContractWithPathParams, {
+        pathParams: { userId: '7' },
+      })
+
+      expect(result.result?.body).toEqual({ id: '7' })
+    })
+
+    it('strips unknown properties from the handler result', async () => {
+      await helper.mockResponseWithImplementation(getApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ id: '1', extra: 'x' }),
+      })
+
+      const result = await sendByApiContract(client(), getApiContract, {})
+
+      expect(result.result?.body).toEqual({ id: '1' })
+    })
+
+    it('replies with the declared JSON media type, not application/json', async () => {
+      await helper.mockResponseWithImplementation(problemJsonContentApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ title: 'Invalid', detail: 'Something went wrong' }),
+      })
+
+      const response = await fetch(`${mockServer.url}/content-problem-json`)
+      expect(response.headers.get('content-type')).toBe('application/problem+json')
+
+      const result = await sendByApiContract(client(), problemJsonContentApiContract, {})
+      expect(result.result?.body).toEqual({ title: 'Invalid', detail: 'Something went wrong' })
+    })
+
+    it('serves the JSON media type selected via contentType', async () => {
+      await helper.mockResponseWithImplementation(multiJsonContentApiContract, {
+        responseStatus: 200,
+        contentType: 'application/problem+json',
+        handleRequest: () => ({ title: 'Invalid', detail: 'Something went wrong' }),
+      })
+
+      const response = await fetch(`${mockServer.url}/content-multi-json`)
+
+      expect(response.headers.get('content-type')).toBe('application/problem+json')
+      await expect(response.json()).resolves.toEqual({
+        title: 'Invalid',
+        detail: 'Something went wrong',
+      })
+    })
+
+    it('requires contentType when the status declares several JSON media types', async () => {
+      await expect(
+        helper.mockResponseWithImplementation(
+          multiJsonContentApiContract,
+          // @ts-expect-error contentType is required when the choice of media type is ambiguous
+          { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
+        ),
+      ).rejects.toThrow(
+        'Status 200 declares more than one JSON content type (application/json, application/problem+json); pass contentType to select one',
+      )
+    })
+
+    it('serves the JSON entry of a content map that also declares a blob', async () => {
+      await helper.mockResponseWithImplementation(jsonAndBlobContentApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ id: 'from-json-side' }),
+      })
+
+      const response = await fetch(`${mockServer.url}/content-json-blob`)
+
+      expect(response.headers.get('content-type')).toBe('application/json')
+      await expect(response.json()).resolves.toEqual({ id: 'from-json-side' })
+    })
+
+    it('resolves the body schema through a range status key', async () => {
+      await helper.mockResponseWithImplementation(getApiContractWith4xxRange, {
+        responseStatus: 404,
+        handleRequest: () => ({ id: 'missing' }),
+      })
+
+      const response = await fetch(`${mockServer.url}/not-found`)
+
+      expect(response.status).toBe(404)
+      await expect(response.json()).resolves.toEqual({ id: 'missing' })
+    })
+
+    it('resolves the body schema from a JSON content map', async () => {
+      await helper.mockResponseWithImplementation(jsonContentApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ id: 'from-content-map' }),
+      })
+
+      const result = await sendByApiContract(client(), jsonContentApiContract, {})
+
+      expect(result.result?.body).toEqual({ id: 'from-content-map' })
+    })
+
+    describe('per-call status codes', () => {
+      it('validates the body against the entry for the overridden status', async () => {
+        let callCount = 0
+        await helper.mockResponseWithImplementation(getApiContractWithSuccessAndErrorStatuses, {
+          responseStatus: 200,
+          handleRequest: () => {
+            callCount++
+            if (callCount === 1) {
+              return ApiContractMockttpHelper.response({ message: 'nope' }, { status: 404 })
+            }
+            return { id: 'second' }
+          },
+        })
+
+        const first = await fetch(`${mockServer.url}/success-or-error`)
+        expect(first.status).toBe(404)
+        await expect(first.json()).resolves.toEqual({ message: 'nope' })
+
+        const second = await fetch(`${mockServer.url}/success-or-error`)
+        expect(second.status).toBe(200)
+        await expect(second.json()).resolves.toEqual({ id: 'second' })
+        expect(failureLog).not.toHaveBeenCalled()
+      })
+
+      it('reports an overridden status the contract does not declare', async () => {
+        await helper.mockResponseWithImplementation(getApiContract, {
+          responseStatus: 200,
+          handleRequest: () => ApiContractMockttpHelper.response({ id: '1' }, { status: 503 }),
+        })
+
+        const response = await fetch(mockServer.url)
+
+        expect(response.status).toBe(500)
+        expect(loggedFailure()).toContain(
+          'Status 503 passed to response() cannot be mapped with contract',
+        )
+      })
+    })
+
+    describe('failure reporting', () => {
+      it('reports a handler result the contract schema rejects', async () => {
+        await helper.mockResponseWithImplementation(getApiContract, {
+          responseStatus: 200,
+          // @ts-expect-error handler must return the contract response body
+          handleRequest: () => ({ wrong: 'x' }),
+        })
+
+        const response = await fetch(mockServer.url)
+
+        expect(response.status).toBe(500)
+        expect(loggedFailure()).toContain(
+          '[ApiContractMockttpHelper.mockResponseWithImplementation]',
+        )
+        expect(loggedFailure()).toContain('GET /')
+        expect(loggedFailure()).toContain('ZodError')
+      })
+
+      it('reports an exception thrown by the handler', async () => {
+        await helper.mockResponseWithImplementation(getApiContract, {
+          responseStatus: 200,
+          handleRequest: () => {
+            throw new Error('boom from handler')
+          },
+        })
+
+        const response = await fetch(mockServer.url)
+
+        expect(response.status).toBe(500)
+        expect(loggedFailure()).toContain('boom from handler')
+        await expect(response.json()).resolves.toEqual({
+          message: expect.stringContaining('boom from handler'),
+        })
+      })
+
+      it('refuses a request that negotiated the status entry SSE branch', async () => {
+        await helper.mockResponseWithImplementation(dualContentApiContract, {
+          responseStatus: 200,
+          handleRequest: () => ({ id: 'json-side' }),
+        })
+
+        const negotiated = await fetch(`${mockServer.url}/content-dual`, {
+          method: 'POST',
+          headers: { accept: 'text/event-stream' },
+          body: JSON.stringify({ name: 'x' }),
+        })
+
+        expect(negotiated.status).toBe(406)
+        expect(loggedFailure()).toContain('use mockResponse for the SSE branch')
+      })
+
+      it('serves the JSON branch of a dual content map to a plain request', async () => {
+        await helper.mockResponseWithImplementation(dualContentApiContract, {
+          responseStatus: 200,
+          handleRequest: () => ({ id: 'json-side' }),
+        })
+
+        const result = await sendByApiContract(client(), dualContentApiContract, {
+          streaming: false,
+          body: { name: 'x' },
+        })
+
+        expect(result.result?.body).toEqual({ id: 'json-side' })
+        expect(failureLog).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('statuses it refuses to mock', () => {
+      // Guards untyped callers, for whom the type-level rejections do not apply.
+      const untypedHelper = helper as unknown as {
+        mockResponseWithImplementation: (contract: unknown, params: unknown) => Promise<void>
+      }
+
+      it('rejects a status the contract does not declare', async () => {
+        await expect(
+          helper.mockResponseWithImplementation(getApiContract, {
+            // @ts-expect-error 418 is not declared on the contract
+            responseStatus: 418,
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).rejects.toThrow('Specified responseStatus cannot be mapped with contract')
+      })
+
+      it('rejects an SSE-only status at the type level', async () => {
+        await expect(
+          helper.mockResponseWithImplementation(
+            sseGetApiContract,
+            // @ts-expect-error an SSE-only status leaves no JSON body for handleRequest to return
+            { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
+          ),
+        ).rejects.toThrow(
+          'Status 200 has no JSON response body; use mockResponse for SSE and blob responses',
+        )
+      })
+
+      it('rejects a status whose body has no JSON representation at runtime', async () => {
+        await expect(
+          untypedHelper.mockResponseWithImplementation(blobContentApiContract, {
+            responseStatus: 200,
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).rejects.toThrow(
+          'Status 200 has no JSON response body; use mockResponse for SSE and blob responses',
+        )
+      })
+
+      it('rejects a no-body status without blaming SSE or blob', async () => {
+        await expect(
+          untypedHelper.mockResponseWithImplementation(noBodyContentApiContract, {
+            pathParams: { userId: '7' },
+            responseStatus: 204,
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).rejects.toThrow(
+          'Status 204 declares no response body; mockResponseWithImplementation needs a JSON body to return',
+        )
+      })
+
+      it('rejects a contentType the status does not declare', async () => {
+        await expect(
+          untypedHelper.mockResponseWithImplementation(jsonContentApiContract, {
+            responseStatus: 200,
+            contentType: 'text/plain',
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).rejects.toThrow('Specified contentType cannot be mapped with contract')
+      })
+
+      it('rejects a contentType that names a non-JSON descriptor', async () => {
+        await expect(
+          untypedHelper.mockResponseWithImplementation(jsonAndBlobContentApiContract, {
+            responseStatus: 200,
+            contentType: 'application/octet-stream',
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).rejects.toThrow(
+          'Specified contentType application/octet-stream is not a JSON body; use mockResponse for SSE and blob responses',
+        )
+      })
+    })
   })
 })

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.spec.ts
@@ -497,3 +497,148 @@ describe('ApiContractMockttpHelper', () => {
     })
   })
 })
+
+describe('ApiContractMockttpHelper.mockResponseWithImplementation', () => {
+  const mockServer = getLocal()
+  const helper = new ApiContractMockttpHelper(mockServer)
+
+  beforeEach(async () => {
+    await mockServer.start()
+  })
+  afterEach(() => mockServer.stop())
+
+  function client() {
+    return wretch(mockServer.url)
+  }
+
+  it('derives the response body from the request body', async () => {
+    await helper.mockResponseWithImplementation(postApiContract, {
+      responseStatus: 200,
+      handleRequest: async (request) => {
+        const body = (await request.body.getJson()) as { name: string }
+        return { id: `id-${body.name}` }
+      },
+    })
+
+    const result = await sendByApiContract(client(), postApiContract, {
+      body: { name: 'ragnarok' },
+    })
+
+    expect(result.result?.body).toEqual({ id: 'id-ragnarok' })
+  })
+
+  it('derives the response body from the request path', async () => {
+    await helper.mockResponseWithImplementation(getApiContractWithPathParams, {
+      pathParams: { userId: '7' },
+      responseStatus: 200,
+      handleRequest: (request) => ({ id: request.path.split('/').pop() ?? '' }),
+    })
+
+    const result = await sendByApiContract(client(), getApiContractWithPathParams, {
+      pathParams: { userId: '7' },
+    })
+
+    expect(result.result?.body).toEqual({ id: '7' })
+  })
+
+  it('enforces the contract schema on the handler result', async () => {
+    await helper.mockResponseWithImplementation(getApiContract, {
+      responseStatus: 200,
+      // @ts-expect-error handler must return the contract response body
+      handleRequest: () => ({ wrong: 'x' }),
+    })
+
+    const result = await sendByApiContract(client(), getApiContract, {})
+
+    expect(result.error).toBeDefined()
+  })
+
+  it('strips unknown properties from the handler result', async () => {
+    await helper.mockResponseWithImplementation(getApiContract, {
+      responseStatus: 200,
+      handleRequest: () => ({ id: '1', extra: 'x' }),
+    })
+
+    const result = await sendByApiContract(client(), getApiContract, {})
+
+    expect(result.result?.body).toEqual({ id: '1' })
+  })
+
+  it('varies the status code per call via response()', async () => {
+    let callCount = 0
+    await helper.mockResponseWithImplementation(getApiContractWithExactAndRange, {
+      responseStatus: 200,
+      handleRequest: () => {
+        callCount++
+        if (callCount === 1) {
+          return ApiContractMockttpHelper.response({ id: 'first' }, { status: 500 })
+        }
+        return { id: 'second' }
+      },
+    })
+
+    const first = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
+    const second = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
+
+    expect(first.error).toBeDefined()
+    expect(second.result?.statusCode).toBe(200)
+    expect(second.result?.body).toEqual({ id: 'second' })
+  })
+
+  it('resolves the body schema through a range status key', async () => {
+    await helper.mockResponseWithImplementation(getApiContractWith4xxRange, {
+      responseStatus: 404,
+      handleRequest: () => ({ id: 'missing' }),
+    })
+
+    const response = await fetch(`${mockServer.url}/not-found`)
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ id: 'missing' })
+  })
+
+  it('resolves the body schema from a JSON content map', async () => {
+    await helper.mockResponseWithImplementation(jsonContentApiContract, {
+      responseStatus: 200,
+      handleRequest: () => ({ id: 'from-content-map' }),
+    })
+
+    const result = await sendByApiContract(client(), jsonContentApiContract, {})
+
+    expect(result.result?.body).toEqual({ id: 'from-content-map' })
+  })
+
+  it('rejects a status the contract does not declare', async () => {
+    await expect(
+      helper.mockResponseWithImplementation(getApiContract, {
+        // @ts-expect-error 418 is not declared on the contract
+        responseStatus: 418,
+        handleRequest: () => ({ id: '1' }),
+      }),
+    ).rejects.toThrow('Specified responseStatus cannot be mapped with contract')
+  })
+
+  it('rejects an SSE-only status at the type level', async () => {
+    await expect(
+      helper.mockResponseWithImplementation(
+        sseGetApiContract,
+        // @ts-expect-error an SSE-only status leaves no JSON body for handleRequest to return
+        { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
+      ),
+    ).rejects.toThrow('use mockResponse for SSE and blob responses')
+  })
+
+  it('rejects a status whose body has no JSON representation at runtime', async () => {
+    // Guards untyped callers, for whom the type-level rejection above does not apply.
+    const untypedHelper = helper as unknown as {
+      mockResponseWithImplementation: (contract: unknown, params: unknown) => Promise<void>
+    }
+
+    await expect(
+      untypedHelper.mockResponseWithImplementation(sseGetApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ id: '1' }),
+      }),
+    ).rejects.toThrow('use mockResponse for SSE and blob responses')
+  })
+})

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -1,18 +1,26 @@
 import {
   type ApiContract,
+  type HttpStatusCode,
   isBlobBody,
   isContentResponseEntry,
   isJsonBody,
   isSseBody,
   mapApiContractToPath,
 } from '@lokalise/api-contracts'
-import type { Mockttp, RequestRuleBuilder } from 'mockttp'
+import type { CompletedRequest, Mockttp, RequestRuleBuilder } from 'mockttp'
 import type { z } from 'zod/v4'
 import {
+  type MockResponseWrapper,
+  unwrapMockResponse,
+  wrapMockResponse,
+} from '../responseWrapper.ts'
+import {
   formatSseResponse,
+  type MockImplementationParams,
   type MockResponseParams,
   resolveContractEntry,
   resolveExplicitContentBody,
+  resolveJsonSchema,
 } from './types.ts'
 
 type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
@@ -22,6 +30,14 @@ export class ApiContractMockttpHelper {
 
   constructor(mockServer: Mockttp) {
     this.mockServer = mockServer
+  }
+
+  /**
+   * Wraps a body returned from `handleRequest` so it carries its own status code, overriding
+   * the mock's `responseStatus` for that call.
+   */
+  static response<T>(body: T, options?: { status?: number }): MockResponseWrapper<T> {
+    return wrapMockResponse(body, options)
   }
 
   private resolveMethodBuilder(method: HttpMethod, path: string): RequestRuleBuilder {
@@ -133,6 +149,46 @@ export class ApiContractMockttpHelper {
     const body = responseEntry.parse(anyParams.responseJson)
     await mockRule.thenReply(statusCode, JSON.stringify(body), {
       'content-type': 'application/json',
+    })
+  }
+
+  /**
+   * Mocks a JSON response whose body is computed from the incoming request.
+   *
+   * `responseStatus` picks the contract entry that types `handleRequest`'s return value. Return a
+   * bare body to reply with that status, or wrap it with {@link ApiContractMockttpHelper.response}
+   * to override the status for a single call.
+   */
+  async mockResponseWithImplementation<TContract extends ApiContract>(
+    contract: TContract,
+    params: MockImplementationParams<TContract, CompletedRequest>,
+  ): Promise<void> {
+    // biome-ignore lint/suspicious/noExplicitAny: field access is safe, the public signature enforces the type
+    const anyParams = params as any
+    const path = this.resolvePath(contract, params.pathParams)
+    const statusCode = anyParams.responseStatus as HttpStatusCode
+    const responseEntry = resolveContractEntry(contract.responsesByStatusCode, statusCode)
+
+    if (!responseEntry) {
+      throw new Error('Specified responseStatus cannot be mapped with contract')
+    }
+
+    const jsonSchema = resolveJsonSchema(responseEntry)
+    if (!jsonSchema) {
+      throw new Error(
+        'Specified responseStatus has no JSON response body; use mockResponse for SSE and blob responses',
+      )
+    }
+
+    await this.resolveMethodBuilder(contract.method, path).thenCallback(async (request) => {
+      const result = await anyParams.handleRequest(request)
+      const { body, status } = unwrapMockResponse(result)
+
+      return {
+        statusCode: status ?? statusCode,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(jsonSchema.parse(body)),
+      }
     })
   }
 }

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMockttpHelper.ts
@@ -9,21 +9,38 @@ import {
 } from '@lokalise/api-contracts'
 import type { CompletedRequest, Mockttp, RequestRuleBuilder } from 'mockttp'
 import type { z } from 'zod/v4'
-import {
-  type MockResponseWrapper,
-  unwrapMockResponse,
-  wrapMockResponse,
-} from '../responseWrapper.ts'
+import { type MockResponseWrapper, wrapMockResponse } from '../responseWrapper.ts'
 import {
   formatSseResponse,
   type MockImplementationParams,
   type MockResponseParams,
   resolveContractEntry,
   resolveExplicitContentBody,
-  resolveJsonSchema,
+  resolveJsonTargetForStatus,
+  runMockImplementation,
 } from './types.ts'
 
 type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
+
+/** Request body type the contract declares, or `unknown` for a contract that declares none. */
+type InferRequestBody<TContract extends ApiContract> =
+  TContract['requestBodySchema'] extends z.ZodType
+    ? z.output<TContract['requestBodySchema']>
+    : unknown
+
+/** mockttp's request, with `body.getJson()` typed by the contract's request body schema. */
+export type ApiContractCompletedRequest<TContract extends ApiContract> = Omit<
+  CompletedRequest,
+  'body'
+> & {
+  body: Omit<CompletedRequest['body'], 'getJson'> & {
+    getJson: () => Promise<InferRequestBody<TContract>>
+  }
+}
+
+function normalizeAccept(accept: string | string[] | undefined): string {
+  return Array.isArray(accept) ? accept.join(',') : (accept ?? '')
+}
 
 export class ApiContractMockttpHelper {
   private readonly mockServer: Mockttp
@@ -155,40 +172,36 @@ export class ApiContractMockttpHelper {
   /**
    * Mocks a JSON response whose body is computed from the incoming request.
    *
-   * `responseStatus` picks the contract entry that types `handleRequest`'s return value. Return a
-   * bare body to reply with that status, or wrap it with {@link ApiContractMockttpHelper.response}
-   * to override the status for a single call.
+   * `responseStatus` picks the contract entry that types `handleRequest`'s return value, and
+   * `contentType` picks between JSON media types when that entry declares more than one. Return a
+   * bare body to reply with `responseStatus`, or wrap it with
+   * {@link ApiContractMockttpHelper.response} to override the status for a single call.
    */
   async mockResponseWithImplementation<TContract extends ApiContract>(
     contract: TContract,
-    params: MockImplementationParams<TContract, CompletedRequest>,
+    params: MockImplementationParams<TContract, ApiContractCompletedRequest<TContract>>,
   ): Promise<void> {
     // biome-ignore lint/suspicious/noExplicitAny: field access is safe, the public signature enforces the type
     const anyParams = params as any
     const path = this.resolvePath(contract, params.pathParams)
-    const statusCode = anyParams.responseStatus as HttpStatusCode
-    const responseEntry = resolveContractEntry(contract.responsesByStatusCode, statusCode)
-
-    if (!responseEntry) {
-      throw new Error('Specified responseStatus cannot be mapped with contract')
-    }
-
-    const jsonSchema = resolveJsonSchema(responseEntry)
-    if (!jsonSchema) {
-      throw new Error(
-        'Specified responseStatus has no JSON response body; use mockResponse for SSE and blob responses',
-      )
-    }
+    const responseStatus = anyParams.responseStatus as HttpStatusCode
+    const target = resolveJsonTargetForStatus(
+      contract.responsesByStatusCode,
+      responseStatus,
+      anyParams.contentType,
+    )
 
     await this.resolveMethodBuilder(contract.method, path).thenCallback(async (request) => {
-      const result = await anyParams.handleRequest(request)
-      const { body, status } = unwrapMockResponse(result)
+      const { statusCode, mediaType, body } = await runMockImplementation({
+        helperName: 'ApiContractMockttpHelper',
+        contract,
+        responseStatus,
+        target,
+        accept: normalizeAccept(request.headers.accept),
+        handleRequest: () => anyParams.handleRequest(request),
+      })
 
-      return {
-        statusCode: status ?? statusCode,
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(jsonSchema.parse(body)),
-      }
+      return { statusCode, headers: { 'content-type': mediaType }, body }
     })
   }
 }

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
@@ -504,3 +504,130 @@ describe('ApiContractMswHelper', () => {
     })
   })
 })
+
+describe('ApiContractMswHelper.mockResponseWithImplementation', () => {
+  const server = setupServer()
+  const helper = new ApiContractMswHelper(server, BASE_URL)
+
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'error' })
+  })
+  afterEach(() => {
+    server.resetHandlers()
+  })
+  afterAll(() => {
+    server.close()
+  })
+
+  function client() {
+    return wretch(BASE_URL)
+  }
+
+  it('derives the response body from the request body', async () => {
+    helper.mockResponseWithImplementation(postApiContract, {
+      responseStatus: 200,
+      handleRequest: async ({ request }) => {
+        const body = (await request.json()) as { name: string }
+        return { id: `id-${body.name}` }
+      },
+    })
+
+    const result = await sendByApiContract(client(), postApiContract, {
+      body: { name: 'ragnarok' },
+    })
+
+    expect(result.result?.body).toEqual({ id: 'id-ragnarok' })
+  })
+
+  it('derives the response body from the request path params', async () => {
+    helper.mockResponseWithImplementation(getApiContractWithPathParams, {
+      pathParams: { userId: '7' },
+      responseStatus: 200,
+      handleRequest: ({ request }) => ({
+        id: new URL(request.url).pathname.split('/').pop() ?? '',
+      }),
+    })
+
+    const result = await sendByApiContract(client(), getApiContractWithPathParams, {
+      pathParams: { userId: '7' },
+    })
+
+    expect(result.result?.body).toEqual({ id: '7' })
+  })
+
+  it('enforces the contract schema on the handler result', async () => {
+    helper.mockResponseWithImplementation(getApiContract, {
+      responseStatus: 200,
+      // @ts-expect-error handler must return the contract response body
+      handleRequest: () => ({ wrong: 'x' }),
+    })
+
+    const result = await sendByApiContract(client(), getApiContract, {})
+
+    expect(result.error).toBeDefined()
+  })
+
+  it('varies the status code per call via response()', async () => {
+    let callCount = 0
+    helper.mockResponseWithImplementation(getApiContractWithExactAndRange, {
+      responseStatus: 200,
+      handleRequest: () => {
+        callCount++
+        if (callCount === 1) {
+          return ApiContractMswHelper.response({ id: 'first' }, { status: 500 })
+        }
+        return { id: 'second' }
+      },
+    })
+
+    const first = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
+    const second = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
+
+    expect(first.error).toBeDefined()
+    expect(second.result?.statusCode).toBe(200)
+    expect(second.result?.body).toEqual({ id: 'second' })
+  })
+
+  it('resolves the body schema through a range status key', async () => {
+    helper.mockResponseWithImplementation(getApiContractWith4xxRange, {
+      responseStatus: 404,
+      handleRequest: () => ({ id: 'missing' }),
+    })
+
+    const response = await fetch(`${BASE_URL}/not-found`)
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ id: 'missing' })
+  })
+
+  it('resolves the body schema from a JSON content map', async () => {
+    helper.mockResponseWithImplementation(jsonContentApiContract, {
+      responseStatus: 200,
+      handleRequest: () => ({ id: 'from-content-map' }),
+    })
+
+    const result = await sendByApiContract(client(), jsonContentApiContract, {})
+
+    expect(result.result?.body).toEqual({ id: 'from-content-map' })
+  })
+
+  it('rejects a status the contract does not declare', () => {
+    expect(() =>
+      helper.mockResponseWithImplementation(getApiContract, {
+        // @ts-expect-error 418 is not declared on the contract
+        responseStatus: 418,
+        handleRequest: () => ({ id: '1' }),
+      }),
+    ).toThrow('Specified responseStatus cannot be mapped with contract')
+  })
+
+  it('rejects an SSE-only status at the type level', () => {
+    expect(() =>
+      helper.mockResponseWithImplementation(
+        sseGetApiContract,
+        // @ts-expect-error an SSE-only status leaves no JSON body for handleRequest to return
+        { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
+      ),
+    ).toThrow('use mockResponse for SSE and blob responses')
+  })
+})

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.spec.ts
@@ -1,6 +1,16 @@
 import { sendByApiContract } from '@lokalise/frontend-http-client'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest'
 import wretch from 'wretch'
 import {
   blobContentApiContract,
@@ -18,6 +28,7 @@ import {
   getApiContractWithPathAndQueryParams,
   getApiContractWithPathParams,
   getApiContractWithQueryParams,
+  getApiContractWithSuccessAndErrorStatuses,
   jsonAndBlobContentApiContract,
   jsonContentApiContract,
   multiJsonContentApiContract,
@@ -26,6 +37,7 @@ import {
   patchApiContract,
   postApiContract,
   postApiContractWithPathParams,
+  problemJsonContentApiContract,
   putApiContract,
   sseContentApiContract,
   sseGetApiContract,
@@ -503,131 +515,318 @@ describe('ApiContractMswHelper', () => {
       expect(response.status).toBe(503)
     })
   })
-})
 
-describe('ApiContractMswHelper.mockResponseWithImplementation', () => {
-  const server = setupServer()
-  const helper = new ApiContractMswHelper(server, BASE_URL)
+  describe('mockResponseWithImplementation', () => {
+    // The helper reports handler and validation failures through console.error, since the
+    // frameworks would otherwise bury them in an opaque 500.
+    let failureLog: MockInstance<typeof console.error>
 
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'error' })
-  })
-  afterEach(() => {
-    server.resetHandlers()
-  })
-  afterAll(() => {
-    server.close()
-  })
-
-  function client() {
-    return wretch(BASE_URL)
-  }
-
-  it('derives the response body from the request body', async () => {
-    helper.mockResponseWithImplementation(postApiContract, {
-      responseStatus: 200,
-      handleRequest: async ({ request }) => {
-        const body = (await request.json()) as { name: string }
-        return { id: `id-${body.name}` }
-      },
+    beforeEach(() => {
+      failureLog = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+    afterEach(() => {
+      vi.restoreAllMocks()
     })
 
-    const result = await sendByApiContract(client(), postApiContract, {
-      body: { name: 'ragnarok' },
+    function loggedFailure(): string {
+      return failureLog.mock.calls.map(([message]) => String(message)).join('\n')
+    }
+
+    it('derives the response body from the request body', async () => {
+      helper.mockResponseWithImplementation(postApiContract, {
+        responseStatus: 200,
+        handleRequest: async ({ request }) => {
+          const body = await request.json()
+          return { id: `id-${body.name}` }
+        },
+      })
+
+      const result = await sendByApiContract(client(), postApiContract, {
+        body: { name: 'ragnarok' },
+      })
+
+      expect(result.result?.body).toEqual({ id: 'id-ragnarok' })
     })
 
-    expect(result.result?.body).toEqual({ id: 'id-ragnarok' })
-  })
+    it('derives the response body from the request path', async () => {
+      helper.mockResponseWithImplementation(getApiContractWithPathParams, {
+        pathParams: { userId: '7' },
+        responseStatus: 200,
+        handleRequest: ({ request }) => ({
+          id: new URL(request.url).pathname.split('/').pop() ?? '',
+        }),
+      })
 
-  it('derives the response body from the request path params', async () => {
-    helper.mockResponseWithImplementation(getApiContractWithPathParams, {
-      pathParams: { userId: '7' },
-      responseStatus: 200,
-      handleRequest: ({ request }) => ({
-        id: new URL(request.url).pathname.split('/').pop() ?? '',
-      }),
+      const result = await sendByApiContract(client(), getApiContractWithPathParams, {
+        pathParams: { userId: '7' },
+      })
+
+      expect(result.result?.body).toEqual({ id: '7' })
     })
 
-    const result = await sendByApiContract(client(), getApiContractWithPathParams, {
-      pathParams: { userId: '7' },
-    })
-
-    expect(result.result?.body).toEqual({ id: '7' })
-  })
-
-  it('enforces the contract schema on the handler result', async () => {
-    helper.mockResponseWithImplementation(getApiContract, {
-      responseStatus: 200,
-      // @ts-expect-error handler must return the contract response body
-      handleRequest: () => ({ wrong: 'x' }),
-    })
-
-    const result = await sendByApiContract(client(), getApiContract, {})
-
-    expect(result.error).toBeDefined()
-  })
-
-  it('varies the status code per call via response()', async () => {
-    let callCount = 0
-    helper.mockResponseWithImplementation(getApiContractWithExactAndRange, {
-      responseStatus: 200,
-      handleRequest: () => {
-        callCount++
-        if (callCount === 1) {
-          return ApiContractMswHelper.response({ id: 'first' }, { status: 500 })
-        }
-        return { id: 'second' }
-      },
-    })
-
-    const first = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
-    const second = await sendByApiContract(client(), getApiContractWithExactAndRange, {})
-
-    expect(first.error).toBeDefined()
-    expect(second.result?.statusCode).toBe(200)
-    expect(second.result?.body).toEqual({ id: 'second' })
-  })
-
-  it('resolves the body schema through a range status key', async () => {
-    helper.mockResponseWithImplementation(getApiContractWith4xxRange, {
-      responseStatus: 404,
-      handleRequest: () => ({ id: 'missing' }),
-    })
-
-    const response = await fetch(`${BASE_URL}/not-found`)
-
-    expect(response.status).toBe(404)
-    await expect(response.json()).resolves.toEqual({ id: 'missing' })
-  })
-
-  it('resolves the body schema from a JSON content map', async () => {
-    helper.mockResponseWithImplementation(jsonContentApiContract, {
-      responseStatus: 200,
-      handleRequest: () => ({ id: 'from-content-map' }),
-    })
-
-    const result = await sendByApiContract(client(), jsonContentApiContract, {})
-
-    expect(result.result?.body).toEqual({ id: 'from-content-map' })
-  })
-
-  it('rejects a status the contract does not declare', () => {
-    expect(() =>
+    it('strips unknown properties from the handler result', async () => {
       helper.mockResponseWithImplementation(getApiContract, {
-        // @ts-expect-error 418 is not declared on the contract
-        responseStatus: 418,
-        handleRequest: () => ({ id: '1' }),
-      }),
-    ).toThrow('Specified responseStatus cannot be mapped with contract')
-  })
+        responseStatus: 200,
+        handleRequest: () => ({ id: '1', extra: 'x' }),
+      })
 
-  it('rejects an SSE-only status at the type level', () => {
-    expect(() =>
-      helper.mockResponseWithImplementation(
-        sseGetApiContract,
-        // @ts-expect-error an SSE-only status leaves no JSON body for handleRequest to return
-        { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
-      ),
-    ).toThrow('use mockResponse for SSE and blob responses')
+      const result = await sendByApiContract(client(), getApiContract, {})
+
+      expect(result.result?.body).toEqual({ id: '1' })
+    })
+
+    it('replies with the declared JSON media type, not application/json', async () => {
+      helper.mockResponseWithImplementation(problemJsonContentApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ title: 'Invalid', detail: 'Something went wrong' }),
+      })
+
+      const response = await fetch(`${BASE_URL}/content-problem-json`)
+      expect(response.headers.get('content-type')).toBe('application/problem+json')
+
+      const result = await sendByApiContract(client(), problemJsonContentApiContract, {})
+      expect(result.result?.body).toEqual({ title: 'Invalid', detail: 'Something went wrong' })
+    })
+
+    it('serves the JSON media type selected via contentType', async () => {
+      helper.mockResponseWithImplementation(multiJsonContentApiContract, {
+        responseStatus: 200,
+        contentType: 'application/problem+json',
+        handleRequest: () => ({ title: 'Invalid', detail: 'Something went wrong' }),
+      })
+
+      const response = await fetch(`${BASE_URL}/content-multi-json`)
+
+      expect(response.headers.get('content-type')).toBe('application/problem+json')
+      await expect(response.json()).resolves.toEqual({
+        title: 'Invalid',
+        detail: 'Something went wrong',
+      })
+    })
+
+    it('requires contentType when the status declares several JSON media types', () => {
+      expect(() =>
+        helper.mockResponseWithImplementation(
+          multiJsonContentApiContract,
+          // @ts-expect-error contentType is required when the choice of media type is ambiguous
+          { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
+        ),
+      ).toThrow(
+        'Status 200 declares more than one JSON content type (application/json, application/problem+json); pass contentType to select one',
+      )
+    })
+
+    it('serves the JSON entry of a content map that also declares a blob', async () => {
+      helper.mockResponseWithImplementation(jsonAndBlobContentApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ id: 'from-json-side' }),
+      })
+
+      const response = await fetch(`${BASE_URL}/content-json-blob`)
+
+      expect(response.headers.get('content-type')).toBe('application/json')
+      await expect(response.json()).resolves.toEqual({ id: 'from-json-side' })
+    })
+
+    it('resolves the body schema through a range status key', async () => {
+      helper.mockResponseWithImplementation(getApiContractWith4xxRange, {
+        responseStatus: 404,
+        handleRequest: () => ({ id: 'missing' }),
+      })
+
+      const response = await fetch(`${BASE_URL}/not-found`)
+
+      expect(response.status).toBe(404)
+      await expect(response.json()).resolves.toEqual({ id: 'missing' })
+    })
+
+    it('resolves the body schema from a JSON content map', async () => {
+      helper.mockResponseWithImplementation(jsonContentApiContract, {
+        responseStatus: 200,
+        handleRequest: () => ({ id: 'from-content-map' }),
+      })
+
+      const result = await sendByApiContract(client(), jsonContentApiContract, {})
+
+      expect(result.result?.body).toEqual({ id: 'from-content-map' })
+    })
+
+    describe('per-call status codes', () => {
+      it('validates the body against the entry for the overridden status', async () => {
+        let callCount = 0
+        helper.mockResponseWithImplementation(getApiContractWithSuccessAndErrorStatuses, {
+          responseStatus: 200,
+          handleRequest: () => {
+            callCount++
+            if (callCount === 1) {
+              return ApiContractMswHelper.response({ message: 'nope' }, { status: 404 })
+            }
+            return { id: 'second' }
+          },
+        })
+
+        const first = await fetch(`${BASE_URL}/success-or-error`)
+        expect(first.status).toBe(404)
+        await expect(first.json()).resolves.toEqual({ message: 'nope' })
+
+        const second = await fetch(`${BASE_URL}/success-or-error`)
+        expect(second.status).toBe(200)
+        await expect(second.json()).resolves.toEqual({ id: 'second' })
+        expect(failureLog).not.toHaveBeenCalled()
+      })
+
+      it('reports an overridden status the contract does not declare', async () => {
+        helper.mockResponseWithImplementation(getApiContract, {
+          responseStatus: 200,
+          handleRequest: () => ApiContractMswHelper.response({ id: '1' }, { status: 503 }),
+        })
+
+        const response = await fetch(BASE_URL)
+
+        expect(response.status).toBe(500)
+        expect(loggedFailure()).toContain(
+          'Status 503 passed to response() cannot be mapped with contract',
+        )
+      })
+    })
+
+    describe('failure reporting', () => {
+      it('reports a handler result the contract schema rejects', async () => {
+        helper.mockResponseWithImplementation(getApiContract, {
+          responseStatus: 200,
+          // @ts-expect-error handler must return the contract response body
+          handleRequest: () => ({ wrong: 'x' }),
+        })
+
+        const response = await fetch(BASE_URL)
+
+        expect(response.status).toBe(500)
+        expect(loggedFailure()).toContain('[ApiContractMswHelper.mockResponseWithImplementation]')
+        expect(loggedFailure()).toContain('GET /')
+        expect(loggedFailure()).toContain('ZodError')
+      })
+
+      it('reports an exception thrown by the handler', async () => {
+        helper.mockResponseWithImplementation(getApiContract, {
+          responseStatus: 200,
+          handleRequest: () => {
+            throw new Error('boom from handler')
+          },
+        })
+
+        const response = await fetch(BASE_URL)
+
+        expect(response.status).toBe(500)
+        expect(loggedFailure()).toContain('boom from handler')
+        await expect(response.json()).resolves.toEqual({
+          message: expect.stringContaining('boom from handler'),
+        })
+      })
+
+      it('refuses a request that negotiated the status entry SSE branch', async () => {
+        helper.mockResponseWithImplementation(dualContentApiContract, {
+          responseStatus: 200,
+          handleRequest: () => ({ id: 'json-side' }),
+        })
+
+        const negotiated = await fetch(`${BASE_URL}/content-dual`, {
+          method: 'POST',
+          headers: { accept: 'text/event-stream' },
+          body: JSON.stringify({ name: 'x' }),
+        })
+
+        expect(negotiated.status).toBe(406)
+        expect(loggedFailure()).toContain('use mockResponse for the SSE branch')
+      })
+
+      it('serves the JSON branch of a dual content map to a plain request', async () => {
+        helper.mockResponseWithImplementation(dualContentApiContract, {
+          responseStatus: 200,
+          handleRequest: () => ({ id: 'json-side' }),
+        })
+
+        const result = await sendByApiContract(client(), dualContentApiContract, {
+          streaming: false,
+          body: { name: 'x' },
+        })
+
+        expect(result.result?.body).toEqual({ id: 'json-side' })
+        expect(failureLog).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('statuses it refuses to mock', () => {
+      // Guards untyped callers, for whom the type-level rejections do not apply.
+      const untypedHelper = helper as unknown as {
+        mockResponseWithImplementation: (contract: unknown, params: unknown) => void
+      }
+
+      it('rejects a status the contract does not declare', () => {
+        expect(() =>
+          helper.mockResponseWithImplementation(getApiContract, {
+            // @ts-expect-error 418 is not declared on the contract
+            responseStatus: 418,
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).toThrow('Specified responseStatus cannot be mapped with contract')
+      })
+
+      it('rejects an SSE-only status at the type level', () => {
+        expect(() =>
+          helper.mockResponseWithImplementation(
+            sseGetApiContract,
+            // @ts-expect-error an SSE-only status leaves no JSON body for handleRequest to return
+            { responseStatus: 200, handleRequest: () => ({ id: '1' }) },
+          ),
+        ).toThrow(
+          'Status 200 has no JSON response body; use mockResponse for SSE and blob responses',
+        )
+      })
+
+      it('rejects a status whose body has no JSON representation at runtime', () => {
+        expect(() =>
+          untypedHelper.mockResponseWithImplementation(blobContentApiContract, {
+            responseStatus: 200,
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).toThrow(
+          'Status 200 has no JSON response body; use mockResponse for SSE and blob responses',
+        )
+      })
+
+      it('rejects a no-body status without blaming SSE or blob', () => {
+        expect(() =>
+          untypedHelper.mockResponseWithImplementation(noBodyContentApiContract, {
+            pathParams: { userId: '7' },
+            responseStatus: 204,
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).toThrow(
+          'Status 204 declares no response body; mockResponseWithImplementation needs a JSON body to return',
+        )
+      })
+
+      it('rejects a contentType the status does not declare', () => {
+        expect(() =>
+          untypedHelper.mockResponseWithImplementation(jsonContentApiContract, {
+            responseStatus: 200,
+            contentType: 'text/plain',
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).toThrow('Specified contentType cannot be mapped with contract')
+      })
+
+      it('rejects a contentType that names a non-JSON descriptor', () => {
+        expect(() =>
+          untypedHelper.mockResponseWithImplementation(jsonAndBlobContentApiContract, {
+            responseStatus: 200,
+            contentType: 'application/octet-stream',
+            handleRequest: () => ({ id: '1' }),
+          }),
+        ).toThrow(
+          'Specified contentType application/octet-stream is not a JSON body; use mockResponse for SSE and blob responses',
+        )
+      })
+    })
   })
 })

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
@@ -7,27 +7,41 @@ import {
   isSseBody,
   mapApiContractToPath,
 } from '@lokalise/api-contracts'
-import { HttpResponse, type HttpResponseResolver, http, type JsonBodyType } from 'msw'
+import {
+  type DefaultBodyType,
+  HttpResponse,
+  type HttpResponseResolver,
+  http,
+  type JsonBodyType,
+  type PathParams,
+} from 'msw'
 import type { SetupServer } from 'msw/node'
 import type { z } from 'zod/v4'
-import {
-  type MockResponseWrapper,
-  unwrapMockResponse,
-  wrapMockResponse,
-} from '../responseWrapper.ts'
+import { type MockResponseWrapper, wrapMockResponse } from '../responseWrapper.ts'
 import {
   formatSseResponse,
   type MockImplementationParams,
   type MockResponseParams,
   resolveContractEntry,
   resolveExplicitContentBody,
-  resolveJsonSchema,
+  resolveJsonTargetForStatus,
+  runMockImplementation,
 } from './types.ts'
 
 type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
 
-/** Request info msw passes to a route resolver. */
-export type MswRequestInfo = Parameters<HttpResponseResolver>[0]
+/** Request info msw passes to a route resolver, optionally typed by the request body. */
+export type MswRequestInfo<TRequestBody extends DefaultBodyType = DefaultBodyType> = Parameters<
+  HttpResponseResolver<PathParams, TRequestBody>
+>[0]
+
+/** Request body type the contract declares, or msw's default for a contract that declares none. */
+type InferRequestBody<TContract extends ApiContract> =
+  TContract['requestBodySchema'] extends z.ZodType
+    ? z.output<TContract['requestBodySchema']> extends DefaultBodyType
+      ? z.output<TContract['requestBodySchema']>
+      : DefaultBodyType
+    : DefaultBodyType
 
 function joinURL(base: string, path: string): string {
   return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
@@ -156,40 +170,40 @@ export class ApiContractMswHelper {
   /**
    * Mocks a JSON response whose body is computed from the incoming request.
    *
-   * `responseStatus` picks the contract entry that types `handleRequest`'s return value. Return a
-   * bare body to reply with that status, or wrap it with {@link ApiContractMswHelper.response}
-   * to override the status for a single call.
+   * `responseStatus` picks the contract entry that types `handleRequest`'s return value, and
+   * `contentType` picks between JSON media types when that entry declares more than one. Return a
+   * bare body to reply with `responseStatus`, or wrap it with
+   * {@link ApiContractMswHelper.response} to override the status for a single call.
    */
   mockResponseWithImplementation<TContract extends ApiContract>(
     contract: TContract,
-    params: MockImplementationParams<TContract, MswRequestInfo>,
+    params: MockImplementationParams<TContract, MswRequestInfo<InferRequestBody<TContract>>>,
   ): void {
     // biome-ignore lint/suspicious/noExplicitAny: field access is safe, the public signature enforces the type
     const anyParams = params as any
     const path = this.resolvePath(contract, params.pathParams)
-    const statusCode = anyParams.responseStatus as HttpStatusCode
-    const responseEntry = resolveContractEntry(contract.responsesByStatusCode, statusCode)
-
-    if (!responseEntry) {
-      throw new Error('Specified responseStatus cannot be mapped with contract')
-    }
-
-    const jsonSchema = resolveJsonSchema(responseEntry)
-    if (!jsonSchema) {
-      throw new Error(
-        'Specified responseStatus has no JSON response body; use mockResponse for SSE and blob responses',
-      )
-    }
-
+    const responseStatus = anyParams.responseStatus as HttpStatusCode
+    const target = resolveJsonTargetForStatus(
+      contract.responsesByStatusCode,
+      responseStatus,
+      anyParams.contentType,
+    )
     const method = contract.method as HttpMethod
 
     this.server.use(
       http[method](path, async (requestInfo) => {
-        const result = await anyParams.handleRequest(requestInfo)
-        const { body, status } = unwrapMockResponse(result)
+        const reply = await runMockImplementation({
+          helperName: 'ApiContractMswHelper',
+          contract,
+          responseStatus,
+          target,
+          accept: requestInfo.request.headers.get('accept') ?? '',
+          handleRequest: () => anyParams.handleRequest(requestInfo),
+        })
 
-        return HttpResponse.json(jsonSchema.parse(body) as JsonBodyType, {
-          status: status ?? statusCode,
+        return new HttpResponse(reply.body, {
+          status: reply.statusCode,
+          headers: { 'content-type': reply.mediaType },
         })
       }),
     )

--- a/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/ApiContractMswHelper.ts
@@ -1,22 +1,33 @@
 import {
   type ApiContract,
+  type HttpStatusCode,
   isBlobBody,
   isContentResponseEntry,
   isJsonBody,
   isSseBody,
   mapApiContractToPath,
 } from '@lokalise/api-contracts'
-import { HttpResponse, http, type JsonBodyType } from 'msw'
+import { HttpResponse, type HttpResponseResolver, http, type JsonBodyType } from 'msw'
 import type { SetupServer } from 'msw/node'
 import type { z } from 'zod/v4'
 import {
+  type MockResponseWrapper,
+  unwrapMockResponse,
+  wrapMockResponse,
+} from '../responseWrapper.ts'
+import {
   formatSseResponse,
+  type MockImplementationParams,
   type MockResponseParams,
   resolveContractEntry,
   resolveExplicitContentBody,
+  resolveJsonSchema,
 } from './types.ts'
 
 type HttpMethod = 'get' | 'delete' | 'post' | 'patch' | 'put'
+
+/** Request info msw passes to a route resolver. */
+export type MswRequestInfo = Parameters<HttpResponseResolver>[0]
 
 function joinURL(base: string, path: string): string {
   return `${base.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
@@ -29,6 +40,14 @@ export class ApiContractMswHelper {
   constructor(server: SetupServer, baseUrl: string) {
     this.server = server
     this.baseUrl = baseUrl
+  }
+
+  /**
+   * Wraps a body returned from `handleRequest` so it carries its own status code, overriding
+   * the mock's `responseStatus` for that call.
+   */
+  static response<T>(body: T, options?: { status?: number }): MockResponseWrapper<T> {
+    return wrapMockResponse(body, options)
   }
 
   private resolvePath(contract: ApiContract, pathParams: unknown): string {
@@ -132,5 +151,47 @@ export class ApiContractMswHelper {
 
     const body = responseEntry.parse(anyParams.responseJson) as JsonBodyType
     this.server.use(http[method](path, () => HttpResponse.json(body, { status: statusCode })))
+  }
+
+  /**
+   * Mocks a JSON response whose body is computed from the incoming request.
+   *
+   * `responseStatus` picks the contract entry that types `handleRequest`'s return value. Return a
+   * bare body to reply with that status, or wrap it with {@link ApiContractMswHelper.response}
+   * to override the status for a single call.
+   */
+  mockResponseWithImplementation<TContract extends ApiContract>(
+    contract: TContract,
+    params: MockImplementationParams<TContract, MswRequestInfo>,
+  ): void {
+    // biome-ignore lint/suspicious/noExplicitAny: field access is safe, the public signature enforces the type
+    const anyParams = params as any
+    const path = this.resolvePath(contract, params.pathParams)
+    const statusCode = anyParams.responseStatus as HttpStatusCode
+    const responseEntry = resolveContractEntry(contract.responsesByStatusCode, statusCode)
+
+    if (!responseEntry) {
+      throw new Error('Specified responseStatus cannot be mapped with contract')
+    }
+
+    const jsonSchema = resolveJsonSchema(responseEntry)
+    if (!jsonSchema) {
+      throw new Error(
+        'Specified responseStatus has no JSON response body; use mockResponse for SSE and blob responses',
+      )
+    }
+
+    const method = contract.method as HttpMethod
+
+    this.server.use(
+      http[method](path, async (requestInfo) => {
+        const result = await anyParams.handleRequest(requestInfo)
+        const { body, status } = unwrapMockResponse(result)
+
+        return HttpResponse.json(jsonSchema.parse(body) as JsonBodyType, {
+          status: status ?? statusCode,
+        })
+      }),
+    )
   }
 }

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -6,6 +6,8 @@ import {
   type HttpStatusCode,
   type InferSchemaInput,
   isBlobBody,
+  isContentResponseEntry,
+  isJsonBody,
   isSseBody,
   type RequestPathParamsSchema,
   type ResponseEntry,
@@ -14,6 +16,7 @@ import {
   type WildcardStatusCodeKey,
 } from '@lokalise/api-contracts'
 import type { z } from 'zod/v4'
+import type { MockResponseWrapper } from '../responseWrapper.ts'
 
 export type SseMockEventInput<S extends SseSchemaByEventName> = {
   [K in keyof S & string]: { event: K; data: z.input<NonNullable<S[K]>> }
@@ -62,6 +65,26 @@ export function resolveContractEntry(
     responsesByStatusCode[statusCode] ??
     (rangeKey ? responsesByStatusCode[rangeKey] : undefined) ??
     responsesByStatusCode.default
+  )
+}
+
+/**
+ * JSON schema a resolved status entry validates its body against, for both bare-schema entries
+ * and content maps. Returns `undefined` when the entry has no JSON representation.
+ */
+export function resolveJsonSchema(
+  responseEntry: ApiContractResponse | ResponseEntry,
+): z.ZodType | undefined {
+  if (!isContentResponseEntry(responseEntry)) {
+    return responseEntry
+  }
+
+  if (!responseEntry.content) {
+    return undefined
+  }
+
+  return Object.values(responseEntry.content).find((descriptor): descriptor is z.ZodType =>
+    isJsonBody(descriptor),
   )
 }
 
@@ -133,3 +156,61 @@ type PathParamsField<TContract extends ApiContract> =
 
 export type MockResponseParams<TContract extends ApiContract> = PathParamsField<TContract> &
   StatusCodeBodyPair<TContract>
+
+/**
+ * JSON body type a status entry accepts, whether it is a bare schema or a content map.
+ * Resolves to `never` for entries with no JSON representation (SSE-only, blob-only, no-body).
+ */
+type InferJsonBody<T> = T extends z.ZodType
+  ? z.input<T>
+  : T extends { content: infer C }
+    ? [Extract<C[keyof C], z.ZodType>] extends [never]
+      ? never
+      : z.input<Extract<C[keyof C], z.ZodType>>
+    : never
+
+type HandleRequestField<TRequestInfo, TBody> = [TBody] extends [never]
+  ? never
+  : {
+      handleRequest: (
+        requestInfo: TRequestInfo,
+      ) => TBody | MockResponseWrapper<TBody> | Promise<TBody | MockResponseWrapper<TBody>>
+    }
+
+type ExactStatusCodeImplementationPairs<TContract extends ApiContract, TRequestInfo> = {
+  [K in keyof TContract['responsesByStatusCode'] & HttpStatusCode]: {
+    responseStatus: K
+  } & HandleRequestField<
+    TRequestInfo,
+    InferJsonBody<NonNullable<TContract['responsesByStatusCode'][K]>>
+  >
+}[keyof TContract['responsesByStatusCode'] & HttpStatusCode]
+
+type RangeStatusCodeImplementationPairs<TContract extends ApiContract, TRequestInfo> = {
+  [K in keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]: {
+    responseStatus: Exclude<
+      ExpandStatusRangeKey<K>,
+      keyof TContract['responsesByStatusCode'] & HttpStatusCode
+    >
+  } & HandleRequestField<
+    TRequestInfo,
+    InferJsonBody<NonNullable<TContract['responsesByStatusCode'][K]>>
+  >
+}[keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]
+
+/**
+ * Params for a mock whose JSON body is computed per request.
+ *
+ * `responseStatus` selects the contract entry, which types `handleRequest`'s return value.
+ * The handler may wrap its result with the helper's static `response()` to override the status
+ * on a single call. Only JSON entries are addressable: SSE and blob responses stay static, via
+ * `mockResponse`.
+ */
+export type MockImplementationParams<
+  TContract extends ApiContract,
+  TRequestInfo,
+> = PathParamsField<TContract> &
+  (
+    | ExactStatusCodeImplementationPairs<TContract, TRequestInfo>
+    | RangeStatusCodeImplementationPairs<TContract, TRequestInfo>
+  )

--- a/packages/app/universal-testing-utils/src/api-contracts/types.ts
+++ b/packages/app/universal-testing-utils/src/api-contracts/types.ts
@@ -2,6 +2,7 @@ import {
   type ApiContract,
   type ApiContractResponse,
   type BodyDescriptor,
+  describeApiContract,
   type ExpandStatusRangeKey,
   type HttpStatusCode,
   type InferSchemaInput,
@@ -16,7 +17,9 @@ import {
   type WildcardStatusCodeKey,
 } from '@lokalise/api-contracts'
 import type { z } from 'zod/v4'
-import type { MockResponseWrapper } from '../responseWrapper.ts'
+import { type MockResponseWrapper, unwrapMockResponse } from '../responseWrapper.ts'
+
+export const JSON_MEDIA_TYPE = 'application/json'
 
 export type SseMockEventInput<S extends SseSchemaByEventName> = {
   [K in keyof S & string]: { event: K; data: z.input<NonNullable<S[K]>> }
@@ -68,24 +71,168 @@ export function resolveContractEntry(
   )
 }
 
+/** The JSON body a mock serves for one status: which media type it goes out as, and its schema. */
+export type JsonResponseTarget = {
+  /** Content-type header the response carries. The content-map key, or `application/json`. */
+  mediaType: string
+  /** Schema the body is validated against. */
+  schema: z.ZodType
+  /** Media type of an SSE descriptor sharing the same status entry, when the contract declares one. */
+  sseMediaType?: string
+}
+
 /**
- * JSON schema a resolved status entry validates its body against, for both bare-schema entries
- * and content maps. Returns `undefined` when the entry has no JSON representation.
+ * Media type and schema a resolved status entry serves JSON under, for both bare-schema entries
+ * and content maps. `contentType` pins one content-map key; without it the entry must declare
+ * exactly one JSON descriptor.
+ *
+ * Throws when the entry has no JSON representation, when `contentType` names something the entry
+ * does not declare as JSON, or when the choice of media type would be ambiguous.
  */
-export function resolveJsonSchema(
+export function resolveJsonTarget(
   responseEntry: ApiContractResponse | ResponseEntry,
-): z.ZodType | undefined {
+  contentType: string | undefined,
+  statusCode: HttpStatusCode,
+): JsonResponseTarget {
   if (!isContentResponseEntry(responseEntry)) {
-    return responseEntry
+    if (contentType !== undefined && contentType !== JSON_MEDIA_TYPE) {
+      throw new Error('Specified contentType cannot be mapped with contract')
+    }
+    return { mediaType: JSON_MEDIA_TYPE, schema: responseEntry }
   }
 
   if (!responseEntry.content) {
-    return undefined
+    throw new Error(
+      `Status ${statusCode} declares no response body; mockResponseWithImplementation needs a JSON body to return`,
+    )
   }
 
-  return Object.values(responseEntry.content).find((descriptor): descriptor is z.ZodType =>
-    isJsonBody(descriptor),
+  const contentEntries = Object.entries(responseEntry.content)
+  const sseMediaType = contentEntries.find(([, descriptor]) => isSseBody(descriptor))?.[0]
+  const jsonEntries = contentEntries.filter((entry): entry is [string, z.ZodType] =>
+    isJsonBody(entry[1]),
   )
+
+  if (contentType !== undefined) {
+    const selected = jsonEntries.find(([mediaType]) => mediaType === contentType)
+    if (!selected) {
+      throw new Error(
+        contentType in responseEntry.content
+          ? `Specified contentType ${contentType} is not a JSON body; use mockResponse for SSE and blob responses`
+          : 'Specified contentType cannot be mapped with contract',
+      )
+    }
+    return { mediaType: selected[0], schema: selected[1], sseMediaType }
+  }
+
+  const [onlyJsonEntry, secondJsonEntry] = jsonEntries
+
+  if (!onlyJsonEntry) {
+    throw new Error(
+      `Status ${statusCode} has no JSON response body; use mockResponse for SSE and blob responses`,
+    )
+  }
+  if (secondJsonEntry) {
+    const declared = jsonEntries.map(([mediaType]) => mediaType).join(', ')
+    throw new Error(
+      `Status ${statusCode} declares more than one JSON content type (${declared}); pass contentType to select one`,
+    )
+  }
+
+  return { mediaType: onlyJsonEntry[0], schema: onlyJsonEntry[1], sseMediaType }
+}
+
+/** {@link resolveJsonTarget} preceded by the exact → range → `'default'` status lookup. */
+export function resolveJsonTargetForStatus(
+  responsesByStatusCode: ResponsesByStatusCode,
+  statusCode: HttpStatusCode,
+  contentType: string | undefined,
+  unmappedStatusMessage = 'Specified responseStatus cannot be mapped with contract',
+): JsonResponseTarget {
+  const responseEntry = resolveContractEntry(responsesByStatusCode, statusCode)
+
+  if (!responseEntry) {
+    throw new Error(unmappedStatusMessage)
+  }
+
+  return resolveJsonTarget(responseEntry, contentType, statusCode)
+}
+
+/** A reply the framework-specific helpers translate into their own response object. */
+export type MockImplementationReply = {
+  statusCode: number
+  mediaType: string
+  body: string
+}
+
+function reportMockFailure(
+  helperName: string,
+  contract: ApiContract,
+  statusCode: number,
+  reason: string,
+  cause?: unknown,
+): MockImplementationReply {
+  const message = `[${helperName}.mockResponseWithImplementation] ${describeApiContract(contract)}: ${reason}`
+
+  // mockttp and msw turn a throwing route callback into an opaque 500, which reaches the test as a
+  // client-side parse failure with the real cause nowhere in sight. Log it where the test can see.
+  // biome-ignore lint/suspicious/noConsole: surfacing the cause in test output is the point
+  console.error(message, cause ?? '')
+
+  return { statusCode, mediaType: JSON_MEDIA_TYPE, body: JSON.stringify({ message }) }
+}
+
+/**
+ * Runs a `handleRequest` handler and turns its result into a reply: the body validated against the
+ * schema for the status actually sent, under the media type the contract declares it for.
+ *
+ * Handler and validation failures become a labelled 500 rather than a bare framework 500.
+ */
+export async function runMockImplementation(args: {
+  helperName: string
+  contract: ApiContract
+  responseStatus: HttpStatusCode
+  target: JsonResponseTarget
+  accept: string
+  handleRequest: () => unknown
+}): Promise<MockImplementationReply> {
+  const { helperName, contract, responseStatus, target, accept, handleRequest } = args
+
+  // A handler only produces JSON. Serving it to a caller that asked for the entry's SSE branch
+  // would hand back a body that caller cannot read, so refuse instead of answering wrongly.
+  if (target.sseMediaType && accept.includes(target.sseMediaType)) {
+    return reportMockFailure(
+      helperName,
+      contract,
+      406,
+      `request negotiated ${target.sseMediaType}, which mockResponseWithImplementation cannot serve; use mockResponse for the SSE branch`,
+    )
+  }
+
+  try {
+    const { body, status } = unwrapMockResponse(await handleRequest())
+    const statusCode = status ?? responseStatus
+    // A per-call status override selects a different contract entry, so the body is validated
+    // against the schema declared for the status actually being sent.
+    const resolved =
+      statusCode === responseStatus
+        ? target
+        : resolveJsonTargetForStatus(
+            contract.responsesByStatusCode,
+            statusCode as HttpStatusCode,
+            undefined,
+            `Status ${statusCode} passed to response() cannot be mapped with contract`,
+          )
+
+    return {
+      statusCode,
+      mediaType: resolved.mediaType,
+      body: JSON.stringify(resolved.schema.parse(body)),
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    return reportMockFailure(helperName, contract, 500, reason, error)
+  }
 }
 
 // Maps a content-map entry's descriptors to the body field(s) needed for mocking:
@@ -169,20 +316,59 @@ type InferJsonBody<T> = T extends z.ZodType
       : z.input<Extract<C[keyof C], z.ZodType>>
     : never
 
-type HandleRequestField<TRequestInfo, TBody> = [TBody] extends [never]
+/**
+ * Every JSON body the contract declares, across all of its status entries. A body wrapped with
+ * `response({ status })` is validated against the entry for that status, so it is not confined to
+ * the one `responseStatus` selected.
+ */
+type AnyDeclaredJsonBody<TContract extends ApiContract> = {
+  [K in keyof TContract['responsesByStatusCode']]: InferJsonBody<
+    NonNullable<TContract['responsesByStatusCode'][K]>
+  >
+}[keyof TContract['responsesByStatusCode']]
+
+type HandleRequestField<TRequestInfo, TBody, TAnyBody> = [TBody] extends [never]
   ? never
   : {
       handleRequest: (
         requestInfo: TRequestInfo,
-      ) => TBody | MockResponseWrapper<TBody> | Promise<TBody | MockResponseWrapper<TBody>>
+      ) => TBody | MockResponseWrapper<TAnyBody> | Promise<TBody | MockResponseWrapper<TAnyBody>>
     }
+
+/** True for a union of two or more members, false for a single type. */
+type IsUnion<T, U = T> = T extends unknown ? ([U] extends [T] ? false : true) : never
+
+// Selecting one JSON content-type entry explicitly: that descriptor types the handler's result.
+type PerContentTypeHandleRequest<C, TRequestInfo, TAnyBody> = {
+  [K in keyof C & string]: C[K] extends z.ZodType
+    ? { contentType: K } & HandleRequestField<TRequestInfo, z.input<C[K]>, TAnyBody>
+    : never
+}[keyof C & string]
+
+// Maps a single responsesByStatusCode entry to the handler field it accepts.
+// ZodType                   → handler returns that schema's input, no `contentType`
+// content map, one JSON     → same, and `contentType` may still name that one media type
+// content map, several JSON → `contentType` is required, since which one gets served would
+//                             otherwise be ambiguous (unlike mockResponse, which has a fixed body
+//                             to fall back on, a handler's result must match the chosen schema)
+// no JSON descriptor at all → never, which drops the status from the union entirely
+type InferHandleRequestParam<T, TRequestInfo, TAnyBody> = T extends z.ZodType
+  ? { contentType?: never } & HandleRequestField<TRequestInfo, z.input<T>, TAnyBody>
+  : T extends { content: infer C }
+    ? [IsUnion<Extract<C[keyof C], z.ZodType>>] extends [true]
+      ? PerContentTypeHandleRequest<C, TRequestInfo, TAnyBody>
+      :
+          | ({ contentType?: never } & HandleRequestField<TRequestInfo, InferJsonBody<T>, TAnyBody>)
+          | PerContentTypeHandleRequest<C, TRequestInfo, TAnyBody>
+    : never
 
 type ExactStatusCodeImplementationPairs<TContract extends ApiContract, TRequestInfo> = {
   [K in keyof TContract['responsesByStatusCode'] & HttpStatusCode]: {
     responseStatus: K
-  } & HandleRequestField<
+  } & InferHandleRequestParam<
+    NonNullable<TContract['responsesByStatusCode'][K]>,
     TRequestInfo,
-    InferJsonBody<NonNullable<TContract['responsesByStatusCode'][K]>>
+    AnyDeclaredJsonBody<TContract>
   >
 }[keyof TContract['responsesByStatusCode'] & HttpStatusCode]
 
@@ -192,19 +378,21 @@ type RangeStatusCodeImplementationPairs<TContract extends ApiContract, TRequestI
       ExpandStatusRangeKey<K>,
       keyof TContract['responsesByStatusCode'] & HttpStatusCode
     >
-  } & HandleRequestField<
+  } & InferHandleRequestParam<
+    NonNullable<TContract['responsesByStatusCode'][K]>,
     TRequestInfo,
-    InferJsonBody<NonNullable<TContract['responsesByStatusCode'][K]>>
+    AnyDeclaredJsonBody<TContract>
   >
 }[keyof TContract['responsesByStatusCode'] & WildcardStatusCodeKey]
 
 /**
  * Params for a mock whose JSON body is computed per request.
  *
- * `responseStatus` selects the contract entry, which types `handleRequest`'s return value.
- * The handler may wrap its result with the helper's static `response()` to override the status
- * on a single call. Only JSON entries are addressable: SSE and blob responses stay static, via
- * `mockResponse`.
+ * `responseStatus` selects the contract entry, which types `handleRequest`'s return value, and
+ * `contentType` picks between JSON media types when the entry declares more than one. The handler
+ * may wrap its result with the helper's static `response()` to override the status on a single
+ * call, in which case the body is validated against the entry for that status. Only JSON entries
+ * are addressable: SSE and blob responses stay static, via `mockResponse`.
  */
 export type MockImplementationParams<
   TContract extends ApiContract,

--- a/packages/app/universal-testing-utils/src/index.ts
+++ b/packages/app/universal-testing-utils/src/index.ts
@@ -1,6 +1,6 @@
 export { ApiContractMockttpHelper } from './api-contracts/ApiContractMockttpHelper.ts'
-export { ApiContractMswHelper } from './api-contracts/ApiContractMswHelper.ts'
-export type { MockResponseParams } from './api-contracts/types.ts'
+export { ApiContractMswHelper, type MswRequestInfo } from './api-contracts/ApiContractMswHelper.ts'
+export type { MockImplementationParams, MockResponseParams } from './api-contracts/types.ts'
 export {
   type DualModeMockParams,
   type DualModeMockParamsNoPath,

--- a/packages/app/universal-testing-utils/src/index.ts
+++ b/packages/app/universal-testing-utils/src/index.ts
@@ -1,4 +1,7 @@
-export { ApiContractMockttpHelper } from './api-contracts/ApiContractMockttpHelper.ts'
+export {
+  type ApiContractCompletedRequest,
+  ApiContractMockttpHelper,
+} from './api-contracts/ApiContractMockttpHelper.ts'
 export { ApiContractMswHelper, type MswRequestInfo } from './api-contracts/ApiContractMswHelper.ts'
 export type { MockImplementationParams, MockResponseParams } from './api-contracts/types.ts'
 export {

--- a/packages/app/universal-testing-utils/src/responseWrapper.ts
+++ b/packages/app/universal-testing-utils/src/responseWrapper.ts
@@ -1,4 +1,8 @@
-const RESPONSE_BRAND = Symbol('MockResponseWrapper')
+// Registry symbol, not a module-local one: two copies of this package in a single dependency tree
+// (version skew, or a dual ESM/CJS load) must still recognise each other's wrappers.
+const RESPONSE_BRAND: unique symbol = Symbol.for(
+  '@lokalise/universal-testing-utils/MockResponseWrapper',
+)
 
 export type MockResponseWrapper<T> = {
   readonly [RESPONSE_BRAND]: true

--- a/packages/app/universal-testing-utils/src/responseWrapper.ts
+++ b/packages/app/universal-testing-utils/src/responseWrapper.ts
@@ -1,0 +1,29 @@
+const RESPONSE_BRAND = Symbol('MockResponseWrapper')
+
+export type MockResponseWrapper<T> = {
+  readonly [RESPONSE_BRAND]: true
+  readonly body: T
+  readonly status?: number
+}
+
+/**
+ * Wraps a mock response body so a per-call status code travels with it.
+ *
+ * Handlers may return a bare body instead, in which case the status falls back to the one
+ * declared on the mock.
+ */
+export function wrapMockResponse<T>(
+  body: T,
+  options?: { status?: number },
+): MockResponseWrapper<T> {
+  return { [RESPONSE_BRAND]: true, body, status: options?.status }
+}
+
+export function unwrapMockResponse(result: unknown): { body: unknown; status?: number } {
+  if (result && typeof result === 'object' && RESPONSE_BRAND in result) {
+    const wrapper = result as MockResponseWrapper<unknown>
+    return { body: wrapper.body, status: wrapper.status }
+  }
+
+  return { body: result }
+}

--- a/packages/app/universal-testing-utils/test/testApiContracts.ts
+++ b/packages/app/universal-testing-utils/test/testApiContracts.ts
@@ -165,6 +165,19 @@ export const getApiContractWithExactAndRange = defineApiContract({
   },
 })
 
+const ERROR_BODY_SCHEMA = z.object({ message: z.string() })
+
+export const getApiContractWithSuccessAndErrorStatuses = defineApiContract({
+  visibility: 'public',
+  summary: 'Test contract',
+  method: 'get',
+  pathResolver: () => '/success-or-error',
+  responsesByStatusCode: {
+    200: RESPONSE_BODY_SCHEMA,
+    '4xx': ERROR_BODY_SCHEMA,
+  },
+})
+
 export const deleteApiContractWithNoBodyResponse = defineApiContract({
   visibility: 'public',
   summary: 'Test contract',
@@ -253,6 +266,16 @@ export const multiJsonContentApiContract = defineApiContract({
         'application/problem+json': PROBLEM_BODY_SCHEMA,
       },
     },
+  },
+})
+
+export const problemJsonContentApiContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Test contract',
+  method: 'get',
+  pathResolver: () => '/content-problem-json',
+  responsesByStatusCode: {
+    200: { content: { 'application/problem+json': PROBLEM_BODY_SCHEMA } },
   },
 })
 


### PR DESCRIPTION
## Description

`ApiContractMockttpHelper` and `ApiContractMswHelper` could only mock a **fixed** body, via `mockResponse`. The request-derived variant existed only as `MswHelper.mockValidResponseWithImplementation`, which the compatibility matrix ties to the legacy `buildRestContract`/`buildSseContract` definitions. So a `defineApiContract` consumer whose mock needs to read the incoming request had no option but to drop down to raw mockttp or msw.

Found while auditing a service that had finished migrating to `defineApiContract`: its e2e specs hand-roll `mockttp` with `thenCallback` handlers that build responses out of the request body, and `universal-testing-utils` had nothing to offer them.

### `mockResponseWithImplementation`

Added to both `ApiContract*` helpers. `responseStatus` still selects the contract entry, which is what types `handleRequest`'s return value and supplies the Zod schema the result is validated against.

```ts
// mockttp
await helper.mockResponseWithImplementation(postUserContract, {
  responseStatus: 200,
  handleRequest: async (request) => {
    const body = await request.body.getJson()
    return { id: `id-${body.name}` }
  },
})

// msw
helper.mockResponseWithImplementation(postUserContract, {
  responseStatus: 200,
  handleRequest: async ({ request }) => ({ id: `id-${(await request.json()).name}` }),
})
```

Only JSON entries are addressable. An SSE-only or blob-only status collapses the params type to `never`, so it is rejected at compile time; a runtime guard with a pointer back to `mockResponse` covers untyped callers. Both cases are tested.

### Per-call status via `response()`

Both helpers gain a static `response()`, mirroring `MswHelper.response()`:

```ts
handleRequest: () => callCount++ === 0
  ? ApiContractMockttpHelper.response({ id: 'first' }, { status: 500 })
  : { id: 'second' }
```

The `Symbol` brand behind that wrapper moved out of `MswHelper` into a new `responseWrapper.ts` so all three helpers share **one** brand. Without that, a wrapper made by `MswHelper.response()` would not be recognised by the new helpers. `MswHelper.response()` and `MockResponseWrapper` keep their existing signatures and export paths, so its public surface is unchanged.

### Review follow-up (249aa6fc)

- The reply now carries the media type the contract declared it under. `resolveJsonSchema` dropped the content-map key, so an `application/problem+json` entry went out as `application/json` and the client rejected its own contract's response.
- `contentType` selects between JSON media types, matching the field `mockResponse` already takes. Required when a status entry declares more than one, since the handler's result has to match a specific schema.
- A per-call status override resolves against its own contract entry, so a body wrapped with `response({ status })` is validated against the schema for the status actually sent.
- A request negotiating the SSE branch of a dual JSON/SSE status gets a 406 pointing at `mockResponse`, instead of JSON it cannot read.
- Handler and validation failures are reported through `console.error` and a labelled 500. mockttp and msw otherwise bury a throwing route callback in an opaque 500 that reaches the test as a client-side parse error.
- The handler's request argument is typed from the contract's `requestBodySchema`, so `getJson()` and `request.json()` no longer need a cast at every call site.
- The wrapper brand switched to `Symbol.for`, so two copies of the package in one tree still recognise each other's wrappers.

## Verification

- `pnpm run lint` (biome + tsc): clean
- `pnpm test`: 203 passed, covering the content-map fixtures the new method previously never touched (non-default JSON media types, multi-JSON selection, dual JSON/SSE negotiation, no-body and blob-only statuses) and asserting the emitted content-type header
- `pnpm run build`: clean; confirmed the new methods and `MockResponseWrapper` appear correctly in the emitted `.d.ts`

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

