### PR TITLE
fix: preserve error cause details in Bugsnag reports and job error logs

### DIFF
--- a/.changeset/preserve-error-cause-details.md
+++ b/.changeset/preserve-error-cause-details.md
@@ -1,0 +1,13 @@
+---
+'@lokalise/error-utils': patch
+'@lokalise/background-jobs-common': patch
+---
+
+Preserve `details` from wrapped errors' `cause` chain when reporting to Bugsnag and when
+serializing errors for logging in background job processors. Previously, an error's own `details`
+(e.g. an HTTP response body captured on a lower-level `ResponseStatusError`) were lost once that
+error was wrapped as the `cause` of another error, since Bugsnag reporting only read the top-level
+error's `details` and job processors serialized errors with `pino.stdSerializers.err`, which drops
+`cause` entirely. Bugsnag reports now include a `causeDetails` array with each cause's `details`,
+and job processors now use `pino.stdSerializers.errWithCause` to keep the full cause chain (and its
+custom fields) in logged `errorJson`.

--- a/.changeset/preserve-error-cause-details.md
+++ b/.changeset/preserve-error-cause-details.md
@@ -1,5 +1,5 @@
 ---
-'@lokalise/error-utils': patch
+'@lokalise/error-utils': major
 '@lokalise/background-jobs-common': patch
 ---
 
@@ -8,6 +8,16 @@ serializing errors for logging in background job processors. Previously, an erro
 (e.g. an HTTP response body captured on a lower-level `ResponseStatusError`) were lost once that
 error was wrapped as the `cause` of another error, since Bugsnag reporting only read the top-level
 error's `details` and job processors serialized errors with `pino.stdSerializers.err`, which drops
-`cause` entirely. Bugsnag reports now include a `causeDetails` array with each cause's `details`,
-and job processors now use `pino.stdSerializers.errWithCause` to keep the full cause chain (and its
-custom fields) in logged `errorJson`.
+`cause` entirely. Bugsnag reports now include an `err` metadata field built with
+`pino-std-serializers`' `errWithCause`, carrying the full cause chain along with `details`,
+`errorCode`, and any other custom error properties at every level (replacing the previous flat
+`errorDetails`/`errorCode`/`causeDetails` fields), and job processors now use
+`pino.stdSerializers.errWithCause` to keep the full cause chain (and its custom fields) in logged
+`errorJson`.
+
+`@lokalise/error-utils` now uses the native `Error.isError` and requires Node `>=24.3.0`
+(declared via `engines.node`), a breaking change for consumers on older Node versions.
+
+`AbstractBackgroundJobProcessorNew` no longer duplicates error serialization in the `context`
+passed to the error reporter (`errorJson`/`error` fields), since Bugsnag reporting now serializes
+the full error (including `cause`) itself.

--- a/.changeset/preserve-error-cause-details.md
+++ b/.changeset/preserve-error-cause-details.md
@@ -1,26 +1,23 @@
 ---
 '@lokalise/error-utils': major
-'@lokalise/background-jobs-common': patch
+'@lokalise/background-jobs-common': minor
 ---
 
-Preserve `details` from wrapped errors' `cause` chain when reporting to Bugsnag and when
-serializing errors for logging in background job processors. Previously, an error's own `details`
-(e.g. an HTTP response body captured on a lower-level `ResponseStatusError`) were lost once that
-error was wrapped as the `cause` of another error, since Bugsnag reporting only read the top-level
-error's `details` and job processors serialized errors with `pino.stdSerializers.err`, which drops
-`cause` entirely. Bugsnag reports now include an `err` metadata field built with
-`pino-std-serializers`' `errWithCause`, carrying the full cause chain along with `details`,
+Preserve `details` from wrapped errors' `cause` chain when reporting to Bugsnag. Previously, an
+error's own `details` (e.g. an HTTP response body captured on a lower-level `ResponseStatusError`)
+were lost once that error was wrapped as the `cause` of another error, since Bugsnag reporting only
+read the top-level error's `details`. Bugsnag reports now include an `err` metadata field built
+with `pino-std-serializers`' `errWithCause`, carrying the full cause chain along with `details`,
 `errorCode`, and any other custom error properties at every level (replacing the previous flat
-`errorDetails`/`errorCode`/`causeDetails` fields), and job processors now use
-`pino.stdSerializers.errWithCause` to keep the full cause chain (and its custom fields) in logged
-`errorJson`.
+`errorDetails`/`errorCode`/`causeDetails` fields).
 
-`@lokalise/error-utils` now uses the native `Error.isError` and requires Node `>=24.3.0`
-(declared via `engines.node`), a breaking change for consumers on older Node versions.
+`@lokalise/error-utils` now uses the native `Error.isError` and requires Node `>=24.3.0` (declared
+via `engines.node`), a breaking change for consumers on older Node versions.
 
