### PR TITLE
feat: precompile job payload schemas, require zod >= 4.5

### DIFF
--- a/.changeset/precompile-job-payload-schemas.md
+++ b/.changeset/precompile-job-payload-schemas.md
@@ -6,16 +6,16 @@ Precompile registered job payload schemas and require `zod` >= 4.5.0.
 
 The `jobPayloadSchema` of every `QueueConfiguration` is now compiled ahead of time when the configuration is
 registered, so payload validation in `QueueManager`, `FlowManager` and the job processors takes zod's generated
-fast path instead of the interpreted parser. Parsing behavior is unchanged; a schema zod cannot compile keeps
-using the regular parser.
+fast path instead of the interpreted parser. A schema zod refuses to compile (an async refinement or a recursive
+schema) keeps using the regular parser.
 
 Three consequences to be aware of:
 
 - The `zod` peer range moves from `>=3.25.67` to `>=4.5.0 <5.0.0`, since 4.5 is where `z.compile` landed.
-- Passing an already precompiled schema as a `jobPayloadSchema` is a type error, because the library compiles
-  what it is given.
+- Parse results are unchanged, but the fast path only signals that input is invalid, so zod re-runs the original
+  parser to build the error. A synchronous `refine`, `superRefine` or `transform` therefore runs twice for a payload
+  that fails validation, which is observable when such a callback has a side effect outside the parse.
+  `z.config({ jitless: true })` turns precompilation off.
 - `getQueueConfig()` returns a shallow copy of the registered configuration carrying the compiled schema, not the
-  object that was passed in. The config and schema you registered are left untouched.
-
-Adds `precompileSchema`, `isPrecompiledSchema`, and the `PrecompiledSchema` / `NonPrecompiledSchema` types to the
-public API.
+  object that was passed in. The config and schema you registered are left untouched, and the compiled schema is
+  absent from any zod registry the original was added to.

--- a/.changeset/precompile-job-payload-schemas.md
+++ b/.changeset/precompile-job-payload-schemas.md
@@ -1,0 +1,21 @@
+---
+"@lokalise/background-jobs-common": major
+---
+
+Precompile registered job payload schemas and require `zod` >= 4.5.0.
+
+The `jobPayloadSchema` of every `QueueConfiguration` is now compiled ahead of time when the configuration is
+registered, so payload validation in `QueueManager`, `FlowManager` and the job processors takes zod's generated
+fast path instead of the interpreted parser. Parsing behavior is unchanged; a schema zod cannot compile keeps
+using the regular parser.
+
+Three consequences to be aware of:
+
+- The `zod` peer range moves from `>=3.25.67` to `>=4.5.0 <5.0.0`, since 4.5 is where `z.compile` landed.
+- Passing an already precompiled schema as a `jobPayloadSchema` is a type error, because the library compiles
+  what it is given.
+- `getQueueConfig()` returns a shallow copy of the registered configuration carrying the compiled schema, not the
+  object that was passed in. The config and schema you registered are left untouched.
+
+Adds `precompileSchema`, `isPrecompiledSchema`, and the `PrecompiledSchema` / `NonPrecompiledSchema` types to the
+public API.

--- a/packages/app/background-jobs-common/README.md
+++ b/packages/app/background-jobs-common/README.md
@@ -106,31 +106,25 @@ To set up a queue configuration, you need to define a list of objects containing
 
 `zod` can compile a schema ahead of time into a generated fast path, which parses noticeably faster than the
 interpreted parser (roughly 3x on a typical job payload). Registering a queue configuration precompiles its
-`jobPayloadSchema`, so every payload validation the library runs takes that fast path: `QueueManager.schedule` and
+`jobPayloadSchema`, so the payload validations the library runs take that fast path: `QueueManager.schedule` and
 `scheduleBulk`, `FlowManager.addFlow` and `addFlowBulk` (each node in the tree), and the check a processor does on
 `job.data` before `process` runs. Nothing is required on your side.
 
-Because the library handles this, passing a schema you precompiled yourself is a type error:
-
-```typescript
-import { precompileSchema } from '@lokalise/background-jobs-common'
-
-const supportedQueues = [
-  {
-    queueId: 'queue1',
-    // Rejected at compile time: the library precompiles it for you
-    jobPayloadSchema: precompileSchema(JOB_PAYLOAD_SCHEMA),
-  },
-] as const satisfies QueueConfiguration[]
-```
-
 Compiling returns a clone, so the schema the library parses with is not the object you passed in, and
 `getQueueConfig(queueId)` hands back a shallow copy of your configuration carrying that clone. Your own config object
-and schema are left untouched, and parsing behavior is identical: a schema `zod` cannot compile (one with an async
-refinement, say) keeps using the regular parser. `isPrecompiledSchema` tells the two apart if you need it.
+and schema are left untouched.
 
-`precompileSchema` is exported for schemas you parse with yourself elsewhere. It is never needed on a queue
-configuration.
+Some schemas are handed back uncompiled and keep using the regular parser. Async refinements and recursive
+(self-referential) schemas are the two shapes `zod` refuses; nothing breaks, that queue simply does not get the
+speedup. `z.compile(schema, { strict: true })` reports the reason for a given schema.
+
+One behavior does change. The generated fast path only signals that input is invalid, so `zod` re-runs the original
+parser to build the error, and a synchronous `refine`, `superRefine` or `transform` runs **twice for a payload that
+fails validation** (once for a payload that passes). Parse results are the same either way, so this matters only when
+one of those callbacks has a side effect outside the parse, such as incrementing a metric or writing a log line.
+
+To turn precompilation off, set `z.config({ jitless: true })` before your queue configurations are registered. That
+is also what a CSP or no-eval runtime needs, since compiling goes through `new Function`.
 
 ### Purging job data on success
 

--- a/packages/app/background-jobs-common/README.md
+++ b/packages/app/background-jobs-common/README.md
@@ -96,10 +96,41 @@ To set up a queue configuration, you need to define a list of objects containing
    a nested subgroup. The delimiter is `QUEUE_GROUP_DELIMITER`. See [Bull Dashboard Grouping](#bull-dashboard-grouping)
    below for usage and migration guidance — **the grouping is encoded into the queue name, so changing it on an existing
    queue effectively creates a new queue.**
-- **`jobPayloadSchema`**: A Zod schema that defines the structure of the jobs payload for this queue.
+- **`jobPayloadSchema`**: A Zod schema that defines the structure of the jobs payload for this queue. It is
+   precompiled on registration, see [Schema precompilation](#schema-precompilation).
 - **`jobOptions`**: Default options for jobs in this queue. Can be a function that will be resolved when a job is 
    scheduled. See [BullMQ documentation](https://docs.bullmq.io/guide/job-options).
 - **`purgeJobDataOnSuccess`**: Optional boolean, **defaults to `true`**. See [Purging job data on success](#purging-job-data-on-success).
+
+### Schema precompilation
+
+`zod` can compile a schema ahead of time into a generated fast path, which parses noticeably faster than the
+interpreted parser (roughly 3x on a typical job payload). Registering a queue configuration precompiles its
+`jobPayloadSchema`, so every payload validation the library runs takes that fast path: `QueueManager.schedule` and
+`scheduleBulk`, `FlowManager.addFlow` and `addFlowBulk` (each node in the tree), and the check a processor does on
+`job.data` before `process` runs. Nothing is required on your side.
+
+Because the library handles this, passing a schema you precompiled yourself is a type error:
+
+```typescript
+import { precompileSchema } from '@lokalise/background-jobs-common'
+
+const supportedQueues = [
+  {
+    queueId: 'queue1',
+    // Rejected at compile time: the library precompiles it for you
+    jobPayloadSchema: precompileSchema(JOB_PAYLOAD_SCHEMA),
+  },
+] as const satisfies QueueConfiguration[]
+```
+
+Compiling returns a clone, so the schema the library parses with is not the object you passed in, and
+`getQueueConfig(queueId)` hands back a shallow copy of your configuration carrying that clone. Your own config object
+and schema are left untouched, and parsing behavior is identical: a schema `zod` cannot compile (one with an async
+refinement, say) keeps using the regular parser. `isPrecompiledSchema` tells the two apart if you need it.
+
+`precompileSchema` is exported for schemas you parse with yourself elsewhere. It is never needed on a queue
+configuration.
 
 ### Purging job data on success
 

--- a/packages/app/background-jobs-common/UPGRADING.md
+++ b/packages/app/background-jobs-common/UPGRADING.md
@@ -1,5 +1,34 @@
 # Upgrading Guide
 
+## Upgrading from `15.x.x` to `16.0.0`
+
+### Description of Breaking Changes
+
+1. **`zod` peer floor raised to `>=4.5.0 <5.0.0`.**
+  - `zod` 4.5 is where ahead-of-time schema compilation landed, and the library now relies on it. Upgrade `zod` first
+    if you are still on 3.x, or on 4.x below 4.5.
+
+2. **Registered job payload schemas are precompiled automatically.**
+  - The `jobPayloadSchema` of every `QueueConfiguration` is compiled when the configuration is registered, so payload
+    validation in `QueueManager`, `FlowManager` and the job processors takes zod's generated fast path. Parsing
+    behavior does not change, only its speed.
+
+3. **Precompiling a schema yourself is now a type error.**
+  - `QueueConfiguration.jobPayloadSchema` rejects an already precompiled schema. If you were calling `z.compile()`
+    before handing a schema over, drop the call and pass the original schema.
+
+4. **`getQueueConfig()` returns a copy, not the object you registered.**
+  - `QueueConfigRegistry.getQueueConfig()`, `QueueRegistry.getQueueConfig()` and `QueueManager.getQueueConfig()` hand
+    back a shallow copy of the configuration whose `jobPayloadSchema` is the precompiled counterpart. The config
+    object and the schema you passed in are left untouched.
+
+### Migration Steps
+
+- Bump `zod` to `>=4.5.0`.
+- Remove any `z.compile()` call applied to a `jobPayloadSchema`.
+- Replace reference-equality assertions on `getQueueConfig()` results (`expect(config).toBe(MY_CONFIG)`) with
+  content comparisons.
+
 ## Upgrading from `4.0.0` to `5.0.0`
 
 ### Description of Breaking Changes

--- a/packages/app/background-jobs-common/UPGRADING.md
+++ b/packages/app/background-jobs-common/UPGRADING.md
@@ -10,24 +10,30 @@
 
 2. **Registered job payload schemas are precompiled automatically.**
   - The `jobPayloadSchema` of every `QueueConfiguration` is compiled when the configuration is registered, so payload
-    validation in `QueueManager`, `FlowManager` and the job processors takes zod's generated fast path. Parsing
-    behavior does not change, only its speed.
+    validation in `QueueManager`, `FlowManager` and the job processors takes zod's generated fast path. A schema zod
+    refuses to compile (an async refinement or a recursive schema) keeps using the regular parser.
+  - Parse results are unchanged, with one observable difference. The fast path only signals that input is invalid, so
+    zod re-runs the original parser to build the error, and a synchronous `refine`, `superRefine` or `transform` runs
+    twice for a payload that fails validation. Check those callbacks for side effects outside the parse, such as
+    incrementing a metric or writing a log line. `z.config({ jitless: true })` turns precompilation off.
 
-3. **Precompiling a schema yourself is now a type error.**
-  - `QueueConfiguration.jobPayloadSchema` rejects an already precompiled schema. If you were calling `z.compile()`
-    before handing a schema over, drop the call and pass the original schema.
-
-4. **`getQueueConfig()` returns a copy, not the object you registered.**
+3. **`getQueueConfig()` returns a copy, not the object you registered.**
   - `QueueConfigRegistry.getQueueConfig()`, `QueueRegistry.getQueueConfig()` and `QueueManager.getQueueConfig()` hand
     back a shallow copy of the configuration whose `jobPayloadSchema` is the precompiled counterpart. The config
-    object and the schema you passed in are left untouched.
+    object and the schema you passed in are left untouched. The copy is shallow, so nested values such as
+    `bullDashboardGrouping`, `queueOptions` and `jobOptions` are still shared with your object.
+  - The compiled schema is a different object from the one you registered, so it is not a member of any zod registry
+    the original was added to: `z.globalRegistry.has(config.jobPayloadSchema)` and `myRegistry.has(...)` now return
+    `false`. Reading metadata still works, since `.meta()` and `z.toJSONSchema()` resolve through the original.
 
 ### Migration Steps
 
-- Bump `zod` to `>=4.5.0`.
-- Remove any `z.compile()` call applied to a `jobPayloadSchema`.
+- Bump `zod` to `>=4.5.0 <5.0.0`.
 - Replace reference-equality assertions on `getQueueConfig()` results (`expect(config).toBe(MY_CONFIG)`) with
   content comparisons.
+- Look up zod registry entries with the schema you registered, not with `getQueueConfig().jobPayloadSchema`.
+- Drop any `z.compile()` call you applied to a `jobPayloadSchema` yourself. It is accepted and harmless, but the
+  library already does it.
 
 ## Upgrading from `4.0.0` to `5.0.0`
 

--- a/packages/app/background-jobs-common/package.json
+++ b/packages/app/background-jobs-common/package.json
@@ -48,7 +48,7 @@
         "ioredis": "^5.4.1 || ^6.0.0",
         "pino": ">=9.7.0",
         "toad-scheduler": "^4.0.1",
-        "zod": ">=3.25.67"
+        "zod": ">=4.5.0 <5.0.0"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.9",
@@ -63,6 +63,6 @@
         "toad-scheduler": "^4.0.1",
         "typescript": "7.0.2",
         "vitest": "^4.1.11",
-        "zod": "^4.4.3"
+        "zod": "^4.5.4"
     }
 }

--- a/packages/app/background-jobs-common/src/background-job-processor/index.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/index.ts
@@ -3,6 +3,12 @@ export * from './factories/index.ts'
 export * from './logger/BackgroundJobProcessorLogger.ts'
 export * from './managers/index.ts'
 export * from './monitoring/backgroundJobProcessorGetActiveQueueIds.ts'
+export {
+  isPrecompiledSchema,
+  type NonPrecompiledSchema,
+  type PrecompiledSchema,
+  precompileSchema,
+} from './precompileUtils.ts'
 export * from './processors/index.ts'
 export * from './public-utils/index.ts'
 export * from './spy/types.ts'

--- a/packages/app/background-jobs-common/src/background-job-processor/index.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/index.ts
@@ -3,12 +3,6 @@ export * from './factories/index.ts'
 export * from './logger/BackgroundJobProcessorLogger.ts'
 export * from './managers/index.ts'
 export * from './monitoring/backgroundJobProcessorGetActiveQueueIds.ts'
-export {
-  isPrecompiledSchema,
-  type NonPrecompiledSchema,
-  type PrecompiledSchema,
-  precompileSchema,
-} from './precompileUtils.ts'
 export * from './processors/index.ts'
 export * from './public-utils/index.ts'
 export * from './spy/types.ts'

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.spec.ts
@@ -5,6 +5,7 @@ import { TestDependencyFactory } from '../../../test/TestDependencyFactory.ts'
 import { getTestRedisConfig } from '../../../test/TestRedis.ts'
 import { CommonBullmqFactory } from '../factories/index.ts'
 import { backgroundJobProcessorGetActiveQueueIds } from '../monitoring/backgroundJobProcessorGetActiveQueueIds.ts'
+import { isPrecompiledSchema } from '../precompileUtils.ts'
 import { QueueRegistry } from './QueueRegistry.ts'
 import type { QueueConfiguration } from './types.ts'
 
@@ -84,7 +85,9 @@ describe('QueueRegistry', () => {
       getTestRedisConfig(),
     )
     const config = extendedRegistry.getQueueConfig('queue')
-    expect(config).toBe(extendedQueues[0])
+    // registration precompiles the payload schema, so the stored config is a copy
+    expect(config).toEqual({ ...extendedQueues[0], jobPayloadSchema: config.jobPayloadSchema })
+    expect(isPrecompiledSchema(config.jobPayloadSchema)).toBe(true)
     expectTypeOf(config).toMatchTypeOf<ExtendedQueueConfig>()
   })
 
@@ -155,11 +158,18 @@ describe('QueueRegistry', () => {
 
   describe('getQueueConfig', () => {
     it('should return the correct config by queue id', () => {
+      const queue1Payload = { id: 'id', value: 'value', metadata: { correlationId: 'correlation' } }
+
       const config1 = registry.getQueueConfig('queue1')
-      expect(config1).toBe(QUEUES[0])
+      expect(config1).toEqual({ ...QUEUES[0], jobPayloadSchema: config1.jobPayloadSchema })
+      expect(isPrecompiledSchema(config1.jobPayloadSchema)).toBe(true)
+      expect(config1.jobPayloadSchema.safeParse(queue1Payload).success).toBe(true)
 
       const config2 = registry.getQueueConfig('queue2')
-      expect(config2).toBe(QUEUES[1])
+      expect(config2).toEqual({ ...QUEUES[1], jobPayloadSchema: config2.jobPayloadSchema })
+      expect(isPrecompiledSchema(config2.jobPayloadSchema)).toBe(true)
+      // queue2 requires `value2`, so its schema rejects a queue1 payload
+      expect(config2.jobPayloadSchema.safeParse(queue1Payload).success).toBe(false)
     })
 
     it('should throw an error if queue id is not supported', () => {

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.spec.ts
@@ -5,7 +5,7 @@ import { TestDependencyFactory } from '../../../test/TestDependencyFactory.ts'
 import { getTestRedisConfig } from '../../../test/TestRedis.ts'
 import { CommonBullmqFactory } from '../factories/index.ts'
 import { backgroundJobProcessorGetActiveQueueIds } from '../monitoring/backgroundJobProcessorGetActiveQueueIds.ts'
-import { isPrecompiledSchema } from '../precompileUtils.ts'
+import { isPrecompiledSchema, precompileSchema } from '../precompileUtils.ts'
 import { QueueRegistry } from './QueueRegistry.ts'
 import type { QueueConfiguration } from './types.ts'
 
@@ -86,7 +86,12 @@ describe('QueueRegistry', () => {
     )
     const config = extendedRegistry.getQueueConfig('queue')
     // registration precompiles the payload schema, so the stored config is a copy
-    expect(config).toEqual({ ...extendedQueues[0], jobPayloadSchema: config.jobPayloadSchema })
+    expect(config).not.toBe(extendedQueues[0])
+    expect(config.jobPayloadSchema).not.toBe(extendedQueues[0].jobPayloadSchema)
+    expect(config).toEqual({
+      ...extendedQueues[0],
+      jobPayloadSchema: precompileSchema(extendedQueues[0].jobPayloadSchema),
+    })
     expect(isPrecompiledSchema(config.jobPayloadSchema)).toBe(true)
     expectTypeOf(config).toMatchTypeOf<ExtendedQueueConfig>()
   })
@@ -161,12 +166,22 @@ describe('QueueRegistry', () => {
       const queue1Payload = { id: 'id', value: 'value', metadata: { correlationId: 'correlation' } }
 
       const config1 = registry.getQueueConfig('queue1')
-      expect(config1).toEqual({ ...QUEUES[0], jobPayloadSchema: config1.jobPayloadSchema })
+      expect(config1).not.toBe(QUEUES[0])
+      expect(config1.jobPayloadSchema).not.toBe(QUEUES[0].jobPayloadSchema)
+      expect(config1).toEqual({
+        ...QUEUES[0],
+        jobPayloadSchema: precompileSchema(QUEUES[0].jobPayloadSchema),
+      })
       expect(isPrecompiledSchema(config1.jobPayloadSchema)).toBe(true)
       expect(config1.jobPayloadSchema.safeParse(queue1Payload).success).toBe(true)
 
       const config2 = registry.getQueueConfig('queue2')
-      expect(config2).toEqual({ ...QUEUES[1], jobPayloadSchema: config2.jobPayloadSchema })
+      expect(config2).not.toBe(QUEUES[1])
+      expect(config2.jobPayloadSchema).not.toBe(QUEUES[1].jobPayloadSchema)
+      expect(config2).toEqual({
+        ...QUEUES[1],
+        jobPayloadSchema: precompileSchema(QUEUES[1].jobPayloadSchema),
+      })
       expect(isPrecompiledSchema(config2.jobPayloadSchema)).toBe(true)
       // queue2 requires `value2`, so its schema rejects a queue1 payload
       expect(config2.jobPayloadSchema.safeParse(queue1Payload).success).toBe(false)

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.ts
@@ -4,6 +4,7 @@ import { merge } from 'ts-deepmerge'
 import { DEFAULT_QUEUE_OPTIONS } from '../constants.ts'
 import type { BullmqQueueFactory } from '../factories/index.ts'
 import { registerActiveQueueIds } from '../monitoring/registerActiveQueueIds.ts'
+import { precompileSchema } from '../precompileUtils.ts'
 import { enrichRedisConfig, sanitizeRedisConfig } from '../public-utils/index.ts'
 import { resolveQueueId } from '../utils.ts'
 import type { QueueConfiguration, SupportedQueueIds } from './types.ts'
@@ -14,6 +15,9 @@ import type { QueueConfiguration, SupportedQueueIds } from './types.ts'
  * Holds no Bull queue instances and has no lifecycle — use this when you only
  * need typed access to {@link QueueConfiguration} entries (for example, from a
  * FlowManager that publishes through a shared FlowProducer).
+ *
+ * Registering a configuration precompiles its `jobPayloadSchema`, so every payload
+ * validation done through the registry takes zod's generated fast path.
  */
 export class QueueConfigRegistry<
   Queues extends QueueConfiguration<QueueOptionsType, JobOptionsType>[],
@@ -27,11 +31,20 @@ export class QueueConfigRegistry<
   constructor(supportedQueues: Queues) {
     this.queueIds = new Set<string>()
     for (const queue of supportedQueues) {
-      this.queuesConfig[queue.queueId] = queue
+      // Every payload scheduled to or processed from this queue is parsed with the schema, so it is
+      // worth compiling. The stored config is a shallow copy: the caller's object is left untouched.
+      this.queuesConfig[queue.queueId] = {
+        ...queue,
+        jobPayloadSchema: precompileSchema(queue.jobPayloadSchema),
+      } as Queues[number]
       this.queueIds.add(queue.queueId)
     }
   }
 
+  /**
+   * The registered configuration, whose `jobPayloadSchema` is the precompiled counterpart of the
+   * one that was passed in. It is a shallow copy of the caller's config, not the same object.
+   */
   public getQueueConfig(queueId: SupportedQueueIds<Queues>): Queues[number] {
     if (!this.isSupportedQueue(queueId) || !this.queuesConfig[queueId]) {
       throw new Error(`Queue with id ${queueId} is not supported`)

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/QueueRegistry.ts
@@ -16,8 +16,9 @@ import type { QueueConfiguration, SupportedQueueIds } from './types.ts'
  * need typed access to {@link QueueConfiguration} entries (for example, from a
  * FlowManager that publishes through a shared FlowProducer).
  *
- * Registering a configuration precompiles its `jobPayloadSchema`, so every payload
- * validation done through the registry takes zod's generated fast path.
+ * Registering a configuration precompiles its `jobPayloadSchema`, so payload validation done
+ * through the registry takes zod's generated fast path. A schema zod cannot compile keeps using
+ * the regular parser.
  */
 export class QueueConfigRegistry<
   Queues extends QueueConfiguration<QueueOptionsType, JobOptionsType>[],
@@ -32,7 +33,8 @@ export class QueueConfigRegistry<
     this.queueIds = new Set<string>()
     for (const queue of supportedQueues) {
       // Every payload scheduled to or processed from this queue is parsed with the schema, so it is
-      // worth compiling. The stored config is a shallow copy: the caller's object is left untouched.
+      // worth compiling. The stored config is a shallow copy, so replacing a top-level field on the
+      // caller's object afterwards does not reach the registry. Nested values are shared.
       this.queuesConfig[queue.queueId] = {
         ...queue,
         jobPayloadSchema: precompileSchema(queue.jobPayloadSchema),
@@ -43,7 +45,8 @@ export class QueueConfigRegistry<
 
   /**
    * The registered configuration, whose `jobPayloadSchema` is the precompiled counterpart of the
-   * one that was passed in. It is a shallow copy of the caller's config, not the same object.
+   * one that was passed in. It is a shallow copy of the caller's config, not the same object, and
+   * it shares nested values such as `bullDashboardGrouping` with it.
    */
   public getQueueConfig(queueId: SupportedQueueIds<Queues>): Queues[number] {
     if (!this.isSupportedQueue(queueId) || !this.queuesConfig[queueId]) {

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
@@ -2,7 +2,6 @@ import type { RedisConfig } from '@lokalise/node-core'
 import type { FlowProducer, Job, JobsOptions, Queue, QueueBaseOptions, QueueOptions } from 'bullmq'
 import type { z } from 'zod/v4'
 import type { BullmqFlowProducerFactory } from '../factories/BullmqFlowProducerFactory.ts'
-import type { NonPrecompiledSchema } from '../precompileUtils.ts'
 import type { BaseJobPayload } from '../types.ts'
 import type { QueueManager } from './QueueManager.ts'
 
@@ -38,10 +37,10 @@ export type QueueConfiguration<
    */
   purgeJobDataOnSuccess?: boolean
   /**
-   * Zod schema every job payload on this queue is parsed with. It is precompiled on registration,
-   * so pass the schema as you wrote it: an already precompiled one is rejected at compile time.
+   * Zod schema every job payload on this queue is parsed with. Registration precompiles it, so the
+   * schema the library actually parses with is a compiled clone of the one you pass here.
    */
-  jobPayloadSchema: NonPrecompiledSchema<z.ZodType<BaseJobPayload>>
+  jobPayloadSchema: z.ZodType<BaseJobPayload>
   jobOptions?:
     | JobOptionsWithDeduplicationIdBuilder<JobOptionsType>
     // biome-ignore lint/suspicious/noExplicitAny: We cannot infer type of payload, but we have run time validation

--- a/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/managers/types.ts
@@ -2,6 +2,7 @@ import type { RedisConfig } from '@lokalise/node-core'
 import type { FlowProducer, Job, JobsOptions, Queue, QueueBaseOptions, QueueOptions } from 'bullmq'
 import type { z } from 'zod/v4'
 import type { BullmqFlowProducerFactory } from '../factories/BullmqFlowProducerFactory.ts'
+import type { NonPrecompiledSchema } from '../precompileUtils.ts'
 import type { BaseJobPayload } from '../types.ts'
 import type { QueueManager } from './QueueManager.ts'
 
@@ -36,7 +37,11 @@ export type QueueConfiguration<
    * job data in Redis.
    */
   purgeJobDataOnSuccess?: boolean
-  jobPayloadSchema: z.ZodType<BaseJobPayload>
+  /**
+   * Zod schema every job payload on this queue is parsed with. It is precompiled on registration,
+   * so pass the schema as you wrote it: an already precompiled one is rejected at compile time.
+   */
+  jobPayloadSchema: NonPrecompiledSchema<z.ZodType<BaseJobPayload>>
   jobOptions?:
     | JobOptionsWithDeduplicationIdBuilder<JobOptionsType>
     // biome-ignore lint/suspicious/noExplicitAny: We cannot infer type of payload, but we have run time validation

--- a/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod/v4'
+import { QueueConfigRegistry } from './managers/QueueRegistry.ts'
+import type { QueueConfiguration } from './managers/types.ts'
+import {
+  isPrecompiledSchema,
+  type NonPrecompiledSchema,
+  type PrecompiledSchema,
+  precompileSchema,
+} from './precompileUtils.ts'
+
+const JOB_PAYLOAD_SCHEMA = z.object({
+  id: z.string(),
+  metadata: z.object({ correlationId: z.string() }),
+})
+type JobPayload = z.infer<typeof JOB_PAYLOAD_SCHEMA>
+
+const VALID_PAYLOAD: JobPayload = { id: 'job-1', metadata: { correlationId: 'correlation-1' } }
+
+describe('precompileSchema', () => {
+  it('leaves the original schema alone and returns a precompiled clone', () => {
+    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+
+    expect(precompiled).not.toBe(JOB_PAYLOAD_SCHEMA)
+    expect(isPrecompiledSchema(JOB_PAYLOAD_SCHEMA)).toBe(false)
+    expect(isPrecompiledSchema(precompiled)).toBe(true)
+  })
+
+  it('parses exactly like the schema it was built from', () => {
+    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+
+    expect(precompiled.parse(VALID_PAYLOAD)).toEqual(JOB_PAYLOAD_SCHEMA.parse(VALID_PAYLOAD))
+    expect(precompiled.safeParse({ id: 1, metadata: { correlationId: 'c' } }).success).toBe(false)
+    expect(() => precompiled.parse({})).toThrow(z.ZodError)
+  })
+
+  it('is idempotent', () => {
+    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+
+    expect(precompileSchema(precompiled)).toBe(precompiled)
+  })
+
+  it('hands back schemas that zod refuses to compile, still usable', async () => {
+    const asyncSchema = z.string().refine(async (value) => value.length > 0)
+
+    const precompiled = precompileSchema(asyncSchema)
+
+    expect(precompiled).toBe(asyncSchema)
+    expect(isPrecompiledSchema(asyncSchema)).toBe(false)
+    // second call short-circuits on the cache instead of asking zod again
+    expect(precompileSchema(asyncSchema)).toBe(asyncSchema)
+    await expect(precompiled.parseAsync('a')).resolves.toBe('a')
+  })
+
+  it('does not expose the marker as an enumerable property', () => {
+    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+
+    expect(Object.keys(precompiled)).toEqual(Object.keys(JOB_PAYLOAD_SCHEMA))
+    expect(JSON.stringify(precompiled)).toEqual(JSON.stringify(JOB_PAYLOAD_SCHEMA))
+  })
+})
+
+describe('queue configuration registration', () => {
+  const queues = [
+    { queueId: 'queue1', jobPayloadSchema: JOB_PAYLOAD_SCHEMA },
+  ] as const satisfies QueueConfiguration[]
+
+  it('precompiles the payload schema of every registered queue', () => {
+    const registry = new QueueConfigRegistry(queues)
+
+    const { jobPayloadSchema } = registry.getQueueConfig('queue1')
+
+    expect(isPrecompiledSchema(jobPayloadSchema)).toBe(true)
+    expect(jobPayloadSchema.parse(VALID_PAYLOAD)).toEqual(VALID_PAYLOAD)
+  })
+
+  it('keeps the configuration it was given untouched', () => {
+    new QueueConfigRegistry(queues)
+
+    expect(isPrecompiledSchema(queues[0].jobPayloadSchema)).toBe(false)
+    expect(new QueueConfigRegistry(queues).getQueueConfig('queue1')).toMatchObject({
+      queueId: 'queue1',
+    })
+  })
+
+  it('carries the rest of the configuration over to the stored copy', () => {
+    const fullQueues = [
+      {
+        queueId: 'queue1',
+        jobPayloadSchema: JOB_PAYLOAD_SCHEMA,
+        bullDashboardGrouping: ['service', 'module'],
+        purgeJobDataOnSuccess: false,
+        queueOptions: { skipMetasUpdate: true },
+        jobOptions: { attempts: 10 },
+      },
+    ] as const satisfies QueueConfiguration[]
+
+    const config = new QueueConfigRegistry(fullQueues).getQueueConfig('queue1')
+
+    expect(config).toEqual({ ...fullQueues[0], jobPayloadSchema: config.jobPayloadSchema })
+  })
+})
+
+describe('precompilation types', () => {
+  const PRECOMPILED_JOB_PAYLOAD_SCHEMA = precompileSchema(JOB_PAYLOAD_SCHEMA)
+
+  it('keeps the input and output types of the schema it was built from', () => {
+    expectTypeOf<z.output<typeof PRECOMPILED_JOB_PAYLOAD_SCHEMA>>().toEqualTypeOf<JobPayload>()
+    expectTypeOf<z.input<typeof PRECOMPILED_JOB_PAYLOAD_SCHEMA>>().toEqualTypeOf<
+      z.input<typeof JOB_PAYLOAD_SCHEMA>
+    >()
+  })
+
+  it('marks the result as precompiled', () => {
+    expectTypeOf(PRECOMPILED_JOB_PAYLOAD_SCHEMA).toExtend<PrecompiledSchema<unknown>>()
+    expectTypeOf(JOB_PAYLOAD_SCHEMA).not.toExtend<PrecompiledSchema<unknown>>()
+  })
+
+  it('accepts a plain schema on a queue configuration', () => {
+    expectTypeOf(JOB_PAYLOAD_SCHEMA).toExtend<QueueConfiguration['jobPayloadSchema']>()
+    expectTypeOf<NonPrecompiledSchema<typeof JOB_PAYLOAD_SCHEMA>>().toExtend<
+      QueueConfiguration['jobPayloadSchema']
+    >()
+  })
+
+  it('refuses an already precompiled schema on a queue configuration', () => {
+    expectTypeOf(PRECOMPILED_JOB_PAYLOAD_SCHEMA).not.toExtend<
+      QueueConfiguration['jobPayloadSchema']
+    >()
+
+    const config: QueueConfiguration = {
+      queueId: 'queue1',
+      // @ts-expect-error the library precompiles registered schemas, so pass the original one
+      jobPayloadSchema: PRECOMPILED_JOB_PAYLOAD_SCHEMA,
+    }
+
+    expect(config.queueId).toBe('queue1')
+  })
+})

--- a/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.spec.ts
@@ -1,46 +1,53 @@
-import { describe, expect, expectTypeOf, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { z } from 'zod/v4'
 import { QueueConfigRegistry } from './managers/QueueRegistry.ts'
 import type { QueueConfiguration } from './managers/types.ts'
-import {
-  isPrecompiledSchema,
-  type NonPrecompiledSchema,
-  type PrecompiledSchema,
-  precompileSchema,
-} from './precompileUtils.ts'
+import { isPrecompiledSchema, precompileSchema } from './precompileUtils.ts'
 
-const JOB_PAYLOAD_SCHEMA = z.object({
-  id: z.string(),
-  metadata: z.object({ correlationId: z.string() }),
-})
-type JobPayload = z.infer<typeof JOB_PAYLOAD_SCHEMA>
+const PRECOMPILED_SCHEMA_MARKER = Symbol.for('@lokalise/background-jobs-common/precompiledSchema')
+
+// Precompilation is memoized per schema object, so every test builds its own instead of sharing one.
+const buildJobPayloadSchema = () =>
+  z.object({
+    id: z.string(),
+    metadata: z.object({ correlationId: z.string() }),
+  })
+
+type JobPayload = z.infer<ReturnType<typeof buildJobPayloadSchema>>
 
 const VALID_PAYLOAD: JobPayload = { id: 'job-1', metadata: { correlationId: 'correlation-1' } }
 
 describe('precompileSchema', () => {
   it('leaves the original schema alone and returns a precompiled clone', () => {
-    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+    const schema = buildJobPayloadSchema()
 
-    expect(precompiled).not.toBe(JOB_PAYLOAD_SCHEMA)
-    expect(isPrecompiledSchema(JOB_PAYLOAD_SCHEMA)).toBe(false)
+    const precompiled = precompileSchema(schema)
+
+    expect(precompiled).not.toBe(schema)
+    expect(isPrecompiledSchema(schema)).toBe(false)
     expect(isPrecompiledSchema(precompiled)).toBe(true)
   })
 
   it('parses exactly like the schema it was built from', () => {
-    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+    const schema = buildJobPayloadSchema()
 
-    expect(precompiled.parse(VALID_PAYLOAD)).toEqual(JOB_PAYLOAD_SCHEMA.parse(VALID_PAYLOAD))
+    const precompiled = precompileSchema(schema)
+
+    expect(precompiled.parse(VALID_PAYLOAD)).toEqual(schema.parse(VALID_PAYLOAD))
     expect(precompiled.safeParse({ id: 1, metadata: { correlationId: 'c' } }).success).toBe(false)
     expect(() => precompiled.parse({})).toThrow(z.ZodError)
   })
 
-  it('is idempotent', () => {
-    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+  it('compiles a given schema once', () => {
+    const schema = buildJobPayloadSchema()
 
+    const precompiled = precompileSchema(schema)
+
+    expect(precompileSchema(schema)).toBe(precompiled)
     expect(precompileSchema(precompiled)).toBe(precompiled)
   })
 
-  it('hands back schemas that zod refuses to compile, still usable', async () => {
+  it('hands back a schema with an async refinement, still usable', async () => {
     const asyncSchema = z.string().refine(async (value) => value.length > 0)
 
     const precompiled = precompileSchema(asyncSchema)
@@ -52,20 +59,100 @@ describe('precompileSchema', () => {
     await expect(precompiled.parseAsync('a')).resolves.toBe('a')
   })
 
-  it('does not expose the marker as an enumerable property', () => {
-    const precompiled = precompileSchema(JOB_PAYLOAD_SCHEMA)
+  it('hands back a recursive schema, still usable', () => {
+    const recursiveSchema = z.object({
+      id: z.string(),
+      get children() {
+        return z.array(recursiveSchema)
+      },
+    })
 
-    expect(Object.keys(precompiled)).toEqual(Object.keys(JOB_PAYLOAD_SCHEMA))
-    expect(JSON.stringify(precompiled)).toEqual(JSON.stringify(JOB_PAYLOAD_SCHEMA))
+    const precompiled = precompileSchema(recursiveSchema)
+
+    expect(precompiled).toBe(recursiveSchema)
+    expect(isPrecompiledSchema(precompiled)).toBe(false)
+    expect(precompiled.parse({ id: 'a', children: [{ id: 'b', children: [] }] })).toEqual({
+      id: 'a',
+      children: [{ id: 'b', children: [] }],
+    })
+  })
+
+  it('compiles nothing while zod is configured jitless', () => {
+    const schema = buildJobPayloadSchema()
+    const previousJitless = z.config().jitless
+
+    try {
+      z.config({ jitless: true })
+
+      const precompiled = precompileSchema(schema)
+
+      expect(precompiled).toBe(schema)
+      expect(isPrecompiledSchema(precompiled)).toBe(false)
+    } finally {
+      z.config({ jitless: previousJitless })
+    }
+
+    // the refusal is not cached: the same schema compiles once the flag is cleared
+    expect(isPrecompiledSchema(precompileSchema(schema))).toBe(true)
+  })
+
+  it('keeps the marker off the original schema and out of enumeration', () => {
+    const schema = buildJobPayloadSchema()
+
+    const precompiled = precompileSchema(schema)
+
+    expect(Object.getOwnPropertyDescriptor(precompiled, PRECOMPILED_SCHEMA_MARKER)).toMatchObject({
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    })
+    expect(Object.getOwnPropertySymbols(schema)).not.toContain(PRECOMPILED_SCHEMA_MARKER)
+    expect(Object.keys(precompiled)).toEqual(Object.keys(schema))
+    expect(JSON.stringify(precompiled)).toEqual(JSON.stringify(schema))
+  })
+
+  it('runs a synchronous refinement twice for input that fails validation', () => {
+    // The generated fast path only signals that input is invalid, so the original parser reruns to
+    // build the error. The README and UPGRADING notes say so; this test keeps them honest.
+    let calls = 0
+    const schema = z.object({
+      id: z.string().refine(() => {
+        calls++
+        return false
+      }),
+    })
+
+    schema.safeParse({ id: 'a' })
+    const runtimeCalls = calls
+
+    calls = 0
+    precompileSchema(schema).safeParse({ id: 'a' })
+
+    expect(runtimeCalls).toBe(1)
+    expect(calls).toBe(2)
+  })
+
+  it('runs a synchronous refinement once for input that passes validation', () => {
+    let calls = 0
+    const schema = z.object({
+      id: z.string().refine(() => {
+        calls++
+        return true
+      }),
+    })
+
+    precompileSchema(schema).safeParse({ id: 'a' })
+
+    expect(calls).toBe(1)
   })
 })
 
 describe('queue configuration registration', () => {
-  const queues = [
-    { queueId: 'queue1', jobPayloadSchema: JOB_PAYLOAD_SCHEMA },
-  ] as const satisfies QueueConfiguration[]
-
   it('precompiles the payload schema of every registered queue', () => {
+    const queues = [
+      { queueId: 'queue1', jobPayloadSchema: buildJobPayloadSchema() },
+    ] as const satisfies QueueConfiguration[]
+
     const registry = new QueueConfigRegistry(queues)
 
     const { jobPayloadSchema } = registry.getQueueConfig('queue1')
@@ -75,19 +162,40 @@ describe('queue configuration registration', () => {
   })
 
   it('keeps the configuration it was given untouched', () => {
-    new QueueConfigRegistry(queues)
+    const queues = [
+      { queueId: 'queue1', jobPayloadSchema: buildJobPayloadSchema() },
+    ] as const satisfies QueueConfiguration[]
 
+    const config = new QueueConfigRegistry(queues).getQueueConfig('queue1')
+
+    expect(config).not.toBe(queues[0])
+    expect(config.jobPayloadSchema).not.toBe(queues[0].jobPayloadSchema)
     expect(isPrecompiledSchema(queues[0].jobPayloadSchema)).toBe(false)
-    expect(new QueueConfigRegistry(queues).getQueueConfig('queue1')).toMatchObject({
-      queueId: 'queue1',
-    })
+  })
+
+  it('compiles a schema shared by several queues once', () => {
+    const jobPayloadSchema = buildJobPayloadSchema()
+    const queues = [
+      { queueId: 'queue1', jobPayloadSchema },
+      { queueId: 'queue2', jobPayloadSchema },
+    ] as const satisfies QueueConfiguration[]
+
+    const registry = new QueueConfigRegistry(queues)
+
+    expect(registry.getQueueConfig('queue1').jobPayloadSchema).toBe(
+      registry.getQueueConfig('queue2').jobPayloadSchema,
+    )
+    // a second registry reuses the same clone rather than compiling again
+    expect(new QueueConfigRegistry(queues).getQueueConfig('queue1').jobPayloadSchema).toBe(
+      registry.getQueueConfig('queue1').jobPayloadSchema,
+    )
   })
 
   it('carries the rest of the configuration over to the stored copy', () => {
     const fullQueues = [
       {
         queueId: 'queue1',
-        jobPayloadSchema: JOB_PAYLOAD_SCHEMA,
+        jobPayloadSchema: buildJobPayloadSchema(),
         bullDashboardGrouping: ['service', 'module'],
         purgeJobDataOnSuccess: false,
         queueOptions: { skipMetasUpdate: true },
@@ -97,43 +205,9 @@ describe('queue configuration registration', () => {
 
     const config = new QueueConfigRegistry(fullQueues).getQueueConfig('queue1')
 
-    expect(config).toEqual({ ...fullQueues[0], jobPayloadSchema: config.jobPayloadSchema })
-  })
-})
-
-describe('precompilation types', () => {
-  const PRECOMPILED_JOB_PAYLOAD_SCHEMA = precompileSchema(JOB_PAYLOAD_SCHEMA)
-
-  it('keeps the input and output types of the schema it was built from', () => {
-    expectTypeOf<z.output<typeof PRECOMPILED_JOB_PAYLOAD_SCHEMA>>().toEqualTypeOf<JobPayload>()
-    expectTypeOf<z.input<typeof PRECOMPILED_JOB_PAYLOAD_SCHEMA>>().toEqualTypeOf<
-      z.input<typeof JOB_PAYLOAD_SCHEMA>
-    >()
-  })
-
-  it('marks the result as precompiled', () => {
-    expectTypeOf(PRECOMPILED_JOB_PAYLOAD_SCHEMA).toExtend<PrecompiledSchema<unknown>>()
-    expectTypeOf(JOB_PAYLOAD_SCHEMA).not.toExtend<PrecompiledSchema<unknown>>()
-  })
-
-  it('accepts a plain schema on a queue configuration', () => {
-    expectTypeOf(JOB_PAYLOAD_SCHEMA).toExtend<QueueConfiguration['jobPayloadSchema']>()
-    expectTypeOf<NonPrecompiledSchema<typeof JOB_PAYLOAD_SCHEMA>>().toExtend<
-      QueueConfiguration['jobPayloadSchema']
-    >()
-  })
-
-  it('refuses an already precompiled schema on a queue configuration', () => {
-    expectTypeOf(PRECOMPILED_JOB_PAYLOAD_SCHEMA).not.toExtend<
-      QueueConfiguration['jobPayloadSchema']
-    >()
-
-    const config: QueueConfiguration = {
-      queueId: 'queue1',
-      // @ts-expect-error the library precompiles registered schemas, so pass the original one
-      jobPayloadSchema: PRECOMPILED_JOB_PAYLOAD_SCHEMA,
-    }
-
-    expect(config.queueId).toBe('queue1')
+    expect(config).toEqual({
+      ...fullQueues[0],
+      jobPayloadSchema: precompileSchema(fullQueues[0].jobPayloadSchema),
+    })
   })
 })

--- a/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.ts
@@ -1,76 +1,81 @@
-import { compile, type ZodType } from 'zod/v4'
+import { compile, config, type ZodType } from 'zod/v4'
 
 /**
- * Set on every schema returned by {@link precompileSchema}. Registered on the global symbol
- * registry so that two copies of this package within one dependency tree recognize each other's
- * work instead of compiling the same schema twice.
+ * Set on every compiled clone produced by {@link precompileSchema}. Registered on the global symbol
+ * registry so that a clone built by one copy of this package is recognized by another copy in the
+ * same dependency tree, instead of being handed to `compile` a second time.
  */
 const PRECOMPILED_SCHEMA_MARKER = Symbol.for('@lokalise/background-jobs-common/precompiledSchema')
 
 /**
- * Schemas that zod's fast path cannot model (async refinements, unsupported features). `compile`
- * hands those back untouched, and there is no place to put the marker without mutating a schema
- * the caller owns, so they are remembered here to keep repeated registrations cheap.
+ * Keyed on the schema handed to {@link precompileSchema}, holding whatever came back for it: the
+ * compiled clone, or the schema itself when zod refused to compile it. Two queues sharing one
+ * schema, or the same configuration array registered by several managers, then compile once.
  */
-const nonCompilableSchemas = new WeakSet<ZodType>()
-
-/**
- * Phantom property, never present at runtime. It exists so that a precompiled schema is
- * distinguishable from a plain one at the type level.
- */
-type PrecompiledSchemaBrand = {
-  readonly __precompiledSchema: true
-}
-
-/** A schema whose validation fast path has already been built by {@link precompileSchema}. */
-export type PrecompiledSchema<Schema> = Schema & PrecompiledSchemaBrand
-
-/**
- * Marks an API position that takes a schema this library has not seen yet. Every registered schema
- * is precompiled on registration, so handing over an already precompiled one is duplicated work;
- * this type turns that into a compile error.
- */
-export type NonPrecompiledSchema<Schema> = Schema & {
-  readonly __precompiledSchema?: 'this schema is already precompiled, pass the original one instead'
-}
+const precompiledSchemas = new WeakMap<ZodType, ZodType>()
 
 /**
  * Reports whether the schema is a compiled clone produced by {@link precompileSchema}. A schema
- * zod refused to compile is not one: it is handed back as the caller's own object, which is left
- * untouched.
+ * zod refused to compile is not one: it is handed back as the caller's own object, untouched.
  */
-export const isPrecompiledSchema = <Schema extends ZodType>(
-  schema: Schema,
-): schema is PrecompiledSchema<Schema> =>
+export const isPrecompiledSchema = (schema: ZodType): boolean =>
   (schema as unknown as Record<symbol, unknown>)[PRECOMPILED_SCHEMA_MARKER] === true
 
 /**
  * Builds an ahead-of-time compiled clone of the given schema, which parses noticeably faster than
- * the interpreted one. Users of this library never need to call it: every `jobPayloadSchema` on a
- * queue configuration is precompiled when the configuration is registered.
+ * the interpreted one. Every `jobPayloadSchema` on a queue configuration goes through this when the
+ * configuration is registered; nothing else needs to call it.
  *
- * The original schema is left untouched, and the call is idempotent: a schema that already went
- * through it is returned as is. A schema zod refuses to compile keeps using the regular runtime
- * parser, with no observable difference for the caller.
+ * The original schema is left untouched, and asking twice for the same schema returns the same
+ * clone. Two cases hand the input straight back, and the caller keeps using the runtime parser:
+ *
+ * - `z.config({ jitless: true })` is set. The flag exists so that CSP/no-eval environments never
+ *   reach `new Function`, and it doubles as the way to turn precompilation off.
+ * - zod refuses the schema. Async refinements and recursive (self-referential) schemas are the two
+ *   shapes to expect; `z.compile(schema, { strict: true })` reports the reason for a given schema.
+ *
+ * One behavior does change on a compiled clone. The generated fast path only signals that input is
+ * invalid, so zod re-runs the original parser to build the error, and a synchronous `refine`,
+ * `superRefine` or `transform` therefore runs twice for input that fails validation (once for input
+ * that passes). Parse results are identical either way, but a callback with a side effect outside
+ * the parse, incrementing a metric for instance, fires twice.
  */
-export const precompileSchema = <Schema extends ZodType>(
-  schema: Schema,
-): PrecompiledSchema<Schema> => {
+export const precompileSchema = <Schema extends ZodType>(schema: Schema): Schema => {
   if (isPrecompiledSchema(schema)) return schema
-  if (nonCompilableSchemas.has(schema)) return schema as PrecompiledSchema<Schema>
 
-  const precompiled = compile(schema)
-  if (precompiled === schema) {
-    nonCompilableSchemas.add(schema)
-    return schema as PrecompiledSchema<Schema>
+  const known = precompiledSchemas.get(schema)
+  if (known) return known as Schema
+
+  // Deliberately not cached: the flag can be flipped between calls, and honoring it is the point.
+  if (config().jitless) return schema
+
+  const precompiled = compileAndMark(schema)
+  precompiledSchemas.set(schema, precompiled)
+
+  return precompiled
+}
+
+/**
+ * Registering a queue configuration could not fail before payload schemas were compiled, and it
+ * still cannot. `compile` documents that it never throws, and anything that escapes it anyway, or
+ * escapes marking the clone, costs the fast path rather than the boot.
+ */
+const compileAndMark = <Schema extends ZodType>(schema: Schema): Schema => {
+  try {
+    const precompiled = compile(schema)
+    if (precompiled === schema) return schema
+
+    Object.defineProperty(precompiled, PRECOMPILED_SCHEMA_MARKER, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    })
+
+    return precompiled
+    /* v8 ignore start */
+  } catch {
+    return schema
   }
-
-  Object.defineProperty(precompiled, PRECOMPILED_SCHEMA_MARKER, {
-    value: true,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  })
-
-  return precompiled as PrecompiledSchema<Schema>
+  /* v8 ignore stop */
 }

--- a/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/precompileUtils.ts
@@ -1,0 +1,76 @@
+import { compile, type ZodType } from 'zod/v4'
+
+/**
+ * Set on every schema returned by {@link precompileSchema}. Registered on the global symbol
+ * registry so that two copies of this package within one dependency tree recognize each other's
+ * work instead of compiling the same schema twice.
+ */
+const PRECOMPILED_SCHEMA_MARKER = Symbol.for('@lokalise/background-jobs-common/precompiledSchema')
+
+/**
+ * Schemas that zod's fast path cannot model (async refinements, unsupported features). `compile`
+ * hands those back untouched, and there is no place to put the marker without mutating a schema
+ * the caller owns, so they are remembered here to keep repeated registrations cheap.
+ */
+const nonCompilableSchemas = new WeakSet<ZodType>()
+
+/**
+ * Phantom property, never present at runtime. It exists so that a precompiled schema is
+ * distinguishable from a plain one at the type level.
+ */
+type PrecompiledSchemaBrand = {
+  readonly __precompiledSchema: true
+}
+
+/** A schema whose validation fast path has already been built by {@link precompileSchema}. */
+export type PrecompiledSchema<Schema> = Schema & PrecompiledSchemaBrand
+
+/**
+ * Marks an API position that takes a schema this library has not seen yet. Every registered schema
+ * is precompiled on registration, so handing over an already precompiled one is duplicated work;
+ * this type turns that into a compile error.
+ */
+export type NonPrecompiledSchema<Schema> = Schema & {
+  readonly __precompiledSchema?: 'this schema is already precompiled, pass the original one instead'
+}
+
+/**
+ * Reports whether the schema is a compiled clone produced by {@link precompileSchema}. A schema
+ * zod refused to compile is not one: it is handed back as the caller's own object, which is left
+ * untouched.
+ */
+export const isPrecompiledSchema = <Schema extends ZodType>(
+  schema: Schema,
+): schema is PrecompiledSchema<Schema> =>
+  (schema as unknown as Record<symbol, unknown>)[PRECOMPILED_SCHEMA_MARKER] === true
+
+/**
+ * Builds an ahead-of-time compiled clone of the given schema, which parses noticeably faster than
+ * the interpreted one. Users of this library never need to call it: every `jobPayloadSchema` on a
+ * queue configuration is precompiled when the configuration is registered.
+ *
+ * The original schema is left untouched, and the call is idempotent: a schema that already went
+ * through it is returned as is. A schema zod refuses to compile keeps using the regular runtime
+ * parser, with no observable difference for the caller.
+ */
+export const precompileSchema = <Schema extends ZodType>(
+  schema: Schema,
+): PrecompiledSchema<Schema> => {
+  if (isPrecompiledSchema(schema)) return schema
+  if (nonCompilableSchemas.has(schema)) return schema as PrecompiledSchema<Schema>
+
+  const precompiled = compile(schema)
+  if (precompiled === schema) {
+    nonCompilableSchemas.add(schema)
+    return schema as PrecompiledSchema<Schema>
+  }
+
+  Object.defineProperty(precompiled, PRECOMPILED_SCHEMA_MARKER, {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  })
+
+  return precompiled as PrecompiledSchema<Schema>
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,7 +301,7 @@ importers:
         version: link:../../dev/biome-config
       '@lokalise/fastify-extras':
         specifier: ^31.0.0
-        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@15.2.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.3(supports-color@8.1.1))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.12.1)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
+        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.3(supports-color@8.1.1))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.4.1
         version: 14.8.1(zod@4.4.3)
@@ -446,7 +446,7 @@ importers:
         version: link:../id-utils
       '@lokalise/node-core':
         specifier: ^14.9.1
-        version: 14.9.1(zod@4.4.3)
+        version: 14.9.1(zod@4.5.4)
       redis-semaphore:
         specifier: ^5.7.0
         version: 5.7.0(ioredis@6.0.0(supports-color@8.1.1))(supports-color@8.1.1)
@@ -491,8 +491,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.4
+        version: 4.5.4
 
   packages/app/context-fastify-plugins:
     dependencies:
@@ -781,7 +781,7 @@ importers:
         version: link:../../dev/biome-config
       '@lokalise/fastify-extras':
         specifier: ^31.0.1
-        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.12.1)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
+        version: 31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)
       '@lokalise/node-core':
         specifier: ^14.1.0
         version: 14.8.1(zod@4.4.3)
@@ -4142,6 +4142,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
@@ -7529,6 +7534,9 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
   zstd-codec@0.1.5:
     resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==}
 
@@ -8414,6 +8422,10 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@lokalise/api-contracts@8.0.0(zod@4.5.4)':
+    dependencies:
+      zod: 4.5.4
+
   '@lokalise/background-jobs-common@15.2.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.4.3)':
     dependencies:
       '@lokalise/id-utils': 3.0.1
@@ -8425,6 +8437,20 @@ snapshots:
       toad-scheduler: 4.1.0
       ts-deepmerge: 8.0.0
       zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@lokalise/background-jobs-common@15.2.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.5.4)':
+    dependencies:
+      '@lokalise/id-utils': 3.0.1
+      '@lokalise/node-core': 14.9.1(zod@4.5.4)
+      bullmq: 5.81.3(supports-color@8.1.1)
+      ioredis: 5.11.1(supports-color@8.1.1)
+      pino: 10.3.1
+      redis-semaphore: 5.7.0(ioredis@5.11.1(supports-color@8.1.1))(supports-color@8.1.1)
+      toad-scheduler: 4.1.0
+      ts-deepmerge: 8.0.0
+      zod: 4.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -8484,14 +8510,44 @@ snapshots:
       - encoding
       - supports-color
 
-  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.4.3))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.4.3))(fastify@5.12.1)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
+  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@15.2.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.5.4))(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@5.81.3(supports-color@8.1.1))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@amplitude/analytics-node': 1.5.68
       '@bugsnag/js': 8.10.0
       '@bugsnag/node': 8.10.0
       '@fastify/error': 4.2.0
       '@fastify/jwt': 10.2.1
-      '@lokalise/api-contracts': 8.0.0(zod@4.4.3)
+      '@lokalise/api-contracts': 8.0.0(zod@4.5.4)
+      '@lokalise/background-jobs-common': 15.2.0(bullmq@5.81.3(supports-color@8.1.1))(ioredis@5.11.1(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(toad-scheduler@4.1.0)(zod@4.5.4)
+      '@lokalise/error-utils': 3.0.0(@lokalise/node-core@14.8.1(zod@4.4.3))
+      '@lokalise/node-core': 14.8.1(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      '@splitsoftware/splitio': 11.11.2(supports-color@8.1.1)
+      '@supercharge/promise-pool': 3.3.0
+      bullmq: 5.81.3(supports-color@8.1.1)
+      dd-trace: 6.11.0
+      fastify: 5.12.1
+      fastify-metrics: 13.2.1(fastify@5.12.1)
+      fastify-plugin: 5.1.0
+      fastify-type-provider-zod: 7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4)
+      ioredis: 5.11.1(supports-color@8.1.1)
+      pino: 10.3.1
+      prom-client: 15.1.3
+      toad-cache: 3.7.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@platformatic/prom-client'
+      - encoding
+      - supports-color
+
+  '@lokalise/fastify-extras@31.0.1(@fastify/jwt@10.2.1)(@lokalise/api-contracts@8.0.0(zod@4.5.4))(@lokalise/background-jobs-common@packages+app+background-jobs-common)(@lokalise/node-core@14.8.1(zod@4.4.3))(@opentelemetry/api@1.9.1)(bullmq@6.2.0(ioredis@6.0.0(supports-color@8.1.1))(pg@8.22.0))(dd-trace@6.11.0)(fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4))(fastify@5.12.1)(ioredis@6.0.0(supports-color@8.1.1))(pino@10.3.1)(supports-color@8.1.1)(zod@4.4.3)':
+    dependencies:
+      '@amplitude/analytics-node': 1.5.68
+      '@bugsnag/js': 8.10.0
+      '@bugsnag/node': 8.10.0
+      '@fastify/error': 4.2.0
+      '@fastify/jwt': 10.2.1
+      '@lokalise/api-contracts': 8.0.0(zod@4.5.4)
       '@lokalise/background-jobs-common': link:packages/app/background-jobs-common
       '@lokalise/error-utils': 3.0.0(@lokalise/node-core@14.8.1(zod@4.4.3))
       '@lokalise/node-core': 14.8.1(zod@4.4.3)
@@ -8503,7 +8559,7 @@ snapshots:
       fastify: 5.12.1
       fastify-metrics: 13.2.1(fastify@5.12.1)
       fastify-plugin: 5.1.0
-      fastify-type-provider-zod: 7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.4.3)
+      fastify-type-provider-zod: 7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4)
       ioredis: 6.0.0(supports-color@8.1.1)
       pino: 10.3.1
       prom-client: 15.1.3
@@ -8543,6 +8599,14 @@ snapshots:
       pino-pretty: 13.1.3
       tslib: 2.8.1
       zod: 4.4.3
+
+  '@lokalise/node-core@14.9.1(zod@4.5.4)':
+    dependencies:
+      dot-prop: 6.0.1
+      pino: 10.3.1
+      pino-pretty: 13.1.3
+      tslib: 2.8.1
+      zod: 4.5.4
 
   '@lokalise/universal-ts-utils@4.11.0': {}
 
@@ -10724,11 +10788,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 7.0.2
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -11991,6 +12057,14 @@ snapshots:
       fastify: 5.12.1
       openapi-types: 12.1.3
       zod: 4.4.3
+
+  fastify-type-provider-zod@7.0.0(@fastify/swagger@9.8.1(supports-color@8.1.1))(fastify@5.12.1)(openapi-types@12.1.3)(zod@4.5.4):
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@fastify/swagger': 9.8.1(supports-color@8.1.1)
+      fastify: 5.12.1
+      openapi-types: 12.1.3
+      zod: 4.5.4
 
   fastify@5.12.1:
     dependencies:
@@ -14248,7 +14322,7 @@ snapshots:
     dependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@26.2.0)
       '@rollup/pluginutils': 5.4.0(rollup@4.63.0)
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@7.0.2)
       '@vue/language-core': 2.2.0(typescript@7.0.2)
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -14523,5 +14597,7 @@ snapshots:
       graphmatch: 1.1.1
 
   zod@4.4.3: {}
+
+  zod@4.5.4: {}
 
   zstd-codec@0.1.5: {}


### PR DESCRIPTION
## What

`background-jobs-common` now precompiles every registered `jobPayloadSchema` and requires `zod` >= 4.5.

`zod` 4.5 added `z.compile()`, which turns a schema into a generated fast path instead of walking it interpreted on
every parse. Measured on a typical job payload (5 fields, one nested object, one array) it is roughly 3x faster.

Modelled on [message-queue-toolkit#560](https://github.com/kibertoad/message-queue-toolkit/pull/560).

## How

`QueueConfigRegistry` is the single place a queue configuration is registered, and all four runtime parse sites reach
their schema through it:

| site | call |
| --- | --- |
| `QueueManager.schedule` | `getQueueConfig(id).jobPayloadSchema.parse` |
| `QueueManager.scheduleBulk` | `getQueueConfig(id).jobPayloadSchema.parse` |
| `FlowManager.addFlow` / `addFlowBulk` | `getQueueConfig(id).jobPayloadSchema.parse` per node |
| `AbstractBackgroundJobProcessorNew.processInternal` | `getQueueConfig(id).jobPayloadSchema.safeParse` |

So the registry constructor compiles once, and every site gets the fast path with no call-site changes. That is also
why a new parse site cannot accidentally miss it: there is no uncompiled schema to reach for.

`precompileUtils.ts` holds `precompileSchema` and `isPrecompiledSchema`, both internal. Neither is exported from the
package, since the registry is the only caller and anyone wanting to compile a schema of their own already has
`z.compile()`. `QueueConfiguration.jobPayloadSchema` keeps its `z.ZodType<BaseJobPayload>` type, so no configuration
that type-checked before stops type-checking.

`precompileSchema` leaves the caller's schema untouched and marks the clone with a `Symbol.for`-registered
non-enumerable marker. Results are memoized in a `WeakMap` keyed on the input schema, so a schema shared by several
queues, or one configuration array registered by several managers, compiles once. Schemas `zod` refuses (async
refinements and recursive schemas) come back unchanged and keep using the runtime parser, and
`z.config({ jitless: true })` skips compilation entirely, which is both the CSP/no-eval requirement and the opt-out.

## The one behavior that changes

The generated fast path only signals that input is invalid, so `zod` re-runs the original parser to build the error.
A synchronous `refine`, `superRefine` or `transform` therefore runs **twice for a payload that fails validation**,
once for a payload that passes. Parse results are identical either way; the difference is observable only when such a
callback has a side effect outside the parse, such as incrementing a metric or writing a log line.

Measured against the installed `zod` 4.5.4, documented in the README, `UPGRADING.md` and the changeset, and pinned by
two tests so a future `zod` change forces the docs to be revisited.

## Breaking changes

1. `zod` peer range moves from `>=3.25.67` to `>=4.5.0 <5.0.0`.
2. `getQueueConfig()` returns a shallow copy of the registered configuration carrying the compiled schema, not the
   object that was passed in. Reference-equality assertions against the original config need to compare on content.
   The config object and schema you registered are left untouched, and since the compiled schema is a different
   object, `z.globalRegistry.has(config.jobPayloadSchema)` now returns `false` (`.meta()` and `z.toJSONSchema()` keep
   working, they resolve through the original).

`UPGRADING.md` has the migration steps; the changeset is a major.

## Testing

- `precompileUtils.spec.ts`: 13 cases covering the clone/original split, parse equivalence, memoization, the async
  and recursive fallbacks, the `jitless` opt-out, marker non-enumerability, the double-run callback counts, and
  registry integration. 100% coverage of the new file.
- `QueueRegistry.spec.ts`: the identity assertions now check both that the stored config is a copy (`not.toBe` on the
  config and on its schema) and that each queue kept its own schema, with the expected schema derived from the
  registered config rather than read off the actual.
- `biome check`, `tsc` and `turbo lint` clean, including the two workspace dependents (`fastify-bullboard-plugin`,
  `healthcheck-utils`).
- CI green on Node 22.x and 24.x. `AbstractBackgroundJobProcessor.spec.ts > restart processor after dispose` failed
  once on 22.x and passed on re-run with no code change; it is a bullmq worker shutdown race in the deprecated
  processor, which this PR does not touch.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