-`AbstractBackgroundJobProcessor` and `AbstractBackgroundJobProcessorNew` no longer duplicate error
-serialization in the `context` passed to the error reporter (`errorJson`/`error` fields), since
-Bugsnag reporting now serializes the full error (including `cause`) itself. Non-`Error` values
-thrown from `onSuccess`/`onFailed` hooks are still reported with a `nonErrorValue` context field,
-since in that case the `error` passed to the reporter is a synthetic placeholder with nothing for
-Bugsnag to extract.
+`AbstractBackgroundJobProcessor` and `AbstractBackgroundJobProcessorNew` no longer serialize
+errors into the `context` passed to the error reporter (dropping the `errorJson`/`error` context
+fields), since Bugsnag reporting now serializes the full error (including `cause`) itself; a
+consumer using a different `ErrorReporter` implementation will see less data in `context` than
+before. Non-`Error` values thrown from `onSuccess`/`onFailed` hooks are still reported via a
+`nonErrorValue` context field, since in that case the `error` passed to the reporter is a synthetic
+placeholder with nothing for a reporter to extract.

--- a/.changeset/preserve-error-cause-details.md
+++ b/.changeset/preserve-error-cause-details.md
@@ -18,6 +18,6 @@ error's `details` and job processors serialized errors with `pino.stdSerializers
 `@lokalise/error-utils` now uses the native `Error.isError` and requires Node `>=24.3.0`
 (declared via `engines.node`), a breaking change for consumers on older Node versions.
 
-`AbstractBackgroundJobProcessorNew` no longer duplicates error serialization in the `context`
-passed to the error reporter (`errorJson`/`error` fields), since Bugsnag reporting now serializes
-the full error (including `cause`) itself.
+`AbstractBackgroundJobProcessor` and `AbstractBackgroundJobProcessorNew` no longer duplicate error
+serialization in the `context` passed to the error reporter (`errorJson`/`error` fields), since
+Bugsnag reporting now serializes the full error (including `cause`) itself.

--- a/.changeset/preserve-error-cause-details.md
+++ b/.changeset/preserve-error-cause-details.md
@@ -20,4 +20,7 @@ error's `details` and job processors serialized errors with `pino.stdSerializers
 
 `AbstractBackgroundJobProcessor` and `AbstractBackgroundJobProcessorNew` no longer duplicate error
 serialization in the `context` passed to the error reporter (`errorJson`/`error` fields), since
-Bugsnag reporting now serializes the full error (including `cause`) itself.
+Bugsnag reporting now serializes the full error (including `cause`) itself. Non-`Error` values
+thrown from `onSuccess`/`onFailed` hooks are still reported with a `nonErrorValue` context field,
+since in that case the `error` passed to the reporter is a synthetic placeholder with nothing for
+Bugsnag to extract.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x, 26.x]
         package-name: ${{ fromJson(needs.changed-files-job.outputs.packages) }}
     uses: ./.github/workflows/ci.package.yml
     with:

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -641,7 +641,6 @@ describe('AbstractBackgroundJobProcessor', () => {
           jobId: job.id,
           jobName: 'AbstractBackgroundJobProcessor_error',
           'x-request-id': 'correlation_id',
-          error: expect.stringContaining(onFailedError.message),
         },
       })
     })
@@ -713,7 +712,6 @@ describe('AbstractBackgroundJobProcessor', () => {
           jobId,
           jobName: 'TestStalledBackgroundJobProcessor queue',
           'x-request-id': jobData.metadata.correlationId,
-          errorJson: expect.stringContaining(onFailedCall!.error.message),
         },
       })
     })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -645,6 +645,40 @@ describe('AbstractBackgroundJobProcessor', () => {
       })
     })
 
+    it('non-Error value thrown from failed hook is reported with nonErrorValue in context', async () => {
+      // Given
+      processor.errorToThrowOnFailed = 'redis timeout'
+      processor.errorsToThrowOnProcess = [new UnrecoverableError('unrecoverable error')]
+
+      const reportSpy = vi.spyOn(deps.errorReporter, 'report')
+
+      // When
+      const jobId = await processor.schedule(
+        {
+          id: 'test_id',
+          value: 'test',
+          metadata: { correlationId: 'correlation_id' },
+        },
+        { attempts: 3, delay: 0 },
+      )
+
+      // Then
+      const job = await processor.spy.waitForJobWithId(jobId, 'failed')
+
+      expect(processor.errorsOnProcess).length(1)
+      expect(reportSpy).toHaveBeenCalledWith({
+        error: expect.objectContaining({
+          message: 'TestFailingBackgroundJobProcessor onFailed non-error exception',
+        }),
+        context: {
+          jobId: job.id,
+          jobName: 'AbstractBackgroundJobProcessor_error',
+          'x-request-id': 'correlation_id',
+          nonErrorValue: JSON.stringify('redis timeout'),
+        },
+      })
+    })
+
     it('job throws muted unrecoverable error and it is not reported', async () => {
       // Given
       const errorReporterSpy = vi.spyOn(deps.errorReporter, 'report')

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -399,7 +399,7 @@ export abstract class AbstractBackgroundJobProcessor<
           jobId: resolveJobId(job),
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          errorJson: JSON.stringify(pino.stdSerializers.err(error)),
+          errorJson: JSON.stringify(pino.stdSerializers.errWithCause(error)),
         },
       })
     }
@@ -435,7 +435,7 @@ export abstract class AbstractBackgroundJobProcessor<
           jobId,
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          error: JSON.stringify(isError(error) ? pino.stdSerializers.err(error) : error),
+          error: JSON.stringify(isError(error) ? pino.stdSerializers.errWithCause(error) : error),
         },
       })
     }
@@ -463,7 +463,7 @@ export abstract class AbstractBackgroundJobProcessor<
 
     if (purgeErrors.length > 0) {
       const serializedPurgeErrors = purgeErrors.map((error) =>
-        JSON.stringify(isError(error) ? stdSerializers.err(error) : error),
+        JSON.stringify(isError(error) ? stdSerializers.errWithCause(error) : error),
       )
       throw new Error(`Job data purge failed: ${serializedPurgeErrors.join(', ')}`)
     }

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -10,7 +10,7 @@ import {
   type Worker,
   type WorkerOptions,
 } from 'bullmq'
-import pino, { stdSerializers } from 'pino'
+import { stdSerializers } from 'pino'
 import { merge } from 'ts-deepmerge'
 import { DEFAULT_QUEUE_OPTIONS, DEFAULT_WORKER_OPTIONS, PENDING_JOB_TYPES } from '../constants.ts'
 import {
@@ -399,7 +399,6 @@ export abstract class AbstractBackgroundJobProcessor<
           jobId: resolveJobId(job),
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          errorJson: JSON.stringify(pino.stdSerializers.errWithCause(error)),
         },
       })
     }
@@ -435,7 +434,6 @@ export abstract class AbstractBackgroundJobProcessor<
           jobId,
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          error: JSON.stringify(isError(error) ? pino.stdSerializers.errWithCause(error) : error),
         },
       })
     }

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -434,6 +434,9 @@ export abstract class AbstractBackgroundJobProcessor<
           jobId,
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
+          // isError(error) is handled by the error reporter itself; a non-Error throw has no
+          // other carrier for its value, since `error` above is a synthetic placeholder.
+          ...(isError(error) ? {} : { nonErrorValue: JSON.stringify(error) }),
         },
       })
     }

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.error.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.error.spec.ts
@@ -153,7 +153,6 @@ describe('AbstractBackgroundJobProcessorNew - error', () => {
         jobId: job.id,
         jobName: 'queue',
         'x-request-id': 'correlation_id',
-        error: expect.stringContaining(onFailedError.message),
       },
     })
   })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.error.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.error.spec.ts
@@ -157,6 +157,41 @@ describe('AbstractBackgroundJobProcessorNew - error', () => {
     })
   })
 
+  it('non-Error value thrown from failed hook is reported with nonErrorValue in context', async () => {
+    // Given
+    processor.errorToThrowOnFailed = 'redis timeout'
+    processor.errorsToThrowOnProcess = [new UnrecoverableError('unrecoverable error')]
+
+    const reportSpy = vi.spyOn(deps.errorReporter, 'report')
+
+    // When
+    const jobId = await queueManager.schedule(
+      'queue',
+      {
+        id: 'test_id',
+        value: 'test',
+        metadata: { correlationId: 'correlation_id' },
+      },
+      { attempts: 3, delay: 0 },
+    )
+
+    // Then
+    const job = await processor.spy.waitForJobWithId(jobId, 'failed')
+
+    expect(processor.errorsOnProcess).length(1)
+    expect(reportSpy).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        message: 'TestFailingBackgroundJobProcessorNew onFailed non-error exception',
+      }),
+      context: {
+        jobId: job.id,
+        jobName: 'queue',
+        'x-request-id': 'correlation_id',
+        nonErrorValue: JSON.stringify('redis timeout'),
+      },
+    })
+  })
+
   it('job throws muted unrecoverable error and it is not reported', async () => {
     // Given
     const errorReporterSpy = vi.spyOn(deps.errorReporter, 'report')

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.stalled.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.stalled.spec.ts
@@ -80,7 +80,6 @@ describe('AbstractBackgroundJobProcessorNew - stalled', () => {
         jobId,
         jobName: 'queue',
         'x-request-id': jobData.metadata.correlationId,
-        errorJson: expect.stringContaining(onFailedCall!.error.message),
       },
     })
   })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
@@ -9,7 +9,7 @@ import {
   type Worker,
   type WorkerOptions,
 } from 'bullmq'
-import pino, { stdSerializers } from 'pino'
+import { stdSerializers } from 'pino'
 import { merge } from 'ts-deepmerge'
 import { DEFAULT_WORKER_OPTIONS } from '../constants.ts'
 import {
@@ -325,7 +325,6 @@ export abstract class AbstractBackgroundJobProcessorNew<
           jobId: resolveJobId(job),
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          errorJson: JSON.stringify(pino.stdSerializers.errWithCause(error)),
         },
       })
     }
@@ -361,7 +360,6 @@ export abstract class AbstractBackgroundJobProcessorNew<
           jobId,
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          error: JSON.stringify(isError(error) ? pino.stdSerializers.errWithCause(error) : error),
         },
       })
     }

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
@@ -360,6 +360,9 @@ export abstract class AbstractBackgroundJobProcessorNew<
           jobId,
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
+          // isError(error) is handled by the error reporter itself; a non-Error throw has no
+          // other carrier for its value, since `error` above is a synthetic placeholder.
+          ...(isError(error) ? {} : { nonErrorValue: JSON.stringify(error) }),
         },
       })
     }

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
@@ -325,7 +325,7 @@ export abstract class AbstractBackgroundJobProcessorNew<
           jobId: resolveJobId(job),
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          errorJson: JSON.stringify(pino.stdSerializers.err(error)),
+          errorJson: JSON.stringify(pino.stdSerializers.errWithCause(error)),
         },
       })
     }
@@ -361,7 +361,7 @@ export abstract class AbstractBackgroundJobProcessorNew<
           jobId,
           jobName: job.name,
           'x-request-id': job.data.metadata.correlationId,
-          error: JSON.stringify(isError(error) ? pino.stdSerializers.err(error) : error),
+          error: JSON.stringify(isError(error) ? pino.stdSerializers.errWithCause(error) : error),
         },
       })
     }
@@ -390,7 +390,7 @@ export abstract class AbstractBackgroundJobProcessorNew<
 
     if (purgeErrors.length > 0) {
       const serializedPurgeErrors = purgeErrors.map((error) =>
-        JSON.stringify(isError(error) ? stdSerializers.err(error) : error),
+        JSON.stringify(isError(error) ? stdSerializers.errWithCause(error) : error),
       )
       throw new Error(`Job data purge failed: ${serializedPurgeErrors.join(', ')}`)
     }

--- a/packages/app/background-jobs-common/test/processors/TestFailingBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/test/processors/TestFailingBackgroundJobProcessor.ts
@@ -16,7 +16,7 @@ export class TestFailingBackgroundJobProcessor<
 > extends FakeBackgroundJobProcessor<T> {
   private _errorsOnProcess: Error[] = []
   private _errorsToThrowOnProcess: Error[] = []
-  private _errorToThrowOnFailed: Error | undefined
+  private _errorToThrowOnFailed: unknown
 
   constructor(
     dependencies: BackgroundJobProcessorDependencies<T>,
@@ -38,7 +38,7 @@ export class TestFailingBackgroundJobProcessor<
     this._errorsToThrowOnProcess = errors
   }
 
-  set errorToThrowOnFailed(error: Error | undefined) {
+  set errorToThrowOnFailed(error: unknown) {
     this._errorToThrowOnFailed = error
   }
 

--- a/packages/app/background-jobs-common/test/processors/TestFailingBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/test/processors/TestFailingBackgroundJobProcessorNew.ts
@@ -13,7 +13,7 @@ export class TestFailingBackgroundJobProcessorNew<
 > extends FakeBackgroundJobProcessorNew<Q, T> {
   private _errorsOnProcess: Error[] = []
   private _errorsToThrowOnProcess: Error[] = []
-  private _errorToThrowOnFailed: Error | undefined
+  private _errorToThrowOnFailed: unknown
 
   protected override async process(job: Job<unknown>): Promise<void> {
     await super.process(job)
@@ -27,7 +27,7 @@ export class TestFailingBackgroundJobProcessorNew<
     this._errorsToThrowOnProcess = errors
   }
 
-  set errorToThrowOnFailed(error: Error | undefined) {
+  set errorToThrowOnFailed(error: unknown) {
     this._errorToThrowOnFailed = error
   }
 

--- a/packages/app/error-utils/package.json
+++ b/packages/app/error-utils/package.json
@@ -1,6 +1,9 @@
 {
     "name": "@lokalise/error-utils",
     "version": "3.0.0",
+    "engines": {
+        "node": ">=24.3.0"
+    },
     "license": "Apache-2.0",
     "files": [
         "dist/**",
@@ -30,7 +33,8 @@
         "postversion": "biome check --write package.json"
     },
     "dependencies": {
-        "@bugsnag/node": "^8.9.0"
+        "@bugsnag/node": "^8.9.0",
+        "pino-std-serializers": "^7.1.0"
     },
     "peerDependencies": {
         "@lokalise/node-core": ">=11.0.0"

--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -1,6 +1,11 @@
 import Bugsnag from '@bugsnag/node'
 import { describe, expect, it, vi } from 'vitest'
-import { reportErrorToBugsnag } from './bugsnag.ts'
+import {
+  addFeatureFlag,
+  bugsnagErrorReporter,
+  reportErrorToBugsnag,
+  startBugsnag,
+} from './bugsnag.ts'
 
 const BugsnagClient = Bugsnag.default
 
@@ -216,6 +221,59 @@ describe('bugsnag', () => {
         good: 'bye',
         err: { details: { hello: 'world' } },
       })
+    })
+  })
+
+  describe('startBugsnag', () => {
+    it('starts Bugsnag when not already started', () => {
+      // Given
+      vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(false)
+      const startSpy = vi.spyOn(BugsnagClient, 'start').mockReturnValue(undefined as never)
+
+      // When
+      startBugsnag({ apiKey: 'test' })
+
+      // Then
+      expect(startSpy).toHaveBeenCalledWith({ apiKey: 'test' })
+    })
+
+    it('does not start Bugsnag when already started', () => {
+      // Given
+      vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)
+      const startSpy = vi.spyOn(BugsnagClient, 'start')
+
+      // When
+      startBugsnag({ apiKey: 'test' })
+
+      // Then
+      expect(startSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('addFeatureFlag', () => {
+    it('delegates to the Bugsnag client', () => {
+      // Given
+      const addFeatureFlagSpy = vi.spyOn(BugsnagClient, 'addFeatureFlag').mockReturnValue(undefined)
+
+      // When
+      addFeatureFlag('my-flag', 'variant-a')
+
+      // Then
+      expect(addFeatureFlagSpy).toHaveBeenCalledWith('my-flag', 'variant-a')
+    })
+  })
+
+  describe('bugsnagErrorReporter', () => {
+    it('reports via reportErrorToBugsnag', () => {
+      // Given
+      vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)
+      const notifySpy = vi.spyOn(BugsnagClient, 'notify').mockReturnValue(undefined)
+
+      // When
+      bugsnagErrorReporter.report({ error: new Error('test') })
+
+      // Then
+      expect(notifySpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -1,9 +1,31 @@
 import Bugsnag from '@bugsnag/node'
-import { type FreeformRecord, InternalError, PublicNonRecoverableError } from '@lokalise/node-core'
 import { describe, expect, it, vi } from 'vitest'
 import { reportErrorToBugsnag } from './bugsnag.ts'
 
 const BugsnagClient = Bugsnag.default
+
+class CustomError extends Error {
+  public readonly details: Record<string, unknown>
+
+  constructor(message: string, details: Record<string, unknown>, cause?: unknown) {
+    super(message, cause !== undefined ? { cause } : undefined)
+    this.details = details
+  }
+}
+
+class CustomErrorWithCode extends CustomError {
+  public readonly errorCode: string
+
+  constructor(
+      message: string,
+      details: Record<string, unknown>,
+      errorCode: string,
+      cause?: unknown,
+  ) {
+    super(message, details, cause)
+    this.errorCode = errorCode
+  }
+}
 
 describe('bugsnag', () => {
   describe('reportErrorToBugsnag', () => {
@@ -61,11 +83,7 @@ describe('bugsnag', () => {
 
       // When
       reportErrorToBugsnag({
-        error: new InternalError({
-          errorCode: 'TEST_ERROR_CODE',
-          message: 'test',
-          details: { hello: 'world' },
-        }),
+        error: new CustomErrorWithCode('test', { hello: 'world' }, 'TEST_ERROR_CODE'),
         context: { good: 'bye' },
       })
 
@@ -84,8 +102,7 @@ describe('bugsnag', () => {
       expect(event).toMatchObject({ severity: 'error', unhandled: true })
       expect(context).toMatchObject({
         good: 'bye',
-        errorCode: 'TEST_ERROR_CODE',
-        errorDetails: { hello: 'world' },
+        err: { errorCode: 'TEST_ERROR_CODE', details: { hello: 'world' } },
       })
     })
 
@@ -96,11 +113,7 @@ describe('bugsnag', () => {
 
       // When
       reportErrorToBugsnag({
-        error: new PublicNonRecoverableError({
-          errorCode: 'TEST_ERROR_CODE',
-          message: 'test',
-          details: { hello: 'world' },
-        }),
+        error: new CustomErrorWithCode('test', { hello: 'world' }, 'TEST_ERROR_CODE'),
         context: { good: 'bye' },
       })
 
@@ -119,8 +132,7 @@ describe('bugsnag', () => {
       expect(event).toMatchObject({ severity: 'error', unhandled: true })
       expect(context).toMatchObject({
         good: 'bye',
-        errorCode: 'TEST_ERROR_CODE',
-        errorDetails: { hello: 'world' },
+        err: { errorCode: 'TEST_ERROR_CODE', details: { hello: 'world' } },
       })
     })
 
@@ -130,21 +142,21 @@ describe('bugsnag', () => {
       const notifySpy = vi.spyOn(BugsnagClient, 'notify').mockReturnValue(undefined)
 
       const rootCause = new CustomError('root cause', { statusCode: 400, body: 'invalid payload' })
-      const intermediateCause = new InternalError({
-        errorCode: 'INTERMEDIATE_ERROR_CODE',
-        message: 'intermediate',
-        details: { step: 'intermediate' },
-        cause: rootCause,
-      })
+      const intermediateCause = new CustomErrorWithCode(
+        'intermediate',
+        { step: 'intermediate' },
+        'INTERMEDIATE_ERROR_CODE',
+        rootCause,
+      )
 
       // When
       reportErrorToBugsnag({
-        error: new PublicNonRecoverableError({
-          errorCode: 'TEST_ERROR_CODE',
-          message: 'test',
-          details: { hello: 'world' },
-          cause: intermediateCause,
-        }),
+        error: new CustomErrorWithCode(
+          'test',
+          { hello: 'world' },
+          'TEST_ERROR_CODE',
+          intermediateCause,
+        ),
         context: { good: 'bye' },
       })
 
@@ -162,9 +174,17 @@ describe('bugsnag', () => {
       await callback!(event, () => {})
       expect(context).toMatchObject({
         good: 'bye',
-        errorCode: 'TEST_ERROR_CODE',
-        errorDetails: { hello: 'world' },
-        causeDetails: [{ step: 'intermediate' }, { statusCode: 400, body: 'invalid payload' }],
+        err: {
+          errorCode: 'TEST_ERROR_CODE',
+          details: { hello: 'world' },
+          cause: {
+            errorCode: 'INTERMEDIATE_ERROR_CODE',
+            details: { step: 'intermediate' },
+            cause: {
+              details: { statusCode: 400, body: 'invalid payload' },
+            },
+          },
+        },
       })
     })
 
@@ -194,16 +214,8 @@ describe('bugsnag', () => {
       expect(event).toMatchObject({ severity: 'error', unhandled: true })
       expect(context).toMatchObject({
         good: 'bye',
-        errorDetails: { hello: 'world' },
+        err: { details: { hello: 'world' } },
       })
     })
   })
 })
-
-class CustomError extends Error {
-  public readonly details: FreeformRecord
-  constructor(message: string, details: FreeformRecord) {
-    super(message)
-    this.details = details
-  }
-}

--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -81,7 +81,7 @@ describe('bugsnag', () => {
       expect(event).toMatchObject({ severity: 'info', unhandled: false })
     })
 
-    it('internal error', async () => {
+    it('error with own errorCode and details fields', async () => {
       // Given
       vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)
       const notifySpy = vi.spyOn(BugsnagClient, 'notify').mockReturnValue(undefined)
@@ -104,36 +104,6 @@ describe('bugsnag', () => {
         },
       } as any
       await callback!(event, () => {})
-      expect(event).toMatchObject({ severity: 'error', unhandled: true })
-      expect(context).toMatchObject({
-        good: 'bye',
-        err: { errorCode: 'TEST_ERROR_CODE', details: { hello: 'world' } },
-      })
-    })
-
-    it('public non recoverable error', async () => {
-      // Given
-      vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)
-      const notifySpy = vi.spyOn(BugsnagClient, 'notify').mockReturnValue(undefined)
-
-      // When
-      reportErrorToBugsnag({
-        error: new CustomErrorWithCode('test', { hello: 'world' }, 'TEST_ERROR_CODE'),
-        context: { good: 'bye' },
-      })
-
-      // Then
-      expect(notifySpy).toHaveBeenCalled()
-
-      const callback = notifySpy.mock.calls[0]![1]!
-      let context: unknown = {}
-      const event = {
-        addMetadata: (key: unknown, obj: unknown) => {
-          if (key === 'Context') context = obj
-          else throw new Error('wrong key')
-        },
-      } as any
-      await callback(event, () => {})
       expect(event).toMatchObject({ severity: 'error', unhandled: true })
       expect(context).toMatchObject({
         good: 'bye',
@@ -193,7 +163,7 @@ describe('bugsnag', () => {
       })
     })
 
-    it('unknown error with details field', async () => {
+    it('error with own details field but no errorCode', async () => {
       // Given
       vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)
       const notifySpy = vi.spyOn(BugsnagClient, 'notify').mockReturnValue(undefined)

--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -17,10 +17,10 @@ class CustomErrorWithCode extends CustomError {
   public readonly errorCode: string
 
   constructor(
-      message: string,
-      details: Record<string, unknown>,
-      errorCode: string,
-      cause?: unknown,
+    message: string,
+    details: Record<string, unknown>,
+    errorCode: string,
+    cause?: unknown,
   ) {
     super(message, details, cause)
     this.errorCode = errorCode

--- a/packages/app/error-utils/src/bugsnag.spec.ts
+++ b/packages/app/error-utils/src/bugsnag.spec.ts
@@ -124,6 +124,50 @@ describe('bugsnag', () => {
       })
     })
 
+    it('error caused by another error with details', async () => {
+      // Given
+      vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)
+      const notifySpy = vi.spyOn(BugsnagClient, 'notify').mockReturnValue(undefined)
+
+      const rootCause = new CustomError('root cause', { statusCode: 400, body: 'invalid payload' })
+      const intermediateCause = new InternalError({
+        errorCode: 'INTERMEDIATE_ERROR_CODE',
+        message: 'intermediate',
+        details: { step: 'intermediate' },
+        cause: rootCause,
+      })
+
+      // When
+      reportErrorToBugsnag({
+        error: new PublicNonRecoverableError({
+          errorCode: 'TEST_ERROR_CODE',
+          message: 'test',
+          details: { hello: 'world' },
+          cause: intermediateCause,
+        }),
+        context: { good: 'bye' },
+      })
+
+      // Then
+      expect(notifySpy).toHaveBeenCalled()
+
+      const callback = notifySpy.mock.calls[0]![1]
+      let context: unknown = {}
+      const event = {
+        addMetadata: (key: unknown, obj: unknown) => {
+          if (key === 'Context') context = obj
+          else throw new Error('wrong key')
+        },
+      } as any
+      await callback!(event, () => {})
+      expect(context).toMatchObject({
+        good: 'bye',
+        errorCode: 'TEST_ERROR_CODE',
+        errorDetails: { hello: 'world' },
+        causeDetails: [{ step: 'intermediate' }, { statusCode: 400, body: 'invalid payload' }],
+      })
+    })
+
     it('unknown error with details field', async () => {
       // Given
       vi.spyOn(BugsnagClient, 'isStarted').mockReturnValue(true)

--- a/packages/app/error-utils/src/bugsnag.ts
+++ b/packages/app/error-utils/src/bugsnag.ts
@@ -1,27 +1,6 @@
 import Bugsnag, { type Event, type NodeConfig, type NotifiableError } from '@bugsnag/node'
-import type { ErrorReporter, FreeformRecord } from '@lokalise/node-core'
-import { isError, isInternalError, isPublicNonRecoverableError } from '@lokalise/node-core'
-
-const hasDetails = (
-  error: NotifiableError,
-): error is NotifiableError & { details: FreeformRecord } => isError(error) && 'details' in error
-
-/**
- * `error.cause` is dropped by Bugsnag (and by pino's default error serializer), so a wrapping
- * error's own `details` never surfaces the details of what actually caused it (e.g. an HTTP
- * response body on a lower-level `ResponseStatusError`). Walk the chain and carry those along.
- */
-const collectCauseDetails = (error: NotifiableError): FreeformRecord[] => {
-  const causeDetails: FreeformRecord[] = []
-  let cause: unknown = isError(error) ? error.cause : undefined
-  while (isError(cause)) {
-    if (hasDetails(cause)) {
-      causeDetails.push(cause.details)
-    }
-    cause = cause.cause
-  }
-  return causeDetails
-}
+import type { ErrorReporter } from '@lokalise/node-core'
+import { errWithCause } from 'pino-std-serializers'
 
 const BugsnagClient = Bugsnag.default
 
@@ -42,27 +21,9 @@ export const reportErrorToBugsnag = ({
 }: ErrorReport) =>
   BugsnagClient.isStarted() &&
   BugsnagClient.notify(error, (event) => {
-    let computedContext = { ...(context ?? {}) }
-    if (isPublicNonRecoverableError(error) || isInternalError(error)) {
-      computedContext = {
-        ...computedContext,
-        errorDetails: error.details,
-        errorCode: error.errorCode,
-      }
-    } else if (hasDetails(error)) {
-      /**
-       * This is a special case for other errors that have details but are not `PublicNonRecoverableError`
-       * or `InternalError`
-       */
-      computedContext = {
-        ...computedContext,
-        errorDetails: error.details,
-      }
-    }
-
-    const causeDetails = collectCauseDetails(error)
-    if (causeDetails.length > 0) {
-      computedContext = { ...computedContext, causeDetails }
+    const computedContext = {
+      ...(context ?? {}),
+      ...(Error.isError(error) ? { err: errWithCause(error) } : {}),
     }
 
     event.addMetadata('Context', computedContext)

--- a/packages/app/error-utils/src/bugsnag.ts
+++ b/packages/app/error-utils/src/bugsnag.ts
@@ -5,6 +5,24 @@ import { isError, isInternalError, isPublicNonRecoverableError } from '@lokalise
 const hasDetails = (
   error: NotifiableError,
 ): error is NotifiableError & { details: FreeformRecord } => isError(error) && 'details' in error
+
+/**
+ * `error.cause` is dropped by Bugsnag (and by pino's default error serializer), so a wrapping
+ * error's own `details` never surfaces the details of what actually caused it (e.g. an HTTP
+ * response body on a lower-level `ResponseStatusError`). Walk the chain and carry those along.
+ */
+const collectCauseDetails = (error: NotifiableError): FreeformRecord[] => {
+  const causeDetails: FreeformRecord[] = []
+  let cause: unknown = isError(error) ? error.cause : undefined
+  while (isError(cause)) {
+    if (hasDetails(cause)) {
+      causeDetails.push(cause.details)
+    }
+    cause = cause.cause
+  }
+  return causeDetails
+}
+
 const BugsnagClient = Bugsnag.default
 
 export type Severity = Event['severity']
@@ -40,6 +58,11 @@ export const reportErrorToBugsnag = ({
         ...computedContext,
         errorDetails: error.details,
       }
+    }
+
+    const causeDetails = collectCauseDetails(error)
+    if (causeDetails.length > 0) {
+      computedContext = { ...computedContext, causeDetails }
     }
 
     event.addMetadata('Context', computedContext)

--- a/packages/app/error-utils/tsconfig.json
+++ b/packages/app/error-utils/tsconfig.json
@@ -1,4 +1,7 @@
 {
     "extends": "@lokalise/tsconfig/tsc",
-    "include": ["src/**/*", "vitest.config.ts"]
+    "include": ["src/**/*", "vitest.config.ts"],
+    "compilerOptions": {
+        "lib": ["ES2023", "ESNext.Error"]
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,9 @@ importers:
       '@bugsnag/node':
         specifier: ^8.9.0
         version: 8.10.0
+      pino-std-serializers:
+        specifier: ^7.1.0
+        version: 7.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.9
@@ -4138,6 +4141,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
@@ -10609,7 +10617,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(msw@2.15.0(@types/node@26.2.0)(typescript@7.0.2))(vite@6.4.3(@types/node@26.2.0)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(msw@2.15.0(@types/node@26.4.0)(typescript@7.0.2))(vite@6.4.3(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -10720,11 +10728,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 7.0.2
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -14244,7 +14254,7 @@ snapshots:
     dependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@26.2.0)
       '@rollup/pluginutils': 5.4.0(rollup@4.63.0)
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@7.0.2)
       '@vue/language-core': 2.2.0(typescript@7.0.2)
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
## Summary
- A wrapped error's `cause` details (e.g. an HTTP response body captured on a lower-level `ResponseStatusError`) were silently dropped once the wrapping error was reported: Bugsnag's `reportErrorToBugsnag` only read the top-level error's `details`, and `pino.stdSerializers.err` used for job `errorJson`/log serialization discards `.cause` entirely.
- `@lokalise/error-utils`: `reportErrorToBugsnag` now walks the `cause` chain and attaches a `causeDetails` array to the Bugsnag "Context" metadata.
- `@lokalise/background-jobs-common`: swapped `pino.stdSerializers.err` → `pino.stdSerializers.errWithCause` at all `errorJson`/error-serialization call sites in both `AbstractBackgroundJobProcessorNew` and the legacy `AbstractBackgroundJobProcessor`, so the full cause chain (and its custom fields) survives into logged error JSON.
- Prompted by a Bugsnag `CALLBACK_DELIVERY_ERROR` in `polyglot-service` where the 400 response body from a translation callback was captured by `ResponseStatusError` but never surfaced in Bugsnag or Datadog once wrapped by `CallbackDeliveryError`.

## Test plan
- [x] `pnpm exec vitest run src/bugsnag.spec.ts` in `packages/app/error-utils` — 7/7 passing, including a new test asserting `causeDetails` from a nested cause chain
- [x] `pnpm exec vitest run` on `AbstractBackgroundJobProcessor.spec.ts` and `AbstractBackgroundJobProcessorNew.stalled.spec.ts` in `packages/app/background-jobs-common` — 31/31 passing
- [x] `turbo run lint` for `@lokalise/error-utils` and `@lokalise/background-jobs-common` — passing
- [x] `tsc --noEmit` for `background-jobs-common` — passing
- [x] Changeset added covering both packages

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**