### PR TITLE
feat(frontend-http-client): add sse-fallback transport adapter

### DIFF
--- a/.changeset/fallback-transport-adapter.md
+++ b/.changeset/fallback-transport-adapter.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/frontend-http-client": minor
+---
+
+Add `createFallbackTransport`, the HTTP adapter for `@opinionated-machine/sse-fallback`'s SSE-with-polling-fallback client: `fetchSnapshot` requests a contract's JSON branch and validates the snapshot against its schema, `openStream` requests the SSE branch, forwards `Last-Event-ID` on reconnect and yields raw text chunks so the core's byte-level liveness watchdog keeps working. Refusals resolve with their status so `unretryableStatuses` and `onAuthChallenge` can act on them, the header source is resolved fresh per request so a refreshed token reaches the retry, and SSE payloads are validated against the contract's event schemas (`eventValidation: 'report' | 'drop' | 'off'`). Ships with `buildFallbackParams` for contract-typed subscription params, `SseFramer`, and the `FallbackSnapshotOf` / `FallbackEventsOf` contract inference helpers. No new dependency: the transport seam is matched structurally.

--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -509,6 +509,7 @@ await subscription.waitFor('uploadFinished')
 | A non-2xx response **resolves** with its status | The core owns what a status means: `unretryableStatuses`, and handing a 401 to `onAuthChallenge` |
 | Only an unusable outcome rejects — network failure, schema violation, wrong representation | A rejected poll is a recoverable poll failure; a snapshot the version gate cannot trust is not |
 | Raw text chunks by default, comment frames included | Keeps the core's `staleConnectionTimeoutMs` watchdog byte-level, so a silently dead connection is caught |
+| No cross-subscription state | One transport serves any number of subscriptions; nothing a stream learns is carried into another, so a per-tenant cursor can never reach the wrong stream |
 | A snapshot it refuses has its body released | The core aborts a poll on timeout or on stopping, never one the transport rejected — an unread body (an SSE stream reached by a bad `Accept` negotiation never ends) would hold a socket per failing poll |
 | In `streamMode: 'events'`, an `id:` or `retry:` with no frame to ride on is carried into the next connect | The core's own parser reads both per chunk in `'chunks'` mode; framing here would otherwise drop a cursor advance or a server backoff hint |
 | No deadline of its own | The core bounds every wait (`pollTimeoutMs`, `connectTimeoutMs`) through the `signal` it passes |
@@ -546,14 +547,27 @@ Passing `contract` turns on the checks this package exists for:
 | `eventValidation` | Effect | Requires |
 |---|---|---|
 | `'report'` (default when the contract declares SSE events) | Reports to `diagnostics.onEventSchemaError`; the frame is still delivered | — |
-| `'drop'` | The frame never reaches the core, so the version watermark does not advance past it and the deadman poll repairs the gap | `streamMode: 'events'` |
+| `'drop'` | The frame never reaches the core **and the stream ends**, so the watermark stays below the hole and the repair snapshot lands above it | `streamMode: 'events'` |
 | `'off'` | No checking | — |
 
 `'drop'` needs `streamMode: 'events'` because that is where framing happens before the core sees
 anything. With raw chunks the core frames the stream itself, so by the time a payload could be
 withheld its version has already been gated — and the repair poll would read the snapshot as a
-duplicate and drop it. `'events'` costs byte-level liveness (comment frames are consumed by the
-framing), which is why `'chunks'` + `'report'` is the default. A cursor advance the core would
+duplicate and drop it.
+
+Ending the stream is the other half of `'drop'`, not an implementation detail: withholding one
+frame while delivering the next lets the core's watermark advance past the hole, and the repair
+poll then arrives at or below that watermark, where the reconciler treats it as a stale duplicate
+and synthesizes nothing. The withheld event would be lost for good. The cost is a reconnect per
+rejected payload — which is proportionate, since a stream emitting bodies its own contract rejects
+is broken, and polling carries the subscription meanwhile.
+
+`'events'` has two costs of its own, which is why `'chunks'` + `'report'` is the default: comment
+frames are consumed by the framing, so the stale-connection watchdog drops from byte-level to
+event-level; and an `id:` or `retry:` arriving with no `data:` reaches the core only if a later
+frame on the same connection carries it out, whereas the core's own parser reads both per chunk.
+Neither loses data — an unreported cursor replays events the version gate then dedupes, and an
+unreported `retry:` leaves the core on its own backoff. A cursor advance the core would
 otherwise miss is not part of that cost: an `id:` or `retry:` that no frame carried is inherited by
 the next connect, except past a frame `'drop'` withheld — replaying from there would skip for good
 the very event the repair poll is owed.

--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -509,6 +509,8 @@ await subscription.waitFor('uploadFinished')
 | A non-2xx response **resolves** with its status | The core owns what a status means: `unretryableStatuses`, and handing a 401 to `onAuthChallenge` |
 | Only an unusable outcome rejects — network failure, schema violation, wrong representation | A rejected poll is a recoverable poll failure; a snapshot the version gate cannot trust is not |
 | Raw text chunks by default, comment frames included | Keeps the core's `staleConnectionTimeoutMs` watchdog byte-level, so a silently dead connection is caught |
+| A snapshot it refuses has its body released | The core aborts a poll on timeout or on stopping, never one the transport rejected — an unread body (an SSE stream reached by a bad `Accept` negotiation never ends) would hold a socket per failing poll |
+| In `streamMode: 'events'`, an `id:` or `retry:` with no frame to ride on is carried into the next connect | The core's own parser reads both per chunk in `'chunks'` mode; framing here would otherwise drop a cursor advance or a server backoff hint |
 | No deadline of its own | The core bounds every wait (`pollTimeoutMs`, `connectTimeoutMs`) through the `signal` it passes |
 | Header source resolved per request | What makes the one retry `onAuthChallenge` grants actually carry a refreshed token |
 | Abort ends stream iteration quietly; a mid-stream death throws | The core aborts on purpose (stale watchdog, stop); a real failure has to surface so it backs off and polls |
@@ -551,7 +553,10 @@ Passing `contract` turns on the checks this package exists for:
 anything. With raw chunks the core frames the stream itself, so by the time a payload could be
 withheld its version has already been gated — and the repair poll would read the snapshot as a
 duplicate and drop it. `'events'` costs byte-level liveness (comment frames are consumed by the
-framing), which is why `'chunks'` + `'report'` is the default.
+framing), which is why `'chunks'` + `'report'` is the default. A cursor advance the core would
+otherwise miss is not part of that cost: an `id:` or `retry:` that no frame carried is inherited by
+the next connect, except past a frame `'drop'` withheld — replaying from there would skip for good
+the very event the repair poll is owed.
 
 An event the contract does not declare is reported to `diagnostics.onUndeclaredEvent` and never
 dropped: it usually means a newer server, not a broken one.
@@ -605,8 +610,8 @@ snapshot being a retried poll failure rather than a poisoned watermark; and
 | `FallbackSnapshotValidationError` | A snapshot body violated the contract schema; carries `issues` |
 | `FallbackUnexpectedSnapshotError` | The poll branch answered with something that cannot be a snapshot — an undeclared content type, an SSE stream (the `Accept` negotiation went wrong), a binary body, no body, or invalid JSON. Carries `contentType` and `bodyPreview` |
 | `FallbackEventValidationError` | An SSE payload failed its schema, or was not JSON. Never thrown — reported to `diagnostics.onEventSchemaError` |
-| `FallbackParamsValidationError` | `buildFallbackParams` was given params the contract's request schemas reject |
-| `FallbackUnsupportedParamError` | A query parameter is a list or a structured value; a subscription request's query is a flat string map |
+| `FallbackParamsValidationError` | `buildFallbackParams` was given params the contract's request schemas reject. Headers are checked too, but only the ones supplied — the rest come from the transport's `headers` option |
+| `FallbackUnsupportedParamError` | A query parameter is a list or a structured value; a subscription request's query is a flat string map. A schema that parses a query string into a `Date` is not one of these: the value you supplied is sent, exactly as `sendByApiContract` would |
 
 ## Credits
 

--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -394,6 +394,220 @@ sendPostWithProgress({
 abortController.abort()
 ```
 
+## Resilient live data — SSE with a polling fallback
+
+Push channels fail silently. A connection dies without an error event, a proxy kills an idle
+stream, a room rebalance drops a message — and the UI waiting for "upload finished" is stuck
+until the user reloads. [`@opinionated-machine/sse-fallback`](https://github.com/kibertoad/opinionated-machine/tree/main/packages/sse-fallback)
+solves that by making **polling the correctness backbone and SSE the latency optimization**:
+it subscribes to the SSE branch of a dual-mode contract, keeps a deadman timer, and polls the
+JSON branch of the same route whenever the stream goes quiet. A single version gate reconciles
+the two channels, so application code sees one uniform event stream.
+
+That core owns no HTTP. This package supplies the HTTP half: `createFallbackTransport` gives it
+a `fetchSnapshot` / `openStream` pair built on your configured `wretch` client and your API
+contracts, with the same schema validation, header handling and path prefixing as
+`sendByApiContract`.
+
+```
+                    ┌─────────────────────────────────────────────┐
+   your code  ◄──── │  createResilientSubscription (sse-fallback) │
+   one event        │  version gate · deadman poll · reconnect ·  │
+   stream           │  hydration · degradation · budgets          │
+                    └──────────────────────┬──────────────────────┘
+                                           │ FallbackTransport
+                    ┌──────────────────────┴──────────────────────┐
+                    │  createFallbackTransport (this package)     │
+                    │  Accept negotiation · Last-Event-ID ·       │
+                    │  Zod validation · fresh auth headers        │
+                    └─────────────────────────────────────────────┘
+```
+
+### No dependency, on purpose
+
+This package does **not** depend on `@opinionated-machine/sse-fallback`. The transport seam is
+matched structurally, so you install whichever core version you like and nothing here has to
+move in lock-step — and consumers who only use the plain HTTP client install nothing extra. A
+type test in this repo keeps the vendored declarations honest, so drift fails our build rather
+than yours.
+
+```sh
+npm install @opinionated-machine/sse-fallback   # the client core, when you need it
+```
+
+### Quick start
+
+The contract is **dual-mode**: one status carrying both a JSON representation (the poll) and an
+`sseResponse` (the push).
+
+```ts
+import { defineApiContract, sseResponse } from '@lokalise/api-contracts'
+import { createResilientSubscription, defineFallbackBinding } from '@opinionated-machine/sse-fallback'
+import { buildFallbackParams, createFallbackTransport } from '@lokalise/frontend-http-client'
+import { z } from 'zod/v4'
+
+const uploadStatusContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload status',
+  method: 'get',
+  pathResolver: (params: { uploadId: string }) => `/uploads/${params.uploadId}/status`,
+  requestPathParamsSchema: z.object({ uploadId: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({
+          version: z.number(),
+          status: z.enum(['pending', 'completed', 'failed']),
+        }),
+        ...sseResponse({
+          uploadFinished: z.object({ version: z.number() }),
+          uploadFailed: z.object({ version: z.number(), error: z.string() }),
+        }).content,
+      },
+    },
+  },
+})
+
+// How a poll snapshot relates to the pushed events — the one thing that cannot be inferred.
+const uploadStatusBinding = defineFallbackBinding(uploadStatusContract, {
+  snapshotToEvents: (snapshot) =>
+    snapshot.status === 'completed'
+      ? [{ event: 'uploadFinished', data: { version: snapshot.version } }]
+      : [],
+  version: { ofSnapshot: (snapshot) => snapshot.version },
+  terminalEvents: ['uploadFinished', 'uploadFailed'],
+})
+
+const transport = createFallbackTransport(client, {
+  contract: uploadStatusContract,
+  // Resolved fresh for every poll and every reconnect.
+  headers: async () => ({ authorization: `Bearer ${await auth.token()}` }),
+  diagnostics: { onEventSchemaError: (error) => reportToBugsnag(error) },
+})
+
+const subscription = createResilientSubscription(uploadStatusBinding, {
+  transport,
+  params: buildFallbackParams(uploadStatusContract, { pathParams: { uploadId } }),
+  policy: { subscriptionBudget: { maxDurationMs: 10 * 60_000 } },
+  onAuthChallenge: async () => {
+    await auth.refresh()
+    return true
+  },
+})
+
+// Resolves identically whether the event arrived over SSE, a replay, or a poll.
+await subscription.waitFor('uploadFinished')
+```
+
+### What the transport guarantees
+
+| Behaviour | Why it matters to the core |
+|---|---|
+| `Accept: application/json` on the poll, `text/event-stream` on the stream — always, overriding any request-level `accept` | Branch selection is the transport's job; a params-level `Accept` would send the poll to the stream branch and leave the fallback with no snapshot |
+| `Cache-Control: no-cache` on both channels | A cached poll keeps "succeeding" while reporting stale state — the exact silent failure this machinery exists to catch |
+| `Last-Event-ID` forwarded on reconnect (omitted when the cursor is empty) | Server-side replay composes with the version gate; an empty cursor would ask for a full replay |
+| A non-2xx response **resolves** with its status | The core owns what a status means: `unretryableStatuses`, and handing a 401 to `onAuthChallenge` |
+| Only an unusable outcome rejects — network failure, schema violation, wrong representation | A rejected poll is a recoverable poll failure; a snapshot the version gate cannot trust is not |
+| Raw text chunks by default, comment frames included | Keeps the core's `staleConnectionTimeoutMs` watchdog byte-level, so a silently dead connection is caught |
+| No deadline of its own | The core bounds every wait (`pollTimeoutMs`, `connectTimeoutMs`) through the `signal` it passes |
+| Header source resolved per request | What makes the one retry `onAuthChallenge` grants actually carry a refreshed token |
+| Abort ends stream iteration quietly; a mid-stream death throws | The core aborts on purpose (stale watchdog, stop); a real failure has to surface so it backs off and polls |
+
+### Why not build it on `sendByApiContract`?
+
+Two things a fallback subscription needs are outside what a one-shot contract request can express,
+and both would fail silently rather than loudly:
+
+- **The per-frame `id:`.** `sendByApiContract`'s SSE mode yields `lastEventId`, the *sticky*
+  cursor, and no per-frame id. The core's default version extractor reads the frame's own id, so
+  handing it a sticky cursor would make every id-less frame look like a repeat of the previous
+  version — and the version gate would drop it.
+- **Raw bytes.** Comment frames (`: heartbeat`) are consumed by any framing that yields events, so
+  the core's stale-connection watchdog would degrade from byte-level to event-level and a silently
+  dead connection would go unnoticed for a full timeout.
+
+`createFallbackTransport` therefore reads the response body itself and hands the core raw text,
+while reusing the same contract schemas, header handling and path building. `Last-Event-ID` is
+likewise a transport-level header rather than a contract-declared one.
+
+### Validation
+
+Passing `contract` turns on the checks this package exists for:
+
+- **Snapshots** are parsed with the contract's JSON schema for the responding status. A violation
+  **rejects** the poll (`FallbackSnapshotValidationError`) rather than reaching
+  `version.ofSnapshot` — a wrong watermark silently drops every later event, and a poll failure
+  is merely retried.
+- **SSE payloads** are checked against the contract's `sseResponse` event schemas, per
+  `eventValidation`:
+
+| `eventValidation` | Effect | Requires |
+|---|---|---|
+| `'report'` (default when the contract declares SSE events) | Reports to `diagnostics.onEventSchemaError`; the frame is still delivered | — |
+| `'drop'` | The frame never reaches the core, so the version watermark does not advance past it and the deadman poll repairs the gap | `streamMode: 'events'` |
+| `'off'` | No checking | — |
+
+`'drop'` needs `streamMode: 'events'` because that is where framing happens before the core sees
+anything. With raw chunks the core frames the stream itself, so by the time a payload could be
+withheld its version has already been gated — and the repair poll would read the snapshot as a
+duplicate and drop it. `'events'` costs byte-level liveness (comment frames are consumed by the
+framing), which is why `'chunks'` + `'report'` is the default.
+
+An event the contract does not declare is reported to `diagnostics.onUndeclaredEvent` and never
+dropped: it usually means a newer server, not a broken one.
+
+### Adopting before the SSE endpoint exists
+
+The transport is happy with a contract that has only a JSON branch — pair it with the core's
+`policy.mode: 'poll-only'` (or `POLL_ONLY_POLICY`), which never opens a stream. The binding,
+version gate and state machine are the ones the streaming rollout will use, so turning SSE on
+later is a config change rather than a second migration. Point `snapshotContract` at the poll
+contract if the dual-mode one does not exist yet, or use `snapshotContract` + `streamContract`
+when the two channels live on separate routes.
+
+### Acceptance gate
+
+The unit suite covers the adapter in isolation. `test/verifyWithCore.mjs` covers the seam — the
+adapter driving the real client core against a real HTTP server — so a change here cannot quietly
+break what the core relies on. Because the core is optional, the gate is opt-in:
+
+```sh
+pnpm add -D @opinionated-machine/sse-fallback
+pnpm run build && pnpm run test:core
+```
+
+It asserts, end to end: SSE delivery with subscribe-first hydration; a deadman poll repairing an
+event the live stream never sent; `Last-Event-ID` resuming after a drop; `onAuthChallenge`
+recovery picking up a freshly resolved token; `poll-only` never opening a stream; a schema-invalid
+snapshot being a retried poll failure rather than a poisoned watermark; and
+`eventValidation: 'drop'` withholding a bad payload while a valid delta still applies.
+
+### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `contract` | `ApiContract` | — | Dual-mode contract used by both channels; supplying it enables validation |
+| `snapshotContract` / `streamContract` | `ApiContract` | `contract` | Per-channel contracts, when the poll and the stream live on separate routes |
+| `pathPrefix` | `string` | — | Prefix prepended to both channels' paths |
+| `headers` | `object \| () => object \| () => Promise<object>` | — | Headers added to every request, resolved fresh per request |
+| `snapshotAccept` | `string` | `'application/json'` | `Accept` sent on the poll; override only for a vendored JSON media type |
+| `validateSnapshot` | `boolean` | `true` | Validate snapshot bodies against the contract schema |
+| `strictContentType` | `boolean` | `true` | Require the snapshot `content-type` to match a declared representation |
+| `streamMode` | `'chunks' \| 'events'` | `'chunks'` | Raw text framed by the core, or frames framed here |
+| `eventValidation` | `'off' \| 'report' \| 'drop'` | `'report'` when SSE schemas are declared | See above |
+| `diagnostics` | `FallbackTransportDiagnostics` | — | `onSnapshot`, `onStreamOpen`, `onEventSchemaError`, `onUndeclaredEvent` |
+
+### Errors
+
+| Error | Raised when |
+|---|---|
+| `FallbackTransportError` | Base class; also the network-failure and unsupported-method case. Carries `channel` (`'poll'` / `'stream'`), `path` and `status` |
+| `FallbackSnapshotValidationError` | A snapshot body violated the contract schema; carries `issues` |
+| `FallbackUnexpectedSnapshotError` | The poll branch answered with something that cannot be a snapshot — an undeclared content type, an SSE stream (the `Accept` negotiation went wrong), a binary body, no body, or invalid JSON. Carries `contentType` and `bodyPreview` |
+| `FallbackEventValidationError` | An SSE payload failed its schema, or was not JSON. Never thrown — reported to `diagnostics.onEventSchemaError` |
+| `FallbackParamsValidationError` | `buildFallbackParams` was given params the contract's request schemas reject |
+| `FallbackUnsupportedParamError` | A query parameter is a list or a structured value; a subscription request's query is a flat string map |
+
 ## Credits
 
 This library is brought to you by a joint effort of Lokalise engineers:

--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -423,6 +423,11 @@ contracts, with the same schema validation, header handling and path prefixing a
                     └─────────────────────────────────────────────┘
 ```
 
+Meeting this for the first time? [How the SSE fallback works](docs/sse-fallback.md) walks through
+the same mechanism with diagrams and a glossary: what the layers are, what happens to one event on
+its way to your callback, and what each kind of failure does. The rest of this section is the
+reference.
+
 ### No dependency, on purpose
 
 This package does **not** depend on `@opinionated-machine/sse-fallback`. The transport seam is

--- a/packages/app/frontend-http-client/README.md
+++ b/packages/app/frontend-http-client/README.md
@@ -516,7 +516,6 @@ await subscription.waitFor('uploadFinished')
 | Raw text chunks by default, comment frames included | Keeps the core's `staleConnectionTimeoutMs` watchdog byte-level, so a silently dead connection is caught |
 | No cross-subscription state | One transport serves any number of subscriptions; nothing a stream learns is carried into another, so a per-tenant cursor can never reach the wrong stream |
 | A snapshot it refuses has its body released | The core aborts a poll on timeout or on stopping, never one the transport rejected — an unread body (an SSE stream reached by a bad `Accept` negotiation never ends) would hold a socket per failing poll |
-| In `streamMode: 'events'`, an `id:` or `retry:` with no frame to ride on is carried into the next connect | The core's own parser reads both per chunk in `'chunks'` mode; framing here would otherwise drop a cursor advance or a server backoff hint |
 | No deadline of its own | The core bounds every wait (`pollTimeoutMs`, `connectTimeoutMs`) through the `signal` it passes |
 | Header source resolved per request | What makes the one retry `onAuthChallenge` grants actually carry a refreshed token |
 | Abort ends stream iteration quietly; a mid-stream death throws | The core aborts on purpose (stale watchdog, stop); a real failure has to surface so it backs off and polls |
@@ -572,10 +571,7 @@ frames are consumed by the framing, so the stale-connection watchdog drops from 
 event-level; and an `id:` or `retry:` arriving with no `data:` reaches the core only if a later
 frame on the same connection carries it out, whereas the core's own parser reads both per chunk.
 Neither loses data — an unreported cursor replays events the version gate then dedupes, and an
-unreported `retry:` leaves the core on its own backoff. A cursor advance the core would
-otherwise miss is not part of that cost: an `id:` or `retry:` that no frame carried is inherited by
-the next connect, except past a frame `'drop'` withheld — replaying from there would skip for good
-the very event the repair poll is owed.
+unreported `retry:` leaves the core on its own backoff.
 
 An event the contract does not declare is reported to `diagnostics.onUndeclaredEvent` and never
 dropped: it usually means a newer server, not a broken one.
@@ -604,7 +600,8 @@ It asserts, end to end: SSE delivery with subscribe-first hydration; a deadman p
 event the live stream never sent; `Last-Event-ID` resuming after a drop; `onAuthChallenge`
 recovery picking up a freshly resolved token; `poll-only` never opening a stream; a schema-invalid
 snapshot being a retried poll failure rather than a poisoned watermark; and
-`eventValidation: 'drop'` withholding a bad payload while a valid delta still applies.
+`eventValidation: 'drop'` holding the watermark below the gap — the frame after the withheld one
+included — so that a poll actually repairs it.
 
 ### Options
 

--- a/packages/app/frontend-http-client/docs/sse-fallback.md
+++ b/packages/app/frontend-http-client/docs/sse-fallback.md
@@ -1,0 +1,316 @@
+# How the SSE fallback works
+
+A plain-language companion to the [Resilient live data](../README.md#resilient-live-data--sse-with-a-polling-fallback)
+section of the README. That section is the reference: every option, every guarantee, every error.
+This one is the mental model: what the moving parts are, and what happens to a single event on its
+way from the server to your callback.
+
+## The problem
+
+A push channel can stop delivering without telling anyone. A connection dies with no error event,
+a proxy kills a stream it thinks is idle, a room rebalance drops a message. Application code that
+is waiting for "upload finished" then waits forever, and the only fix the user knows is a reload.
+
+## The idea
+
+**Poll for correctness, stream for latency.** A poll of the same route returns the full current
+state, so it can always answer "what is true right now". The stream just makes the answer arrive
+sooner. Both channels feed one version gate, so the subscription delivers each event once and your
+code never learns which channel it came from.
+
+## Who does what
+
+| Layer | Lives in | Owns |
+|---|---|---|
+| Your code | your app | asks for events, waits for a terminal one |
+| Contract | `@lokalise/api-contracts` | the shape of both branches: a JSON schema for the poll, `sseResponse` schemas for the stream |
+| Binding | your app, one per contract | the one thing nothing can infer: how a snapshot relates to events (`snapshotToEvents`, `version.ofSnapshot`, `terminalEvents`) |
+| Client core | `@opinionated-machine/sse-fallback` | timing and truth: hydration, deadman timer, version gate, reconnect, degradation, budgets |
+| Transport | this package, `createFallbackTransport` | HTTP: `Accept` negotiation, fresh headers, `Last-Event-ID`, byte decoding, Zod validation |
+
+The core owns no HTTP and this package owns no policy. That split is the whole design: the seam
+between them is two functions, `fetchSnapshot` and `openStream`.
+
+## The big picture
+
+```mermaid
+flowchart TB
+    app["Your code<br/>one uniform event stream"]
+    core["Client core: createResilientSubscription<br/>version gate · deadman timer · reconnect<br/>degradation · budgets"]
+    transport["This package: createFallbackTransport<br/>contracts · headers · validation"]
+    poll["fetchSnapshot<br/>Accept: application/json"]
+    stream["openStream<br/>Accept: text/event-stream"]
+    server["One route, two representations"]
+
+    app -->|"waitFor, onEvent, getState"| core
+    core -->|"FallbackTransport seam"| transport
+    transport --> poll
+    transport --> stream
+    poll -->|"full current state and version"| server
+    stream -->|"low-latency deltas"| server
+```
+
+In words: your code talks to one subscription object. The subscription decides *when* to poll and
+*when* to reconnect. This package decides *how* those two requests are made, and refuses anything
+it cannot trust.
+
+## One subscription, start to finish
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as Your code
+    participant Core as Client core
+    participant T as Transport
+    participant S as Server
+
+    App->>Core: createResilientSubscription(binding, opts)
+    par Hydration
+        Core->>T: fetchSnapshot
+        T->>S: GET, Accept application/json, no-cache
+        S-->>T: 200, version 1, status pending
+        T->>T: validate against the contract schema
+        T-->>Core: snapshot
+    and Live channel
+        Core->>T: openStream
+        T->>S: GET, Accept text/event-stream
+        S-->>T: 200 text/event-stream
+        T-->>Core: async iterable of text chunks
+    end
+    Note over Core: watermark = 1
+
+    S-->>T: heartbeat comment
+    T-->>Core: bytes, so the connection is demonstrably alive
+
+    S-->>T: id 7, event uploadFinished, version 7
+    T-->>Core: chunk forwarded, payload checked on the side
+    Core->>Core: 7 is above 1, accept and raise the watermark
+    Core-->>App: uploadFinished
+
+    Note over Core,App: terminal event, the subscription resolves
+```
+
+In words: the subscription hydrates and connects at the same time, so it has state even if the
+stream never opens. Every accepted event raises a watermark. A terminal event ends the whole
+thing.
+
+When the stream goes quiet, the deadman timer takes over:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Core as Client core
+    participant T as Transport
+    participant S as Server
+
+    Note over Core: watermark = 1, stream connected and heartbeating
+    Note over Core: no event for deadmanDelayMs
+    Core->>T: fetchSnapshot, the repair poll
+    T->>S: GET, Accept application/json
+    S-->>T: 200, version 2, status completed
+    T-->>Core: snapshot
+    Core->>Core: 2 is above 1, so the stream missed something
+    Core->>Core: snapshotToEvents rebuilds the missing event
+    Core-->>Core: deliver uploadFinished, watermark = 2
+```
+
+That poll is the point of the whole library. The stream stayed up, kept sending heartbeats, and
+simply never delivered the event. Polling caught it anyway.
+
+## From bytes to an event your code sees
+
+```mermaid
+flowchart TB
+    body["Response body<br/>byte chunks"]
+    decode["readTextChunks<br/>manual reader plus TextDecoder"]
+    mode{"streamMode"}
+
+    inspect["inspectChunks<br/>frame on the side, forward the chunk untouched"]
+    frame["frameChunks<br/>SseFramer emits frames"]
+
+    validateA["validate the payload<br/>report to diagnostics"]
+    validateB["validate the payload<br/>report, and with 'drop' end the stream"]
+
+    coreparse["Core frames the raw text itself<br/>heartbeats count as liveness"]
+    gate{"Version gate<br/>compare against the watermark"}
+    app["Your callback"]
+    dedupe["Dropped as a duplicate"]
+
+    body --> decode --> mode
+    mode -->|"'chunks', the default"| inspect
+    mode -->|"'events'"| frame
+    inspect --> validateA --> coreparse --> gate
+    frame --> validateB --> gate
+    gate -->|"newer"| app
+    gate -->|"at or below the watermark"| dedupe
+```
+
+In words: the transport always reads the socket itself, because two things the core needs are
+destroyed by framing that happens too early. Heartbeat comments are liveness evidence, and the
+per-frame `id:` is what the version gate reads. In the default `'chunks'` mode the transport
+therefore hands the core the exact bytes it received and validates on the side. In `'events'` mode
+it hands over parsed frames, which is what makes withholding a bad one possible.
+
+## The framer, line by line
+
+`SseFramer` is the incremental parser behind both modes, and it is exported if you need it
+directly. It follows the WHATWG event-stream rules:
+
+```mermaid
+flowchart TB
+    chunk["Text chunk appended to the buffer"]
+    split["Split on CR, LF or CRLF<br/>a trailing CR is held back for the next chunk"]
+    line{"What is this line?"}
+
+    blank["Empty: dispatch the frame"]
+    comment["Starts with a colon: a comment, ignored<br/>but still bytes on the wire"]
+    field["field then colon then value<br/>one leading space stripped"]
+
+    which{"Which field?"}
+    data["data: appended to the data buffer"]
+    event["event: sets the type<br/>an empty value means 'message'"]
+    id["id: moves the sticky cursor<br/>a value containing NUL is ignored"]
+    retry["retry: digits only, held for the next dispatch"]
+    other["Anything else: ignored"]
+
+    hasdata{"Did the frame carry data?"}
+    emit["Emit a frame<br/>id, event, data, retry, lastEventId"]
+    nothing["Emit nothing<br/>the cursor still moved"]
+
+    chunk --> split --> line
+    line --> blank
+    line --> comment
+    line --> field
+    field --> which
+    which --> data
+    which --> event
+    which --> id
+    which --> retry
+    which --> other
+    blank --> hasdata
+    hasdata -->|"yes"| emit
+    hasdata -->|"no"| nothing
+```
+
+Two details carry most of the weight. The reconnect cursor advances only when a frame is
+dispatched, so a frame the connection cut off mid-way cannot make a reconnect skip past the event
+it was carrying. And the per-frame `id:` is reported separately from the sticky cursor, because the
+core's default version extractor reads the frame's own id: hand it the cursor instead and every
+id-less frame looks like a repeat of the previous version.
+
+## When things break
+
+```mermaid
+stateDiagram-v2
+    [*] --> Hydrating
+    Hydrating --> Live: stream opened
+    Hydrating --> Reconnecting: connect refused or failed
+    Live --> Repairing: deadman timer fired
+    Repairing --> Live: snapshot answered
+    Live --> Reconnecting: stream ended, died, or sent no bytes in time
+    Reconnecting --> Live: connect succeeded, resumed from the cursor
+    Reconnecting --> Degraded: connects keep failing
+    Degraded --> Degraded: poll every degradedPollIntervalMs
+    Degraded --> Live: a later connect succeeds
+    Live --> [*]: terminal event, budget spent, or stop
+    Degraded --> [*]: terminal event, budget spent, or stop
+```
+
+In words: the stream is allowed to fail. Losing it costs latency, not correctness, because the
+polling backbone keeps the subscription answering. The thresholds and backoffs are core policy
+(`sseRetryBackoff`, `deadmanDelayMs`, `degradedPollIntervalMs`, `staleConnectionTimeoutMs`,
+`subscriptionBudget`). The transport contributes no timers of its own and imposes no deadlines,
+so every wait stays bounded by the signal the core passes in.
+
+`policy.mode: 'poll-only'` pins the machine to the polling side on purpose. That is how you adopt
+the fallback before an SSE endpoint exists: same binding, same version gate, same state, and
+turning the stream on later is a config change rather than a second migration.
+
+## What each failure does
+
+The rule the core relies on: a refusal is a result, and only something genuinely unusable is a
+rejection.
+
+```mermaid
+flowchart TB
+    outcome{"What came back?"}
+    net["Network failure,<br/>unsupported method"]
+    non2xx["Non-2xx status"]
+    bad["A snapshot that cannot be trusted:<br/>schema violation, undeclared content type,<br/>an SSE body, binary, empty, invalid JSON"]
+    okpoll["A valid snapshot"]
+    badevent["An SSE payload that fails its schema"]
+    unknown["An SSE event the contract<br/>does not declare"]
+
+    reject["Reject<br/>the core counts a channel failure and backs off"]
+    resolve["Resolve, carrying the status<br/>the core applies unretryableStatuses<br/>or calls onAuthChallenge"]
+    deliver["Deliver to the version gate"]
+    report["Report to diagnostics.onEventSchemaError"]
+    dropped["'drop': withhold it and end the stream<br/>'report': deliver it anyway"]
+    counted["Report to diagnostics.onUndeclaredEvent,<br/>then deliver"]
+
+    outcome --> net --> reject
+    outcome --> non2xx --> resolve
+    outcome --> bad --> reject
+    outcome --> okpoll --> deliver
+    outcome --> badevent --> report --> dropped
+    outcome --> unknown --> counted
+```
+
+In words: a 401 has to reach the core, because the core is the thing that can refresh a token and
+retry. A snapshot that violates its schema must never reach the core, because a wrong version
+poisons the watermark and silently drops every later event. A failed poll is recoverable; a
+poisoned watermark is not.
+
+## Why `'drop'` ends the stream
+
+With `eventValidation: 'drop'`, withholding the bad frame is only half the job. Ending the
+connection is the other half:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant S as Server
+    participant T as Transport
+    participant Core as Client core
+
+    Note over Core: watermark = 1
+    S-->>T: id 2, progress, percent "half", which the schema rejects
+    T->>T: report to onEventSchemaError
+    T-->>Core: end of stream, the frame withheld
+    Note over Core: watermark still 1, below the hole
+    Core->>T: reconnect from the cursor it still holds, plus a repair poll
+    T-->>Core: snapshot version 3
+    Note over Core: 3 is above 1, so the snapshot applies and rebuilds the gap
+```
+
+Had the transport withheld frame 2 and kept going, the next valid frame would have pushed the
+watermark past the hole. The repair poll would then land at or below the watermark, where the
+reconciler reads it as a stale duplicate and synthesizes nothing, so the withheld event would be
+lost for good. The cost of ending the stream instead is one reconnect per rejected payload, which
+is proportionate: a stream emitting bodies its own contract rejects is broken, and polling carries
+the subscription meanwhile.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| Snapshot | The JSON body of a poll: full current state plus a version |
+| Frame | One SSE event block, terminated by a blank line |
+| Watermark | The highest version the subscription has accepted |
+| Version gate | The check that compares an incoming version against the watermark, so each event is delivered once |
+| Hydration | The first poll, which gives the subscription its initial state and its first watermark |
+| Deadman timer | No *events* for `deadmanDelayMs`, so poll to find out what was missed |
+| Stale-connection watchdog | No *bytes* for `staleConnectionTimeoutMs`, so the connection is presumed dead and gets reconnected |
+| Cursor, `Last-Event-ID` | The id of the last dispatched frame, sent on reconnect so a server can replay from there |
+| Degradation | The core giving up on the stream for a while and polling on an interval instead |
+| Terminal event | An event that completes the subscription, as declared by the binding |
+| Repair poll | A poll fired to close a gap the stream left |
+
+## Picking the modes
+
+| You want | Use |
+|---|---|
+| The default, which is the right answer almost always | `streamMode: 'chunks'` with `eventValidation: 'report'` |
+| To adopt the fallback before an SSE endpoint exists | Any contract with a JSON branch, plus the core's `policy.mode: 'poll-only'` |
+| A payload the contract rejects to never reach app code | `streamMode: 'events'` with `eventValidation: 'drop'`, accepting one reconnect per bad payload and an event-level liveness watchdog |
+| No validation at all | `eventValidation: 'off'`, or no contract |

--- a/packages/app/frontend-http-client/package.json
+++ b/packages/app/frontend-http-client/package.json
@@ -33,6 +33,7 @@
         "lint:fix": "biome check --write",
         "test": "vitest run",
         "test:ci": "vitest run --coverage",
+        "test:core": "node test/verifyWithCore.mjs",
         "package-version": "echo $npm_package_version",
         "prepublishOnly": "pnpm run clean && pnpm run build",
         "postversion": "biome check --write package.json"

--- a/packages/app/frontend-http-client/src/api-contract/sendByApiContract.ts
+++ b/packages/app/frontend-http-client/src/api-contract/sendByApiContract.ts
@@ -17,6 +17,7 @@ import { stringify } from 'fast-querystring'
 import { ServerSentEventTransformStream } from 'parse-sse'
 import type { ConfiguredMiddleware } from 'wretch'
 import type { WretchInstance } from '../types.ts'
+import { normalizeResponseHeaders } from '../utils/responseUtils.ts'
 import { UnexpectedResponseError } from './UnexpectedResponseError.ts'
 
 export type ContractRequestOptions<DoCaptureAsError extends boolean = boolean> = {
@@ -90,16 +91,6 @@ type ReturnTypeForContract<
 
 const resolveRequestHeaders = <T>(headers: HeadersParam<T>): T | Promise<T> =>
   typeof headers === 'function' ? (headers as () => T | Promise<T>)() : headers
-
-function normalizeResponseHeaders(response: Response): Record<string, string> {
-  const headers: Record<string, string> = {}
-
-  response.headers.forEach((value, key) => {
-    headers[key] = value
-  })
-
-  return headers
-}
 
 async function* parseSseStream(
   response: Response,

--- a/packages/app/frontend-http-client/src/index.ts
+++ b/packages/app/frontend-http-client/src/index.ts
@@ -19,3 +19,4 @@ export {
 } from './client.ts'
 export type { SseCallbacks, SseConnection, SseRouteRequestParams } from './sse.ts'
 export { connectSseByContract } from './sse.ts'
+export * from './sse-fallback/index.ts'

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
@@ -1094,7 +1094,7 @@ describe('createFallbackTransport', () => {
       await mockServer.forGet('/uploads/u-1/status').thenJson(200, { version: 1, status: 'ok' })
       await mockServer
         .forGet('/uploads/u-1/events')
-        .thenReply(200, frameOf('uploadFinished', { version: 1, result: 'bad' }), SSE_HEADERS)
+        .thenReply(200, frameOf('uploadFinished', { version: 1, result: 42 }), SSE_HEADERS)
 
       const onEventSchemaError = vi.fn()
       const transport = transportFor({
@@ -1111,7 +1111,12 @@ describe('createFallbackTransport', () => {
         signalOf(),
       )
       await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)
-      expect(onEventSchemaError).not.toHaveBeenCalled()
+      // A payload the *stream* contract rejects: proof the frames are checked
+      // against `streamContract` and not against the poll's schema, which
+      // knows nothing about events at all.
+      expect(onEventSchemaError).toHaveBeenCalledTimes(1)
+      expect(onEventSchemaError.mock.calls[0]?.[0]).toBeInstanceOf(FallbackEventValidationError)
+      expect(onEventSchemaError.mock.calls[0]?.[0].event).toBe('uploadFinished')
     })
   })
 })

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
@@ -886,6 +886,201 @@ describe('createFallbackTransport', () => {
     })
   })
 
+  describe('stream state a frame could not carry (events mode)', () => {
+    /** Open a framed stream, drain it, and report the request it sent. */
+    async function drain(
+      transport: ReturnType<typeof createFallbackTransport>,
+      lastEventId?: string,
+    ): Promise<void> {
+      const stream = await transport.openStream(
+        getRequest,
+        lastEventId === undefined ? signalOf() : { ...signalOf(), lastEventId },
+      )
+      await collectFrames((stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events)
+    }
+
+    // In `chunks` mode the core's own parser reads `id:` and `retry:` per
+    // chunk whether or not they dispatch an event. Framing here is what takes
+    // that away, so the residue has to survive to the next connect.
+    it('resumes from an id the last connection framed but no frame reported', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(
+          200,
+          `${frameOf('progress', { version: 1, percent: 10 }, 'e-1')}id: e-2\n\n`,
+          SSE_HEADERS,
+        )
+
+      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
+      await drain(transport)
+      // The core saw one frame, so its cursor is that frame's id.
+      await drain(transport, 'e-1')
+
+      const requests = await endpoint.getSeenRequests()
+      expect(requests[1]?.headers['last-event-id']).toBe('e-2')
+    })
+
+    it('stamps a retry hint the last connection never got to deliver', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .once()
+        .thenReply(200, 'retry: 9000\n\n', SSE_HEADERS)
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('progress', { version: 1, percent: 10 }, 'e-1'), SSE_HEADERS)
+
+      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
+      await drain(transport)
+
+      const stream = await transport.openStream(getRequest, signalOf())
+      const frames = await collectFrames(
+        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
+      )
+      expect(frames[0]?.retry).toBe(9000)
+    })
+
+    it('does not resume past a frame the core never received', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(
+          200,
+          `${frameOf('progress', { version: 1, percent: 10 }, 'e-1')}${frameOf(
+            'uploadFinished',
+            { version: 2, result: 42 },
+            'e-2',
+          )}`,
+          SSE_HEADERS,
+        )
+
+      const transport = transportFor({
+        contract: dualModeContract,
+        streamMode: 'events',
+        eventValidation: 'drop',
+      })
+      await drain(transport)
+      await drain(transport, 'e-1')
+
+      // `e-2` was withheld, so replaying from it would skip it for good — the
+      // repair the drop counts on is exactly a re-delivery.
+      const requests = await endpoint.getSeenRequests()
+      expect(requests[1]?.headers['last-event-id']).toBe('e-1')
+    })
+
+    it('defers to a cursor the core moved on its own', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(
+          200,
+          `${frameOf('progress', { version: 1, percent: 10 }, 'e-1')}${frameOf(
+            'progress',
+            { version: 2, percent: 20 },
+            'e-2',
+          )}`,
+          SSE_HEADERS,
+        )
+
+      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
+      await drain(transport)
+      // The core is behind the last frame it was handed, so it held the cursor
+      // back on purpose — a frame it could not read. Overriding that would make
+      // the replay skip that frame for good.
+      await drain(transport, 'e-1')
+
+      const requests = await endpoint.getSeenRequests()
+      expect(requests[1]?.headers['last-event-id']).toBe('e-1')
+    })
+
+    it('does not hand one stream the residue of another', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenReply(200, 'id: e-2\n\n', SSE_HEADERS)
+      const other = await mockServer.forGet('/uploads/u-2/status').thenReply(200, '', SSE_HEADERS)
+
+      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
+      await drain(transport)
+
+      const stream = await transport.openStream(
+        { path: '/uploads/u-2/status', method: 'get' },
+        { ...signalOf(), lastEventId: 'other-1' },
+      )
+      await collectFrames((stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events)
+
+      const requests = await other.getSeenRequests()
+      expect(requests[0]?.headers['last-event-id']).toBe('other-1')
+    })
+  })
+
+  describe('releasing a body it walks away from', () => {
+    /** A body that never ends, and tells us whether it was released. */
+    function endlessBody(text: string) {
+      let released = false
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(text))
+        },
+        cancel() {
+          released = true
+        },
+      })
+      return { stream, wasReleased: () => released }
+    }
+
+    const transportRespondingWith = (
+      body: BodyInit,
+      init: ResponseInit,
+      options: Parameters<typeof createFallbackTransport>[1],
+    ) =>
+      createFallbackTransport(
+        wretch(mockServer.url).polyfills({
+          fetch: () => Promise.resolve(new Response(body, init)),
+        }),
+        options,
+      )
+
+    // The core's `executePoll` aborts a poll on timeout or on stopping, never
+    // one the transport rejected — so a body left unread here is a connection
+    // held for the life of the page, once per failing poll.
+    it('releases an SSE stream that reached the poll branch', async () => {
+      const { stream, wasReleased } = endlessBody(': open\n\n')
+
+      await expect(
+        transportRespondingWith(
+          stream,
+          { status: 200, headers: SSE_HEADERS },
+          { contract: dualModeContract },
+        ).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(FallbackUnexpectedSnapshotError)
+
+      expect(wasReleased()).toBe(true)
+    })
+
+    it('releases a binary body it cannot read as a snapshot', async () => {
+      const { stream, wasReleased } = endlessBody('binary')
+
+      await expect(
+        transportRespondingWith(
+          stream,
+          { status: 200, headers: { 'content-type': 'application/octet-stream' } },
+          { contract: blobContract },
+        ).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(FallbackUnexpectedSnapshotError)
+
+      expect(wasReleased()).toBe(true)
+    })
+
+    it('releases a body whose content type the contract does not declare', async () => {
+      const { stream, wasReleased } = endlessBody('<html></html>')
+
+      await expect(
+        transportRespondingWith(
+          stream,
+          { status: 200, headers: { 'content-type': 'text/html' } },
+          { contract: dualModeContract },
+        ).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(FallbackUnexpectedSnapshotError)
+
+      expect(wasReleased()).toBe(true)
+    })
+  })
+
   describe('separate poll and stream contracts', () => {
     it('validates each channel against its own contract', async () => {
       const streamContract = defineApiContract({

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
@@ -1,0 +1,922 @@
+import { Readable } from 'node:stream'
+import {
+  blobResponse,
+  defineApiContract,
+  noBodyResponse,
+  sseResponse,
+} from '@lokalise/api-contracts'
+import { getLocal, type Mockttp } from 'mockttp'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import wretch from 'wretch'
+import { z } from 'zod/v4'
+import { createFallbackTransport } from './createFallbackTransport.ts'
+import {
+  FallbackEventValidationError,
+  FallbackSnapshotValidationError,
+  FallbackTransportError,
+  FallbackUnexpectedSnapshotError,
+} from './errors.ts'
+import type { FallbackParsedSseFrame, FallbackTransportRequest } from './types.ts'
+
+const snapshotSchema = z.object({ version: z.number(), status: z.string() })
+const uploadFinishedSchema = z.object({ version: z.number(), result: z.string() })
+
+const eventSchemas = {
+  uploadFinished: uploadFinishedSchema,
+  progress: z.object({ version: z.number(), percent: z.number() }),
+}
+
+const dualModeContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload status',
+  method: 'get',
+  pathResolver: () => '/uploads/u-1/status',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': snapshotSchema,
+        ...sseResponse(eventSchemas).content,
+      },
+    },
+    404: z.object({ message: z.string() }),
+  },
+})
+
+const jsonOnlyContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload snapshot',
+  method: 'get',
+  pathResolver: () => '/uploads/u-1/status',
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+const postContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Search uploads',
+  method: 'post',
+  pathResolver: () => '/uploads/search',
+  requestBodySchema: z.object({ query: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': snapshotSchema,
+        ...sseResponse(eventSchemas).content,
+      },
+    },
+  },
+})
+
+const blobContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload archive',
+  method: 'get',
+  pathResolver: () => '/uploads/u-1/status',
+  responsesByStatusCode: { 200: blobResponse('application/octet-stream') },
+})
+
+const noBodyContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload ack',
+  method: 'get',
+  pathResolver: () => '/uploads/u-1/status',
+  responsesByStatusCode: { 204: noBodyResponse() },
+})
+
+const JSON_HEADERS = { 'content-type': 'application/json' }
+const SSE_HEADERS = { 'content-type': 'text/event-stream' }
+
+const getRequest: FallbackTransportRequest = {
+  path: '/uploads/u-1/status',
+  method: 'get',
+}
+
+function frameOf(event: string, data: unknown, id?: string): string {
+  return `${id === undefined ? '' : `id: ${id}\n`}event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+}
+
+async function collectChunks(chunks: AsyncIterable<string>): Promise<string[]> {
+  const collected: string[] = []
+  for await (const chunk of chunks) collected.push(chunk)
+  return collected
+}
+
+async function collectFrames(
+  frames: AsyncIterable<FallbackParsedSseFrame>,
+): Promise<FallbackParsedSseFrame[]> {
+  const collected: FallbackParsedSseFrame[] = []
+  for await (const frame of frames) collected.push(frame)
+  return collected
+}
+
+/** A response body we control frame by frame, so a stream can be left open. */
+function openBody() {
+  const body = new Readable({ read() {} })
+  return {
+    body,
+    write: (text: string) => body.push(text),
+    end: () => body.push(null),
+  }
+}
+
+describe('createFallbackTransport', () => {
+  let mockServer: Mockttp
+
+  beforeAll(async () => {
+    mockServer = getLocal()
+    await mockServer.start()
+  })
+
+  afterAll(async () => {
+    await mockServer.stop()
+  })
+
+  afterEach(() => {
+    mockServer.reset()
+  })
+
+  function transportFor(options: Parameters<typeof createFallbackTransport>[1] = {}) {
+    return createFallbackTransport(wretch(mockServer.url), options)
+  }
+
+  const signalOf = (controller = new AbortController()) => ({ signal: controller.signal })
+
+  describe('configuration', () => {
+    it("refuses eventValidation 'drop' without streamMode 'events'", () => {
+      expect(() =>
+        transportFor({ contract: dualModeContract, eventValidation: 'drop' }),
+      ).toThrowError(/eventValidation 'drop' requires streamMode 'events'/)
+    })
+
+    it('refuses validation against a contract that declares no SSE events', () => {
+      expect(() =>
+        transportFor({ contract: jsonOnlyContract, eventValidation: 'report' }),
+      ).toThrowError(/declares no SSE event schemas/)
+    })
+
+    it('refuses validation with no contract to validate against', () => {
+      expect(() => transportFor({ eventValidation: 'report' })).toThrowError(
+        /no contract was supplied to validate against/,
+      )
+    })
+
+    it('rejects a method the client cannot send', async () => {
+      const transport = transportFor({ contract: dualModeContract })
+
+      await expect(
+        transport.fetchSnapshot({ path: '/uploads/u-1/status', method: 'trace' }, signalOf()),
+      ).rejects.toThrowError(/"trace" is not a supported HTTP method/)
+    })
+  })
+
+  describe('fetchSnapshot', () => {
+    it('asks for the JSON branch and validates the snapshot', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenJson(200, { version: 3, status: 'pending' })
+
+      const transport = transportFor({ contract: dualModeContract })
+      const snapshot = await transport.fetchSnapshot(getRequest, signalOf())
+
+      expect(snapshot.status).toBe(200)
+      expect(snapshot.body).toEqual({ version: 3, status: 'pending' })
+      expect(snapshot.headers['content-type']).toContain('application/json')
+
+      const [request] = await endpoint.getSeenRequests()
+      expect(request?.headers.accept).toBe('application/json')
+      // A cached poll would keep "succeeding" while reporting stale state,
+      // which is exactly the silent failure the fallback exists to catch.
+      expect(request?.headers['cache-control']).toBe('no-cache')
+    })
+
+    it('applies the path prefix and the query string', async () => {
+      const endpoint = await mockServer
+        .forGet('/api/v2/uploads/u-1/status')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      const transport = transportFor({ contract: dualModeContract, pathPrefix: '/api/v2' })
+      await transport.fetchSnapshot({ ...getRequest, query: { verbose: 'true' } }, signalOf())
+
+      const [request] = await endpoint.getSeenRequests()
+      expect(request?.url).toContain('/api/v2/uploads/u-1/status?verbose=true')
+    })
+
+    it('honours a vendored JSON media type', async () => {
+      const vendoredContract = defineApiContract({
+        visibility: 'public',
+        summary: 'Vendored snapshot',
+        method: 'get',
+        pathResolver: () => '/uploads/u-1/status',
+        responsesByStatusCode: {
+          200: { content: { 'application/json+01': snapshotSchema } },
+        },
+      })
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, JSON.stringify({ version: 1, status: 'pending' }), {
+          'content-type': 'application/json+01',
+        })
+
+      const transport = transportFor({
+        contract: vendoredContract,
+        snapshotAccept: 'application/json+01',
+      })
+      const snapshot = await transport.fetchSnapshot(getRequest, signalOf())
+
+      expect(snapshot.body).toEqual({ version: 1, status: 'pending' })
+      const [request] = await endpoint.getSeenRequests()
+      expect(request?.headers.accept).toBe('application/json+01')
+    })
+
+    it('resolves the header source for every request, so a refreshed token is used', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      let token = 'first'
+      const transport = transportFor({
+        contract: dualModeContract,
+        headers: () => ({ authorization: `Bearer ${token}` }),
+      })
+
+      await transport.fetchSnapshot(getRequest, signalOf())
+      token = 'refreshed'
+      await transport.fetchSnapshot(getRequest, signalOf())
+
+      const requests = await endpoint.getSeenRequests()
+      expect(requests.map((request) => request.headers.authorization)).toEqual([
+        'Bearer first',
+        'Bearer refreshed',
+      ])
+    })
+
+    it('accepts an async header source and a static header map', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      await transportFor({
+        contract: dualModeContract,
+        headers: () => Promise.resolve({ 'x-async': 'yes' }),
+      }).fetchSnapshot(getRequest, signalOf())
+      await transportFor({
+        contract: dualModeContract,
+        headers: { 'x-static': 'yes' },
+      }).fetchSnapshot(getRequest, signalOf())
+
+      const requests = await endpoint.getSeenRequests()
+      expect(requests[0]?.headers['x-async']).toBe('yes')
+      expect(requests[1]?.headers['x-static']).toBe('yes')
+    })
+
+    it('lets request headers through but keeps ownership of Accept', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      await transportFor({ contract: dualModeContract }).fetchSnapshot(
+        { ...getRequest, headers: { 'x-tenant': 'acme', accept: 'text/event-stream' } },
+        signalOf(),
+      )
+
+      const [request] = await endpoint.getSeenRequests()
+      expect(request?.headers['x-tenant']).toBe('acme')
+      // Letting a request-level Accept win would send the poll to the stream
+      // branch and leave the fallback with no snapshot at all.
+      expect(request?.headers.accept).toBe('application/json')
+    })
+
+    it('sends a JSON body for a payload contract', async () => {
+      const endpoint = await mockServer
+        .forPost('/uploads/search')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      await transportFor({ contract: postContract }).fetchSnapshot(
+        { path: '/uploads/search', method: 'post', body: { query: 'invoice' } },
+        signalOf(),
+      )
+
+      const [request] = await endpoint.getSeenRequests()
+      expect(await request?.body.getJson()).toEqual({ query: 'invoice' })
+      expect(request?.headers['content-type']).toBe('application/json')
+    })
+
+    it('ignores a body on a method that cannot carry one', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      await transportFor({ contract: dualModeContract }).fetchSnapshot(
+        { ...getRequest, body: { ignored: true } },
+        signalOf(),
+      )
+
+      const [request] = await endpoint.getSeenRequests()
+      expect(await request?.body.getText()).toBe('')
+    })
+
+    it('reports every poll to diagnostics, refusals included', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenJson(404, { message: 'gone' })
+
+      const onSnapshot = vi.fn()
+      const snapshot = await transportFor({
+        contract: dualModeContract,
+        diagnostics: { onSnapshot },
+      }).fetchSnapshot(getRequest, signalOf())
+
+      expect(snapshot).toEqual({
+        status: 404,
+        headers: expect.objectContaining({ 'content-type': expect.stringContaining('json') }),
+        body: { message: 'gone' },
+      })
+      expect(onSnapshot).toHaveBeenCalledWith({
+        path: '/uploads/u-1/status',
+        status: 404,
+        durationMs: expect.any(Number),
+      })
+    })
+
+    it('resolves a refusal that carried a plain-text body', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenReply(503, 'upstream unavailable')
+
+      const snapshot = await transportFor({ contract: dualModeContract }).fetchSnapshot(
+        getRequest,
+        signalOf(),
+      )
+
+      // The core, not the transport, decides what a status means — so a refusal
+      // is a resolved snapshot response rather than a rejection.
+      expect(snapshot.status).toBe(503)
+      expect(snapshot.body).toBe('upstream unavailable')
+    })
+
+    it('rejects a snapshot that violates the contract schema', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenJson(200, { version: 'three' })
+
+      let caught: unknown
+      try {
+        await transportFor({ contract: dualModeContract }).fetchSnapshot(getRequest, signalOf())
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(FallbackSnapshotValidationError)
+      const error = caught as FallbackSnapshotValidationError
+      expect(error.channel).toBe('poll')
+      expect(error.path).toBe('/uploads/u-1/status')
+      expect(error.status).toBe(200)
+      expect(error.issues.length).toBeGreaterThan(0)
+      expect(error.message).toContain('does not match the schema of "Upload status"')
+    })
+
+    it('passes the body through unvalidated when asked to', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenJson(200, { version: 'three' })
+
+      const snapshot = await transportFor({
+        contract: dualModeContract,
+        validateSnapshot: false,
+      }).fetchSnapshot(getRequest, signalOf())
+
+      expect(snapshot.body).toEqual({ version: 'three' })
+    })
+
+    it('works without a contract, parsing the body as JSON', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenJson(200, { anything: true })
+
+      const snapshot = await transportFor().fetchSnapshot(getRequest, signalOf())
+
+      expect(snapshot.body).toEqual({ anything: true })
+    })
+
+    it('rejects a body that is not JSON, with a preview of what arrived', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, '<html>login</html>', JSON_HEADERS)
+
+      let caught: unknown
+      try {
+        await transportFor({ contract: dualModeContract }).fetchSnapshot(getRequest, signalOf())
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(FallbackUnexpectedSnapshotError)
+      expect((caught as FallbackUnexpectedSnapshotError).bodyPreview).toBe('<html>login</html>')
+    })
+
+    it('truncates a long body preview', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenReply(200, 'x'.repeat(500), JSON_HEADERS)
+
+      const caught = await transportFor({ contract: dualModeContract })
+        .fetchSnapshot(getRequest, signalOf())
+        .catch((error: unknown) => error)
+
+      expect((caught as FallbackUnexpectedSnapshotError).bodyPreview).toBe(`${'x'.repeat(200)}…`)
+    })
+
+    it('rejects an empty snapshot body', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenReply(200, '', JSON_HEADERS)
+
+      await expect(
+        transportFor({ contract: dualModeContract }).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(/returned an empty body where a JSON snapshot was expected/)
+    })
+
+    it('rejects a content type the contract does not declare for that status', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, 'plain', { 'content-type': 'text/plain' })
+
+      await expect(
+        transportFor({ contract: dualModeContract }).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(/does not declare for that status/)
+    })
+
+    it('falls back to the sole declared representation when strictness is off', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, JSON.stringify({ version: 1, status: 'pending' }), {
+          'content-type': 'text/plain',
+        })
+
+      const snapshot = await transportFor({
+        contract: jsonOnlyContract,
+        strictContentType: false,
+      }).fetchSnapshot(getRequest, signalOf())
+
+      expect(snapshot.body).toEqual({ version: 1, status: 'pending' })
+    })
+
+    it('rejects an SSE stream on the poll branch, naming the negotiation', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('progress', { version: 1, percent: 10 }), SSE_HEADERS)
+
+      await expect(
+        transportFor({ contract: dualModeContract }).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(/answered with an SSE stream instead of a snapshot/)
+    })
+
+    it('rejects a binary snapshot', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, 'binary', { 'content-type': 'application/octet-stream' })
+
+      await expect(
+        transportFor({ contract: blobContract }).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(/resolved to a binary response, which cannot be a snapshot/)
+    })
+
+    it('rejects a bodyless snapshot response', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenReply(204)
+
+      await expect(
+        transportFor({ contract: noBodyContract }).fetchSnapshot(getRequest, signalOf()),
+      ).rejects.toThrowError(/returned status 204 with no body/)
+    })
+
+    it('rejects a network failure with the channel and path attached', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenCloseConnection()
+
+      let caught: unknown
+      try {
+        await transportFor({ contract: dualModeContract }).fetchSnapshot(getRequest, signalOf())
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(FallbackTransportError)
+      expect((caught as FallbackTransportError).channel).toBe('poll')
+      expect((caught as FallbackTransportError).path).toBe('/uploads/u-1/status')
+      expect((caught as FallbackTransportError).message).toContain('The poll request to')
+    })
+
+    it('rejects once the core aborts the poll', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenTimeout()
+
+      const controller = new AbortController()
+      const pending = transportFor({ contract: dualModeContract }).fetchSnapshot(
+        getRequest,
+        signalOf(controller),
+      )
+      controller.abort()
+
+      // `pollTimeoutMs` is enforced by the core through this signal; the
+      // transport imposes no deadline of its own.
+      await expect(pending).rejects.toThrowError(FallbackTransportError)
+    })
+  })
+
+  describe('openStream', () => {
+    it('asks for the SSE branch and yields raw text, heartbeats included', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(
+          200,
+          `: heartbeat\n\n${frameOf('progress', { version: 1, percent: 50 }, '1')}`,
+          SSE_HEADERS,
+        )
+
+      const stream = await transportFor({ contract: dualModeContract }).openStream(
+        getRequest,
+        signalOf(),
+      )
+
+      expect(stream.status).toBe(200)
+      expect(stream.headers['content-type']).toContain('text/event-stream')
+      expect('chunks' in stream).toBe(true)
+      const text = (await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)).join(
+        '',
+      )
+      // Comment frames must survive: they are what makes the core's
+      // stale-connection watchdog byte-level rather than event-level.
+      expect(text).toContain(': heartbeat')
+      expect(text).toContain('event: progress')
+
+      const [request] = await endpoint.getSeenRequests()
+      expect(request?.headers.accept).toBe('text/event-stream')
+      expect(request?.headers['cache-control']).toBe('no-cache')
+      expect(request?.headers['last-event-id']).toBeUndefined()
+    })
+
+    it('forwards the reconnect cursor as Last-Event-ID', async () => {
+      const endpoint = await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, '', SSE_HEADERS)
+
+      const transport = transportFor({ contract: dualModeContract })
+      await transport.openStream(getRequest, { ...signalOf(), lastEventId: '1757-000042' })
+      // An empty cursor is "no cursor": sending it would ask a spec-following
+      // server to replay the whole stream.
+      await transport.openStream(getRequest, { ...signalOf(), lastEventId: '' })
+
+      const requests = await endpoint.getSeenRequests()
+      expect(requests[0]?.headers['last-event-id']).toBe('1757-000042')
+      expect(requests[1]?.headers['last-event-id']).toBeUndefined()
+    })
+
+    it('resolves a refused connect with its status and no stream', async () => {
+      await mockServer.forGet('/uploads/u-1/status').thenJson(401, { message: 'expired' })
+
+      const onStreamOpen = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        diagnostics: { onStreamOpen },
+      }).openStream(getRequest, { ...signalOf(), lastEventId: '7' })
+
+      // The core needs the status to honour `unretryableStatuses` and to offer
+      // the refusal to `onAuthChallenge`.
+      expect(stream.status).toBe(401)
+      expect(await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)).toEqual([])
+      expect(onStreamOpen).toHaveBeenCalledWith({
+        path: '/uploads/u-1/status',
+        status: 401,
+        contentType: expect.stringContaining('json'),
+        lastEventId: '7',
+      })
+    })
+
+    it('leaves a wrong content type for the core to judge', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenJson(200, { version: 1, status: 'pending' })
+
+      const stream = await transportFor({ contract: dualModeContract }).openStream(
+        getRequest,
+        signalOf(),
+      )
+
+      // The core treats a non-`text/event-stream` 200 as a connect failure and
+      // degrades; second-guessing it here would hide the status from it.
+      expect(stream.status).toBe(200)
+      expect(stream.headers['content-type']).toContain('application/json')
+    })
+
+    it('ends iteration quietly when the core aborts the stream', async () => {
+      const upstream = openBody()
+      await mockServer.forGet('/uploads/u-1/status').thenStream(200, upstream.body, SSE_HEADERS)
+      upstream.write(frameOf('progress', { version: 1, percent: 10 }, '1'))
+
+      const controller = new AbortController()
+      const stream = await transportFor({ contract: dualModeContract }).openStream(
+        getRequest,
+        signalOf(controller),
+      )
+
+      const chunks: string[] = []
+      const drained = (async () => {
+        for await (const chunk of (stream as { chunks: AsyncIterable<string> }).chunks) {
+          chunks.push(chunk)
+        }
+      })()
+
+      await vi.waitFor(() => expect(chunks.length).toBeGreaterThan(0))
+      // The core aborts to force a reconnect (stale watchdog) and to release
+      // the socket on stop; neither is a stream error worth reporting.
+      controller.abort()
+      await expect(drained).resolves.toBeUndefined()
+      upstream.end()
+    })
+
+    it('throws when the connection dies mid-stream', async () => {
+      // A body that errors after its first chunk is not something a mock HTTP
+      // server can express, so the failure is injected at the fetch seam.
+      const dyingFetch = () =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(frameOf('progress', { version: 1 })))
+                controller.error(new Error('upstream went away'))
+              },
+            }),
+            { status: 200, headers: SSE_HEADERS },
+          ),
+        )
+
+      const stream = await createFallbackTransport(
+        wretch(mockServer.url).polyfills({ fetch: dyingFetch }),
+        { contract: dualModeContract },
+      ).openStream(getRequest, signalOf())
+
+      // A dead connection has to surface: the core counts it, backs off, and
+      // polls to repair whatever the stream did not deliver.
+      await expect(
+        collectChunks((stream as { chunks: AsyncIterable<string> }).chunks),
+      ).rejects.toThrowError('upstream went away')
+    })
+
+    it('does not emit a chunk for a split multi-byte character', async () => {
+      const upstream = openBody()
+      await mockServer.forGet('/uploads/u-1/status').thenStream(200, upstream.body, SSE_HEADERS)
+
+      const stream = await transportFor({ contract: dualModeContract }).openStream(
+        getRequest,
+        signalOf(),
+      )
+      const drained = collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)
+
+      // Write the leading byte of the three-byte "…" on its own, so one chunk
+      // decodes to nothing at all.
+      const bytes = Buffer.from('data: …\n\n', 'utf8')
+      upstream.body.push(bytes.subarray(0, 6))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      upstream.body.push(bytes.subarray(6, 7))
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      upstream.body.push(bytes.subarray(7))
+      upstream.end()
+
+      const chunks = await drained
+      expect(chunks.every((chunk) => chunk !== '')).toBe(true)
+      expect(chunks.join('')).toBe('data: …\n\n')
+    })
+  })
+
+  describe('event validation', () => {
+    it('reports a payload that does not match the contract, without withholding it', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('uploadFinished', { version: 1, result: 42 }, '1'), SSE_HEADERS)
+
+      const onEventSchemaError = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        diagnostics: { onEventSchemaError },
+      }).openStream(getRequest, signalOf())
+      const text = (await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)).join(
+        '',
+      )
+
+      // Raw chunks are framed by the core, so its version gate has already
+      // moved by the time app code sees the event: withholding it here would
+      // leave a hole the repair poll reads as a duplicate and drops.
+      expect(text).toContain('uploadFinished')
+      expect(onEventSchemaError).toHaveBeenCalledTimes(1)
+      const error = onEventSchemaError.mock.calls[0]?.[0] as FallbackEventValidationError
+      expect(error).toBeInstanceOf(FallbackEventValidationError)
+      expect(error.event).toBe('uploadFinished')
+      expect(error.issues).toHaveLength(1)
+      expect(error.message).toContain('does not match its schema')
+    })
+
+    it('reports a payload that is not JSON at all', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, 'event: uploadFinished\ndata: not-json\n\n', SSE_HEADERS)
+
+      const onEventSchemaError = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        diagnostics: { onEventSchemaError },
+      }).openStream(getRequest, signalOf())
+      await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)
+
+      const error = onEventSchemaError.mock.calls[0]?.[0] as FallbackEventValidationError
+      expect(error.message).toContain('is not valid JSON')
+      expect(error.data).toBe('not-json')
+    })
+
+    it('reports an event the contract does not declare, but never drops it', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('uploadRenamed', { version: 9 }, '1'), SSE_HEADERS)
+
+      const onUndeclaredEvent = vi.fn()
+      const onEventSchemaError = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        streamMode: 'events',
+        eventValidation: 'drop',
+        diagnostics: { onUndeclaredEvent, onEventSchemaError },
+      }).openStream(getRequest, signalOf())
+
+      const frames = await collectFrames(
+        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
+      )
+      // An undeclared event usually means a newer server, not a broken one.
+      expect(frames).toHaveLength(1)
+      expect(onUndeclaredEvent).toHaveBeenCalledWith({
+        path: '/uploads/u-1/status',
+        event: 'uploadRenamed',
+      })
+      expect(onEventSchemaError).not.toHaveBeenCalled()
+    })
+
+    it('stays silent when validation is off', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('uploadFinished', { version: 1, result: 42 }), SSE_HEADERS)
+
+      const onEventSchemaError = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        eventValidation: 'off',
+        diagnostics: { onEventSchemaError },
+      }).openStream(getRequest, signalOf())
+      await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)
+
+      expect(onEventSchemaError).not.toHaveBeenCalled()
+    })
+
+    it('frames without validating when validation is off in events mode', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('uploadFinished', { version: 1, result: 42 }), SSE_HEADERS)
+
+      const onEventSchemaError = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        streamMode: 'events',
+        eventValidation: 'off',
+        diagnostics: { onEventSchemaError },
+      }).openStream(getRequest, signalOf())
+
+      const frames = await collectFrames(
+        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
+      )
+      expect(frames).toHaveLength(1)
+      expect(onEventSchemaError).not.toHaveBeenCalled()
+    })
+
+    it('frames the stream itself in events mode, keeping per-frame ids', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(
+          200,
+          `: heartbeat\n\n${frameOf('progress', { version: 1, percent: 10 }, '1')}${frameOf(
+            'progress',
+            { version: 2, percent: 20 },
+          )}`,
+          SSE_HEADERS,
+        )
+
+      const stream = await transportFor({
+        contract: dualModeContract,
+        streamMode: 'events',
+      }).openStream(getRequest, signalOf())
+
+      const frames = await collectFrames(
+        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
+      )
+      expect(frames).toEqual([
+        {
+          event: 'progress',
+          data: JSON.stringify({ version: 1, percent: 10 }),
+          id: '1',
+          lastEventId: '1',
+        },
+        // The second frame carries no id of its own — the sticky cursor is
+        // reported separately so the core's version gate does not read it as a
+        // repeat of version 1.
+        {
+          event: 'progress',
+          data: JSON.stringify({ version: 2, percent: 20 }),
+          lastEventId: '1',
+        },
+      ])
+    })
+
+    it('withholds an invalid frame in drop mode so a poll repairs the gap', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(
+          200,
+          `${frameOf('uploadFinished', { version: 1, result: 42 }, '1')}${frameOf(
+            'progress',
+            { version: 2, percent: 20 },
+            '2',
+          )}`,
+          SSE_HEADERS,
+        )
+
+      const onEventSchemaError = vi.fn()
+      const stream = await transportFor({
+        contract: dualModeContract,
+        streamMode: 'events',
+        eventValidation: 'drop',
+        diagnostics: { onEventSchemaError },
+      }).openStream(getRequest, signalOf())
+
+      const frames = await collectFrames(
+        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
+      )
+      expect(frames.map((frame) => frame.event)).toEqual(['progress'])
+      expect(onEventSchemaError).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('responses a mock server cannot produce', () => {
+    const respondWith = (body: BodyInit | null, init?: ResponseInit) =>
+      createFallbackTransport(
+        wretch(mockServer.url).polyfills({
+          fetch: () => Promise.resolve(new Response(body, init)),
+        }),
+        { contract: dualModeContract },
+      )
+
+    /** A stream body keeps fetch from inferring a content type for us. */
+    const streamOf = (text: string) =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(text))
+          controller.close()
+        },
+      })
+
+    it('names a missing content type in the rejection', async () => {
+      const caught = await respondWith(streamOf('{"version":1,"status":"ok"}'), { status: 200 })
+        .fetchSnapshot(getRequest, signalOf())
+        .catch((error: unknown) => error)
+
+      expect(caught).toBeInstanceOf(FallbackUnexpectedSnapshotError)
+      expect((caught as FallbackUnexpectedSnapshotError).message).toContain(
+        'with content-type "<none>"',
+      )
+    })
+
+    it('describes a rejection that was not thrown as an Error', async () => {
+      const caught = await createFallbackTransport(
+        wretch(mockServer.url).polyfills({ fetch: () => Promise.reject('socket hang up') }),
+        { contract: dualModeContract },
+      )
+        .fetchSnapshot(getRequest, signalOf())
+        .catch((error: unknown) => error)
+
+      expect(caught).toBeInstanceOf(FallbackTransportError)
+      expect((caught as FallbackTransportError).message).toContain('socket hang up')
+    })
+  })
+
+  describe('separate poll and stream contracts', () => {
+    it('validates each channel against its own contract', async () => {
+      const streamContract = defineApiContract({
+        visibility: 'public',
+        summary: 'Upload events',
+        method: 'get',
+        pathResolver: () => '/uploads/u-1/events',
+        responsesByStatusCode: { 200: sseResponse(eventSchemas) },
+      })
+
+      await mockServer.forGet('/uploads/u-1/status').thenJson(200, { version: 1, status: 'ok' })
+      await mockServer
+        .forGet('/uploads/u-1/events')
+        .thenReply(200, frameOf('uploadFinished', { version: 1, result: 'bad' }), SSE_HEADERS)
+
+      const onEventSchemaError = vi.fn()
+      const transport = transportFor({
+        snapshotContract: jsonOnlyContract,
+        streamContract,
+        diagnostics: { onEventSchemaError },
+      })
+
+      const snapshot = await transport.fetchSnapshot(getRequest, signalOf())
+      expect(snapshot.body).toEqual({ version: 1, status: 'ok' })
+
+      const stream = await transport.openStream(
+        { path: '/uploads/u-1/events', method: 'get' },
+        signalOf(),
+      )
+      await collectChunks((stream as { chunks: AsyncIterable<string> }).chunks)
+      expect(onEventSchemaError).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.spec.ts
@@ -815,16 +815,16 @@ describe('createFallbackTransport', () => {
       ])
     })
 
-    it('withholds an invalid frame in drop mode so a poll repairs the gap', async () => {
+    it('ends the stream on an invalid frame in drop mode, keeping the gap open', async () => {
       await mockServer
         .forGet('/uploads/u-1/status')
         .thenReply(
           200,
-          `${frameOf('uploadFinished', { version: 1, result: 42 }, '1')}${frameOf(
-            'progress',
-            { version: 2, percent: 20 },
+          `${frameOf('progress', { version: 1, percent: 10 }, '1')}${frameOf(
+            'uploadFinished',
+            { version: 2, result: 42 },
             '2',
-          )}`,
+          )}${frameOf('progress', { version: 3, percent: 30 }, '3')}`,
           SSE_HEADERS,
         )
 
@@ -839,8 +839,30 @@ describe('createFallbackTransport', () => {
       const frames = await collectFrames(
         (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
       )
-      expect(frames.map((frame) => frame.event)).toEqual(['progress'])
+      // Version 2 is withheld — and version 3 is withheld with it. Delivering
+      // it would advance the core's watermark past the hole, and the repair
+      // poll would then arrive at or below that watermark, where the
+      // reconciler treats it as a stale duplicate and synthesizes nothing.
+      expect(frames.map((frame) => frame.id)).toEqual(['1'])
       expect(onEventSchemaError).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports the resumed cursor on an id-less frame after a reconnect', async () => {
+      await mockServer
+        .forGet('/uploads/u-1/status')
+        .thenReply(200, frameOf('progress', { version: 2, percent: 20 }), SSE_HEADERS)
+
+      const stream = await transportFor({
+        contract: dualModeContract,
+        streamMode: 'events',
+      }).openStream(getRequest, { ...signalOf(), lastEventId: 'e-1' })
+
+      const frames = await collectFrames(
+        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
+      )
+      // The cursor is stream-scoped, not connection-scoped: a frame with no
+      // `id:` of its own still reports where the reconnect resumed from.
+      expect(frames[0]?.lastEventId).toBe('e-1')
     })
   })
 
@@ -883,128 +905,6 @@ describe('createFallbackTransport', () => {
 
       expect(caught).toBeInstanceOf(FallbackTransportError)
       expect((caught as FallbackTransportError).message).toContain('socket hang up')
-    })
-  })
-
-  describe('stream state a frame could not carry (events mode)', () => {
-    /** Open a framed stream, drain it, and report the request it sent. */
-    async function drain(
-      transport: ReturnType<typeof createFallbackTransport>,
-      lastEventId?: string,
-    ): Promise<void> {
-      const stream = await transport.openStream(
-        getRequest,
-        lastEventId === undefined ? signalOf() : { ...signalOf(), lastEventId },
-      )
-      await collectFrames((stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events)
-    }
-
-    // In `chunks` mode the core's own parser reads `id:` and `retry:` per
-    // chunk whether or not they dispatch an event. Framing here is what takes
-    // that away, so the residue has to survive to the next connect.
-    it('resumes from an id the last connection framed but no frame reported', async () => {
-      const endpoint = await mockServer
-        .forGet('/uploads/u-1/status')
-        .thenReply(
-          200,
-          `${frameOf('progress', { version: 1, percent: 10 }, 'e-1')}id: e-2\n\n`,
-          SSE_HEADERS,
-        )
-
-      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
-      await drain(transport)
-      // The core saw one frame, so its cursor is that frame's id.
-      await drain(transport, 'e-1')
-
-      const requests = await endpoint.getSeenRequests()
-      expect(requests[1]?.headers['last-event-id']).toBe('e-2')
-    })
-
-    it('stamps a retry hint the last connection never got to deliver', async () => {
-      await mockServer
-        .forGet('/uploads/u-1/status')
-        .once()
-        .thenReply(200, 'retry: 9000\n\n', SSE_HEADERS)
-      await mockServer
-        .forGet('/uploads/u-1/status')
-        .thenReply(200, frameOf('progress', { version: 1, percent: 10 }, 'e-1'), SSE_HEADERS)
-
-      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
-      await drain(transport)
-
-      const stream = await transport.openStream(getRequest, signalOf())
-      const frames = await collectFrames(
-        (stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events,
-      )
-      expect(frames[0]?.retry).toBe(9000)
-    })
-
-    it('does not resume past a frame the core never received', async () => {
-      const endpoint = await mockServer
-        .forGet('/uploads/u-1/status')
-        .thenReply(
-          200,
-          `${frameOf('progress', { version: 1, percent: 10 }, 'e-1')}${frameOf(
-            'uploadFinished',
-            { version: 2, result: 42 },
-            'e-2',
-          )}`,
-          SSE_HEADERS,
-        )
-
-      const transport = transportFor({
-        contract: dualModeContract,
-        streamMode: 'events',
-        eventValidation: 'drop',
-      })
-      await drain(transport)
-      await drain(transport, 'e-1')
-
-      // `e-2` was withheld, so replaying from it would skip it for good — the
-      // repair the drop counts on is exactly a re-delivery.
-      const requests = await endpoint.getSeenRequests()
-      expect(requests[1]?.headers['last-event-id']).toBe('e-1')
-    })
-
-    it('defers to a cursor the core moved on its own', async () => {
-      const endpoint = await mockServer
-        .forGet('/uploads/u-1/status')
-        .thenReply(
-          200,
-          `${frameOf('progress', { version: 1, percent: 10 }, 'e-1')}${frameOf(
-            'progress',
-            { version: 2, percent: 20 },
-            'e-2',
-          )}`,
-          SSE_HEADERS,
-        )
-
-      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
-      await drain(transport)
-      // The core is behind the last frame it was handed, so it held the cursor
-      // back on purpose — a frame it could not read. Overriding that would make
-      // the replay skip that frame for good.
-      await drain(transport, 'e-1')
-
-      const requests = await endpoint.getSeenRequests()
-      expect(requests[1]?.headers['last-event-id']).toBe('e-1')
-    })
-
-    it('does not hand one stream the residue of another', async () => {
-      await mockServer.forGet('/uploads/u-1/status').thenReply(200, 'id: e-2\n\n', SSE_HEADERS)
-      const other = await mockServer.forGet('/uploads/u-2/status').thenReply(200, '', SSE_HEADERS)
-
-      const transport = transportFor({ contract: dualModeContract, streamMode: 'events' })
-      await drain(transport)
-
-      const stream = await transport.openStream(
-        { path: '/uploads/u-2/status', method: 'get' },
-        { ...signalOf(), lastEventId: 'other-1' },
-      )
-      await collectFrames((stream as { events: AsyncIterable<FallbackParsedSseFrame> }).events)
-
-      const requests = await other.getSeenRequests()
-      expect(requests[0]?.headers['last-event-id']).toBe('other-1')
     })
   })
 

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.ts
@@ -1,0 +1,676 @@
+import type { ApiContract, ResponseKind, SseSchemaByEventName } from '@lokalise/api-contracts'
+import {
+  buildRequestPath,
+  getSseSchemaByEventName,
+  resolveResponseEntry,
+} from '@lokalise/api-contracts'
+import { stringify } from 'fast-querystring'
+import { WretchError } from 'wretch/resolver'
+import type { HeadersObject, HeadersSource, WretchInstance } from '../types.ts'
+import { normalizeResponseHeaders } from '../utils/responseUtils.ts'
+import {
+  FallbackEventValidationError,
+  FallbackSnapshotValidationError,
+  FallbackTransportError,
+  FallbackUnexpectedSnapshotError,
+} from './errors.ts'
+import { SseFramer } from './framer.ts'
+import type {
+  FallbackChannel,
+  FallbackParsedSseFrame,
+  FallbackSnapshotResponse,
+  FallbackStreamResponse,
+  FallbackTransport,
+  FallbackTransportRequest,
+} from './types.ts'
+
+const SSE_ACCEPT = 'text/event-stream'
+const DEFAULT_SNAPSHOT_ACCEPT = 'application/json'
+const BODY_PREVIEW_LIMIT = 200
+const SUPPORTED_METHODS = ['get', 'delete', 'post', 'put', 'patch'] as const
+
+type SupportedMethod = (typeof SUPPORTED_METHODS)[number]
+
+/** How SSE payloads that do not match the contract's event schemas are handled. */
+export type FallbackEventValidationMode =
+  /** Deliver every frame unchecked. */
+  | 'off'
+  /**
+   * Validate and report to `diagnostics.onEventSchemaError`, but deliver the
+   * frame anyway. The default, and the only sound choice with
+   * `streamMode: 'chunks'`: by the time app code sees a frame the core's
+   * version gate has already advanced its watermark, so withholding it there
+   * would leave a hole that the repair poll reads as a duplicate and drops.
+   */
+  | 'report'
+  /**
+   * Withhold the frame from the core entirely, so the version watermark never
+   * advances past it and the deadman poll repairs the gap from a snapshot.
+   * Requires `streamMode: 'events'`, which is where the framing — and
+   * therefore the decision — happens before the core sees anything.
+   */
+  | 'drop'
+
+/** Which {@link FallbackStreamResponse} shape `openStream` resolves with. */
+export type FallbackStreamMode =
+  /**
+   * Raw decoded text, framed by the core (default). Heartbeat comments reach
+   * the core, so its `staleConnectionTimeoutMs` watchdog is byte-level, and
+   * every frame keeps its own `id:` for the version gate.
+   */
+  | 'chunks'
+  /**
+   * Frames, framed here. Comment frames are consumed by the framing, so the
+   * stale-connection watchdog degrades from byte-level to event-level — the
+   * price of validating payloads before the core sees them.
+   */
+  | 'events'
+
+export type FallbackTransportDiagnostics = {
+  /** Every snapshot poll that produced a response, including non-2xx ones. */
+  onSnapshot?: (info: { path: string; status: number; durationMs: number }) => void
+  /** Every stream connect attempt that produced response headers. */
+  onStreamOpen?: (info: {
+    path: string
+    status: number
+    contentType: string | undefined
+    lastEventId: string | undefined
+  }) => void
+  /**
+   * An SSE payload did not match the contract. Silent schema drift is how a
+   * push channel stops working without anyone noticing, so this is the hook to
+   * wire to your error reporter.
+   */
+  onEventSchemaError?: (error: FallbackEventValidationError) => void
+  /**
+   * The stream sent an event the contract does not declare. Never dropped —
+   * an unknown event is usually a newer server, not a broken one — but worth
+   * counting: it means the contract and the emitter have diverged.
+   */
+  onUndeclaredEvent?: (info: { path: string; event: string }) => void
+}
+
+export type CreateFallbackTransportOptions = {
+  /**
+   * The dual-mode contract both channels use — one path serving JSON via
+   * `Accept: application/json` and SSE via `Accept: text/event-stream`.
+   *
+   * Supplying it is what turns on validation: snapshots are parsed with the
+   * contract's JSON schema for the responding status, and SSE payloads are
+   * checked against its `sseResponse` event schemas. Without a contract the
+   * transport still works, but bodies pass through unvalidated.
+   */
+  contract?: ApiContract
+  /** Poll contract, when the poll and the stream live on separate contracts. */
+  snapshotContract?: ApiContract
+  /** Stream contract, when the poll and the stream live on separate contracts. */
+  streamContract?: ApiContract
+  /** Prefix prepended to both channels' paths, as in `sendByApiContract`. */
+  pathPrefix?: string
+  /**
+   * Headers added to every request. Resolved **fresh for each poll and each
+   * reconnect**, so a function here is how a rotating credential reaches the
+   * retry that `onAuthChallenge` grants: refresh the token in the challenge
+   * handler, and the retried request picks it up.
+   */
+  headers?: HeadersSource
+  /**
+   * `Accept` sent on the poll. Defaults to `application/json`; override only
+   * for a vendored JSON media type (`application/json+01`) that the contract
+   * declares. The stream's `Accept` is always `text/event-stream` — the branch
+   * selection belongs to the transport, so any `accept` in the request headers
+   * is overridden on both channels.
+   */
+  snapshotAccept?: string
+  /**
+   * Validate snapshot bodies against the contract schema. Default `true`.
+   * Turning it off keeps the response shape unchecked, which puts the burden
+   * of a wrong `version.ofSnapshot` back on runtime behaviour — prefer fixing
+   * the schema.
+   */
+  validateSnapshot?: boolean
+  /**
+   * Require the snapshot's `content-type` to match a representation the
+   * contract declares (default `true`). Mirrors `sendByApiContract`.
+   */
+  strictContentType?: boolean
+  /** See {@link FallbackStreamMode}. Default `'chunks'`. */
+  streamMode?: FallbackStreamMode
+  /**
+   * See {@link FallbackEventValidationMode}. Defaults to `'report'` when the
+   * stream contract declares SSE event schemas, `'off'` otherwise.
+   */
+  eventValidation?: FallbackEventValidationMode
+  diagnostics?: FallbackTransportDiagnostics
+}
+
+type PreparedRequest = {
+  method: SupportedMethod
+  /** Path including the prefix, without the query string — for error messages. */
+  path: string
+  url: string
+  headers: Record<string, string>
+  bodyString: string | undefined
+}
+
+type ExecuteOutcome =
+  | { ok: true; response: Response }
+  | { ok: false; status: number; headers: Record<string, string>; body: unknown }
+
+function previewOf(text: string): string {
+  return text.length > BODY_PREVIEW_LIMIT ? `${text.slice(0, BODY_PREVIEW_LIMIT)}…` : text
+}
+
+function isSupportedMethod(method: string): method is SupportedMethod {
+  return (SUPPORTED_METHODS as readonly string[]).includes(method)
+}
+
+function resolveHeaderSource(source: HeadersSource): HeadersObject | Promise<HeadersObject> {
+  return typeof source === 'function' ? source() : source
+}
+
+function describeCause(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Read what a failed request carried, from the {@link WretchError} wretch
+ * throws for any non-2xx response. `errorType` decides whether the body landed
+ * in `json` or `text`; either way the body has already been consumed, which is
+ * what releases the connection.
+ */
+function fromWretchError(error: WretchError): ExecuteOutcome {
+  return {
+    ok: false,
+    status: error.status,
+    /* v8 ignore next -- wretch always attaches the response it refused */
+    headers: error.response ? normalizeResponseHeaders(error.response) : {},
+    body: error.json !== undefined ? error.json : error.text,
+  }
+}
+
+async function* emptyChunks(): AsyncGenerator<string> {
+  // A refused connect carries no stream; the core counts it as a connect
+  // failure the moment it sees the status.
+}
+
+/**
+ * Decode a response body into text chunks.
+ *
+ * Deliberately a manual reader loop rather than `pipeThrough(new
+ * TextDecoderStream())` plus async iteration: `ReadableStream` async iteration
+ * is still missing in shipping Safari, and this is the one code path in the
+ * package that a long-lived stream depends on.
+ */
+async function* readTextChunks(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): AsyncGenerator<string> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) return
+      const text = decoder.decode(value, { stream: true })
+      // A chunk that split a multi-byte character decodes to nothing until its
+      // continuation arrives.
+      if (text !== '') yield text
+    }
+  } catch (error) {
+    // The core aborts the stream on purpose: to force a reconnect when the
+    // stale-connection watchdog fires, and to release the socket when the
+    // subscription stops. Neither is a stream error worth reporting.
+    if (signal.aborted) return
+    throw error
+  } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      // Already closed or errored — the connection is released either way.
+    }
+  }
+}
+
+type ResolvedOptions = {
+  snapshotContract: ApiContract | undefined
+  pathPrefix: string | undefined
+  headers: HeadersSource | undefined
+  snapshotAccept: string
+  validateSnapshot: boolean
+  strictContentType: boolean
+  streamMode: FallbackStreamMode
+  eventValidation: FallbackEventValidationMode
+  /** `null` when there is nothing to validate against, or validation is off. */
+  eventSchemas: SseSchemaByEventName | null
+  diagnostics: FallbackTransportDiagnostics
+}
+
+function assertConsistentOptions(
+  options: CreateFallbackTransportOptions,
+  resolved: { streamMode: FallbackStreamMode; eventValidation: FallbackEventValidationMode },
+  declaredEventSchemas: SseSchemaByEventName | null,
+): void {
+  if (resolved.eventValidation === 'drop' && resolved.streamMode !== 'events') {
+    throw new Error(
+      "createFallbackTransport: eventValidation 'drop' requires streamMode 'events'. " +
+        "With raw chunks the core frames the stream itself, so a frame cannot be withheld before its version is gated — dropping it there would leave a hole the repair poll reads as a duplicate. Use 'report' to keep byte-level liveness, or switch to streamMode 'events'.",
+    )
+  }
+  if (options.eventValidation === undefined || resolved.eventValidation === 'off') return
+  if (declaredEventSchemas) return
+
+  const streamContract = options.streamContract ?? options.contract
+  throw new Error(
+    `createFallbackTransport: eventValidation '${resolved.eventValidation}' was requested, but ${
+      streamContract
+        ? `contract "${streamContract.summary}" declares no SSE event schemas (add an sseResponse to a success status)`
+        : 'no contract was supplied to validate against (pass `contract` or `streamContract`)'
+    }.`,
+  )
+}
+
+function resolveOptions(options: CreateFallbackTransportOptions): ResolvedOptions {
+  const streamContract = options.streamContract ?? options.contract
+  const declaredEventSchemas = streamContract ? getSseSchemaByEventName(streamContract) : null
+  const streamMode = options.streamMode ?? 'chunks'
+  const eventValidation = options.eventValidation ?? (declaredEventSchemas ? 'report' : 'off')
+
+  assertConsistentOptions(options, { streamMode, eventValidation }, declaredEventSchemas)
+
+  return {
+    snapshotContract: options.snapshotContract ?? options.contract,
+    pathPrefix: options.pathPrefix,
+    headers: options.headers,
+    snapshotAccept: options.snapshotAccept ?? DEFAULT_SNAPSHOT_ACCEPT,
+    validateSnapshot: options.validateSnapshot ?? true,
+    strictContentType: options.strictContentType ?? true,
+    streamMode,
+    eventValidation,
+    eventSchemas: eventValidation === 'off' ? null : declaredEventSchemas,
+    diagnostics: options.diagnostics ?? {},
+  }
+}
+
+/**
+ * Merge the header layers, in the order that keeps the transport in charge of
+ * channel selection: the shared source first (resolved now, so a refreshed
+ * token is picked up), then the subscription's own headers, then the channel's
+ * own `Accept` / `Cache-Control` / `Last-Event-ID`.
+ */
+async function buildRequestHeaders(
+  config: ResolvedOptions,
+  request: FallbackTransportRequest,
+  channelHeaders: Record<string, string>,
+  bodyString: string | undefined,
+): Promise<Record<string, string>> {
+  const headers = new Headers(
+    config.headers ? await resolveHeaderSource(config.headers) : undefined,
+  )
+  for (const [name, value] of Object.entries(request.headers ?? {})) {
+    headers.set(name, value)
+  }
+  for (const [name, value] of Object.entries(channelHeaders)) {
+    headers.set(name, value)
+  }
+  if (bodyString !== undefined && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json')
+  }
+  return Object.fromEntries(headers)
+}
+
+async function prepareRequest(
+  config: ResolvedOptions,
+  request: FallbackTransportRequest,
+  channel: FallbackChannel,
+  channelHeaders: Record<string, string>,
+): Promise<PreparedRequest> {
+  const path = buildRequestPath(request.path, config.pathPrefix)
+  const method = request.method.toLowerCase()
+  if (!isSupportedMethod(method)) {
+    throw new FallbackTransportError(
+      `Cannot open the ${channel} channel: "${request.method}" is not a supported HTTP method (${SUPPORTED_METHODS.join(', ')}).`,
+      { channel, path },
+    )
+  }
+
+  // GET/DELETE contracts carry no body, matching `sendByApiContract`.
+  const carriesBody = method !== 'get' && method !== 'delete' && request.body !== undefined
+  const bodyString = carriesBody ? JSON.stringify(request.body) : undefined
+  const queryString = request.query ? stringify(request.query) : ''
+
+  return {
+    method,
+    path,
+    url: queryString ? `${path}?${queryString}` : path,
+    headers: await buildRequestHeaders(config, request, channelHeaders, bodyString),
+    bodyString,
+  }
+}
+
+/**
+ * Build a {@link FallbackTransport} over a `wretch` instance: the HTTP half of
+ * `@opinionated-machine/sse-fallback`, which owns no HTTP of its own.
+ *
+ * `fetchSnapshot` requests the contract's JSON branch and validates the body;
+ * `openStream` requests its SSE branch, forwards `Last-Event-ID` on reconnect,
+ * and yields raw text chunks so the core's byte-level liveness watchdog works.
+ *
+ * Both channels follow the contract the core relies on: a non-2xx response
+ * **resolves** (carrying the status, so `unretryableStatuses` and
+ * `onAuthChallenge` can act on it) and only a genuinely unusable outcome
+ * rejects — a network failure, or a snapshot that cannot be trusted. Neither
+ * channel imposes its own deadline: the core bounds every wait
+ * (`pollTimeoutMs`, `connectTimeoutMs`) through the `signal` it passes, and an
+ * unbounded wait is exactly the silent failure this machinery exists to catch.
+ *
+ * @example
+ * ```typescript
+ * import { createResilientSubscription, defineFallbackBinding } from '@opinionated-machine/sse-fallback'
+ * import { buildFallbackParams, createFallbackTransport } from '@lokalise/frontend-http-client'
+ *
+ * const binding = defineFallbackBinding(uploadStatusContract, {
+ *   snapshotToEvents: (snapshot) =>
+ *     snapshot.status === 'completed' ? [{ event: 'uploadFinished', data: snapshot }] : [],
+ *   version: { ofSnapshot: (snapshot) => snapshot.version },
+ *   terminalEvents: ['uploadFinished'],
+ * })
+ *
+ * const transport = createFallbackTransport(client, {
+ *   contract: uploadStatusContract,
+ *   headers: () => ({ authorization: `Bearer ${auth.token()}` }),
+ *   diagnostics: { onEventSchemaError: (error) => reportToBugsnag(error) },
+ * })
+ *
+ * const subscription = createResilientSubscription(binding, {
+ *   transport,
+ *   params: buildFallbackParams(uploadStatusContract, { pathParams: { uploadId } }),
+ *   onAuthChallenge: async () => {
+ *     await auth.refresh()
+ *     return true
+ *   },
+ * })
+ *
+ * const finished = await subscription.waitFor('uploadFinished')
+ * ```
+ */
+export function createFallbackTransport(
+  wretch: WretchInstance,
+  options: CreateFallbackTransportOptions = {},
+): FallbackTransport {
+  const config = resolveOptions(options)
+  const {
+    snapshotContract,
+    snapshotAccept,
+    validateSnapshot,
+    strictContentType,
+    streamMode,
+    eventValidation,
+    eventSchemas,
+    diagnostics,
+  } = config
+
+  const prepare = (
+    request: FallbackTransportRequest,
+    channel: FallbackChannel,
+    channelHeaders: Record<string, string>,
+  ): Promise<PreparedRequest> => prepareRequest(config, request, channel, channelHeaders)
+
+  async function execute(
+    prepared: PreparedRequest,
+    signal: AbortSignal,
+    channel: FallbackChannel,
+  ): Promise<ExecuteOutcome> {
+    const instance = wretch.url(prepared.url).headers(prepared.headers).options({ signal })
+    try {
+      const response =
+        prepared.method === 'get' || prepared.method === 'delete'
+          ? await instance[prepared.method]().res()
+          : await instance[prepared.method](prepared.bodyString).res()
+      return { ok: true, response }
+    } catch (error) {
+      // A refused status is a result, not a failure: the core needs to see it
+      // to honour `unretryableStatuses` and offer it to `onAuthChallenge`.
+      if (error instanceof WretchError) return fromWretchError(error)
+      throw new FallbackTransportError(
+        `The ${channel} request to "${prepared.path}" failed: ${describeCause(error)}`,
+        { channel, path: prepared.path, cause: error },
+      )
+    }
+  }
+
+  function rejectUnusableSnapshot(entry: ResponseKind, path: string, status: number): void {
+    if (entry.kind === 'sse') {
+      throw new FallbackUnexpectedSnapshotError(
+        `The poll of "${path}" was answered with an SSE stream instead of a snapshot. The Accept negotiation reached the wrong branch — check that the route (and any gateway in front of it) serves JSON for "Accept: ${snapshotAccept}".`,
+        { channel: 'poll', path, status, contentType: SSE_ACCEPT },
+      )
+    }
+    if (entry.kind === 'blob') {
+      throw new FallbackUnexpectedSnapshotError(
+        `The poll of "${path}" resolved to a binary response, which cannot be a snapshot: the fallback version gate needs a JSON body carrying a version.`,
+        { channel: 'poll', path, status },
+      )
+    }
+    if (entry.kind === 'noContent') {
+      throw new FallbackUnexpectedSnapshotError(
+        `The poll of "${path}" returned status ${status} with no body. A snapshot must carry state and a version — a bodyless response cannot advance the watermark, and treating it as an empty snapshot would report the resource as newly empty.`,
+        { channel: 'poll', path, status },
+      )
+    }
+  }
+
+  async function readSnapshotJson(
+    response: Response,
+    path: string,
+    contentType: string | undefined,
+  ): Promise<unknown> {
+    const text = await response.text()
+    if (text === '') {
+      throw new FallbackUnexpectedSnapshotError(
+        `The poll of "${path}" returned an empty body where a JSON snapshot was expected.`,
+        { channel: 'poll', path, status: response.status, contentType },
+      )
+    }
+    try {
+      return JSON.parse(text)
+    } catch (error) {
+      throw new FallbackUnexpectedSnapshotError(
+        `The poll of "${path}" returned a body that is not valid JSON: ${describeCause(error)}`,
+        {
+          channel: 'poll',
+          path,
+          status: response.status,
+          contentType,
+          bodyPreview: previewOf(text),
+          cause: error,
+        },
+      )
+    }
+  }
+
+  async function readSnapshotBody(
+    response: Response,
+    path: string,
+    contentType: string | undefined,
+  ): Promise<unknown> {
+    if (!snapshotContract) return await readSnapshotJson(response, path, contentType)
+
+    const entry = resolveResponseEntry(
+      snapshotContract.responsesByStatusCode,
+      response.status,
+      contentType,
+      strictContentType,
+    )
+    if (!entry) {
+      throw new FallbackUnexpectedSnapshotError(
+        `The poll of "${path}" returned status ${response.status} with content-type "${contentType ?? '<none>'}", which "${snapshotContract.summary}" does not declare for that status.`,
+        { channel: 'poll', path, status: response.status, contentType },
+      )
+    }
+    rejectUnusableSnapshot(entry, path, response.status)
+
+    const json = await readSnapshotJson(response, path, contentType)
+    // Only the JSON representation survives `rejectUnusableSnapshot`.
+    if (entry.kind !== 'json' || !validateSnapshot) return json
+
+    const result = entry.schema.safeParse(json)
+    if (!result.success) {
+      throw new FallbackSnapshotValidationError(
+        `The snapshot from "${path}" does not match the schema of "${snapshotContract.summary}": ${result.error.message}`,
+        {
+          channel: 'poll',
+          path,
+          status: response.status,
+          issues: result.error.issues,
+        },
+      )
+    }
+    return result.data
+  }
+
+  function reportEventError(error: FallbackEventValidationError): FallbackEventValidationError {
+    diagnostics.onEventSchemaError?.(error)
+    return error
+  }
+
+  function validateFrame(
+    frame: FallbackParsedSseFrame,
+    path: string,
+  ): FallbackEventValidationError | undefined {
+    if (!eventSchemas) return undefined
+
+    const event = frame.event ?? 'message'
+    const schema = eventSchemas[event]
+    if (!schema) {
+      diagnostics.onUndeclaredEvent?.({ path, event })
+      return undefined
+    }
+
+    let payload: unknown
+    try {
+      payload = JSON.parse(frame.data)
+    } catch (error) {
+      return reportEventError(
+        new FallbackEventValidationError(
+          `SSE event "${event}" from "${path}" carried a payload that is not valid JSON: ${describeCause(error)}`,
+          { path, event, data: previewOf(frame.data), cause: error },
+        ),
+      )
+    }
+
+    const result = schema.safeParse(payload)
+    if (result.success) return undefined
+    return reportEventError(
+      new FallbackEventValidationError(
+        `SSE event "${event}" from "${path}" does not match its schema: ${result.error.message}`,
+        { path, event, data: previewOf(frame.data), issues: result.error.issues },
+      ),
+    )
+  }
+
+  /** Pass raw chunks through untouched, validating the frames they complete. */
+  async function* inspectChunks(
+    chunks: AsyncIterable<string>,
+    path: string,
+  ): AsyncGenerator<string> {
+    const framer = new SseFramer()
+    for await (const chunk of chunks) {
+      for (const frame of framer.push(chunk)) {
+        validateFrame(frame, path)
+      }
+      yield chunk
+    }
+  }
+
+  async function* frameChunks(
+    chunks: AsyncIterable<string>,
+    path: string,
+  ): AsyncGenerator<FallbackParsedSseFrame> {
+    const framer = new SseFramer()
+    for await (const chunk of chunks) {
+      for (const frame of framer.push(chunk)) {
+        if (validateFrame(frame, path) && eventValidation === 'drop') continue
+        yield frame
+      }
+    }
+  }
+
+  async function fetchSnapshot(
+    request: FallbackTransportRequest,
+    opts: { signal: AbortSignal },
+  ): Promise<FallbackSnapshotResponse> {
+    const startedAt = Date.now()
+    const prepared = await prepare(request, 'poll', {
+      accept: snapshotAccept,
+      // A cached poll response would quietly disable the correctness backbone:
+      // the fallback would keep "succeeding" while reporting stale state.
+      'cache-control': 'no-cache',
+    })
+    const outcome = await execute(prepared, opts.signal, 'poll')
+    const status = outcome.ok ? outcome.response.status : outcome.status
+    diagnostics.onSnapshot?.({
+      path: prepared.path,
+      status,
+      durationMs: Date.now() - startedAt,
+    })
+
+    if (!outcome.ok) {
+      // Non-2xx resolves: the core owns what a status means (retry, give up,
+      // or hand it to `onAuthChallenge`).
+      return { status, headers: outcome.headers, body: outcome.body }
+    }
+
+    const headers = normalizeResponseHeaders(outcome.response)
+    return {
+      status,
+      headers,
+      body: await readSnapshotBody(outcome.response, prepared.path, headers['content-type']),
+    }
+  }
+
+  async function openStream(
+    request: FallbackTransportRequest,
+    opts: { signal: AbortSignal; lastEventId?: string },
+  ): Promise<FallbackStreamResponse> {
+    const channelHeaders: Record<string, string> = {
+      accept: SSE_ACCEPT,
+      'cache-control': 'no-cache',
+    }
+    // An empty cursor is "no cursor": sending `Last-Event-ID:` with no value
+    // asks a spec-following server to replay from the start of the stream.
+    if (opts.lastEventId !== undefined && opts.lastEventId !== '') {
+      channelHeaders['last-event-id'] = opts.lastEventId
+    }
+
+    const prepared = await prepare(request, 'stream', channelHeaders)
+    const outcome = await execute(prepared, opts.signal, 'stream')
+    const status = outcome.ok ? outcome.response.status : outcome.status
+    const headers = outcome.ok ? normalizeResponseHeaders(outcome.response) : outcome.headers
+    diagnostics.onStreamOpen?.({
+      path: prepared.path,
+      status,
+      contentType: headers['content-type'],
+      lastEventId: opts.lastEventId,
+    })
+
+    // A refused connect resolves with no stream: the core reads the status,
+    // counts a connect failure, and aborts the request so nothing leaks.
+    /* v8 ignore next -- a materialized 2xx fetch response always has a body */
+    if (!outcome.ok || !outcome.response.body) {
+      return { status, headers, chunks: emptyChunks() }
+    }
+
+    const chunks = readTextChunks(outcome.response.body, opts.signal)
+    if (streamMode === 'events') {
+      return { status, headers, events: frameChunks(chunks, prepared.path) }
+    }
+    return {
+      status,
+      headers,
+      chunks: eventSchemas ? inspectChunks(chunks, prepared.path) : chunks,
+    }
+  }
+
+  return { fetchSnapshot, openStream }
+}

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.ts
@@ -44,10 +44,19 @@ export type FallbackEventValidationMode =
    */
   | 'report'
   /**
-   * Withhold the frame from the core entirely, so the version watermark never
-   * advances past it and the deadman poll repairs the gap from a snapshot.
-   * Requires `streamMode: 'events'`, which is where the framing — and
-   * therefore the decision — happens before the core sees anything.
+   * Withhold the frame from the core entirely **and end the stream**, so the
+   * version watermark never advances past the hole and the repair snapshot
+   * lands above it. Both halves are load-bearing: frames delivered after a
+   * withheld one advance the watermark past the gap, and the repair poll then
+   * arrives at or below it — where the reconciler reads it as a stale
+   * duplicate and synthesizes nothing, leaving the withheld event lost for
+   * good.
+   *
+   * The cost is a reconnect per rejected payload, which is the point: a stream
+   * emitting bodies its own contract rejects is broken, and the polling
+   * backbone carries the subscription meanwhile. Requires `streamMode:
+   * 'events'`, which is where the framing — and therefore the decision —
+   * happens before the core sees anything.
    */
   | 'drop'
 
@@ -60,12 +69,18 @@ export type FallbackStreamMode =
    */
   | 'chunks'
   /**
-   * Frames, framed here. Comment frames are consumed by the framing, so the
-   * stale-connection watchdog degrades from byte-level to event-level — the
-   * price of validating payloads before the core sees them. An `id:` or
-   * `retry:` that arrives without a frame to ride on is carried into the next
-   * connect rather than lost, which is the one other thing the core's own
-   * parser would have done for itself.
+   * Frames, framed here. The price of validating payloads before the core sees
+   * them, paid in two places:
+   *
+   * - comment frames are consumed by the framing, so the stale-connection
+   *   watchdog degrades from byte-level to event-level;
+   * - an `id:` or `retry:` that arrives with no `data:` reaches the core only
+   *   if a later frame on the same connection carries it out. In `'chunks'`
+   *   mode the core's own parser reads both per chunk regardless.
+   *
+   * Neither loss corrupts anything — an unreported cursor replays events the
+   * version gate then dedupes, and an unreported `retry:` leaves the core on
+   * its own backoff — but they are why `'chunks'` is the default.
    */
   | 'events'
 
@@ -154,33 +169,6 @@ type PreparedRequest = {
   url: string
   headers: Record<string, string>
   bodyString: string | undefined
-}
-
-/**
- * What a framed connection leaves behind that none of its frames could carry.
- *
- * In `streamMode: 'events'` the core only ever sees frames, so the two
- * stream-scoped fields SSE lets arrive on their own — an `id:` with no `data:`,
- * and a `retry:` hint — are lost when no frame dispatches after them. In
- * `chunks` mode the core's own parser reads both per chunk regardless; carrying
- * the residue into the next connect is what keeps `'events'` level with it.
- */
-/** Where a framed connection starts, once the residue above is applied. */
-type StreamResume = {
-  key: string
-  resumedFrom: string | undefined
-  retry: number | undefined
-}
-
-type StreamCarry = {
-  /** Which stream the residue belongs to; another stream must not inherit it. */
-  key: string
-  /** Cursor as of the last frame the core was actually handed. */
-  deliveredCursor: string | undefined
-  /** Cursor the framer reached afterwards, from frames that dispatched nothing. */
-  trailingCursor: string | undefined
-  /** A `retry:` hint no frame ever carried. */
-  retry: number | undefined
 }
 
 type ExecuteOutcome =
@@ -649,78 +637,29 @@ export function createFallbackTransport(
     }
   }
 
-  /**
-   * Residue of the last framed connection — see {@link StreamCarry}. One slot
-   * rather than a map: reconnects for a stream are consecutive, so a slot
-   * covers them, while a transport shared across several streams simply finds
-   * nothing to inherit instead of inheriting another stream's cursor. It is
-   * only ever written in `streamMode: 'events'`, and read exactly once.
-   */
-  let carry: StreamCarry | undefined
-
-  /** Stream identity across reconnects: the request the binding rebuilds each time. */
-  const streamKeyOf = (request: FallbackTransportRequest): string =>
-    `${request.method} ${request.path} ${JSON.stringify(request.query ?? null)}`
-
-  /**
-   * Where to resume this connection from, and which `retry:` hint it inherits.
-   *
-   * The core's cursor wins unless the previous connection framed an `id:` past
-   * it that no frame could report. The upgrade applies only when the core is
-   * exactly where the last delivered frame left it: anywhere else it held the
-   * cursor back on purpose — an unreadable frame, or one `eventValidation:
-   * 'drop'` withheld — and moving past that frame would make the replay skip
-   * it for good.
-   */
-  function resumeStream(
-    request: FallbackTransportRequest,
-    coreCursor: string | undefined,
-  ): StreamResume {
-    const key = streamKeyOf(request)
-    const previous = carry
-    carry = undefined
-    // An empty cursor is "no cursor" on the wire, so normalize before comparing.
-    const cursor = coreCursor === '' ? undefined : coreCursor
-    if (streamMode !== 'events' || !previous || previous.key !== key) {
-      return { key, resumedFrom: cursor, retry: undefined }
-    }
-    return {
-      key,
-      resumedFrom: cursor === previous.deliveredCursor ? previous.trailingCursor : cursor,
-      retry: previous.retry,
-    }
-  }
-
   async function* frameChunks(
     chunks: AsyncIterable<string>,
     path: string,
-    stream: StreamResume,
+    resumedFrom: string | undefined,
   ): AsyncGenerator<FallbackParsedSseFrame> {
-    const framer = new SseFramer({ lastEventId: stream.resumedFrom, retry: stream.retry })
-    // Both start where the connection opened: with no frames yet, that is
-    // exactly where the core's cursor is.
-    let cursorAtLastFrame = stream.resumedFrom
-    let cursorAtLastDelivery = stream.resumedFrom
-    try {
-      for await (const chunk of chunks) {
-        for (const frame of framer.push(chunk)) {
-          cursorAtLastFrame = frame.lastEventId
-          if (validateFrame(frame, path) && eventValidation === 'drop') continue
-          cursorAtLastDelivery = frame.lastEventId
-          yield frame
+    // Seeded with the cursor this connection resumed from, so an id-less frame
+    // reports the cursor it inherited rather than none at all.
+    const framer = new SseFramer({ lastEventId: resumedFrom })
+    for await (const chunk of chunks) {
+      for (const frame of framer.push(chunk)) {
+        if (validateFrame(frame, path) && eventValidation === 'drop') {
+          // Withholding just this frame would not keep the gap open. The core
+          // delivers the next valid frame and advances its watermark past the
+          // hole; the repair poll then lands at or below that watermark, where
+          // the reconciler reads it as a stale duplicate and synthesizes
+          // nothing — so the withheld event is never reconstructed. Ending the
+          // stream instead leaves the watermark below the hole, which is what
+          // makes the repair snapshot land above it and rebuild the state and
+          // the events it covers. The core reads the end as a disconnect and
+          // reconnects from the cursor it still holds.
+          return
         }
-      }
-    } finally {
-      carry = {
-        key: stream.key,
-        deliveredCursor: cursorAtLastDelivery,
-        // Only an advance that happened *after* the last frame is inheritable.
-        // A cursor sitting past a frame the core never received (a dropped
-        // payload) is one the next connect must not skip over — that frame is
-        // exactly what the repair poll, or a replay, still owes us.
-        trailingCursor:
-          cursorAtLastDelivery === cursorAtLastFrame ? framer.lastEventId : cursorAtLastDelivery,
-        retry: framer.pendingRetry,
+        yield frame
       }
     }
   }
@@ -762,15 +701,15 @@ export function createFallbackTransport(
     request: FallbackTransportRequest,
     opts: { signal: AbortSignal; lastEventId?: string },
   ): Promise<FallbackStreamResponse> {
-    const stream = resumeStream(request, opts.lastEventId)
+    // An empty cursor is "no cursor": sending `Last-Event-ID:` with no value
+    // asks a spec-following server to replay from the start of the stream.
+    const resumedFrom = opts.lastEventId === '' ? undefined : opts.lastEventId
     const channelHeaders: Record<string, string> = {
       accept: SSE_ACCEPT,
       'cache-control': 'no-cache',
     }
-    // An empty cursor is "no cursor": sending `Last-Event-ID:` with no value
-    // asks a spec-following server to replay from the start of the stream.
-    if (stream.resumedFrom !== undefined && stream.resumedFrom !== '') {
-      channelHeaders['last-event-id'] = stream.resumedFrom
+    if (resumedFrom !== undefined) {
+      channelHeaders['last-event-id'] = resumedFrom
     }
 
     const prepared = await prepare(request, 'stream', channelHeaders)
@@ -781,7 +720,7 @@ export function createFallbackTransport(
       path: prepared.path,
       status,
       contentType: headers['content-type'],
-      lastEventId: stream.resumedFrom,
+      lastEventId: opts.lastEventId,
     })
 
     // A refused connect resolves with no stream: the core reads the status,
@@ -793,7 +732,7 @@ export function createFallbackTransport(
 
     const chunks = readTextChunks(outcome.response.body, opts.signal)
     if (streamMode === 'events') {
-      return { status, headers, events: frameChunks(chunks, prepared.path, stream) }
+      return { status, headers, events: frameChunks(chunks, prepared.path, resumedFrom) }
     }
     return {
       status,

--- a/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/createFallbackTransport.ts
@@ -62,7 +62,10 @@ export type FallbackStreamMode =
   /**
    * Frames, framed here. Comment frames are consumed by the framing, so the
    * stale-connection watchdog degrades from byte-level to event-level — the
-   * price of validating payloads before the core sees them.
+   * price of validating payloads before the core sees them. An `id:` or
+   * `retry:` that arrives without a frame to ride on is carried into the next
+   * connect rather than lost, which is the one other thing the core's own
+   * parser would have done for itself.
    */
   | 'events'
 
@@ -153,6 +156,33 @@ type PreparedRequest = {
   bodyString: string | undefined
 }
 
+/**
+ * What a framed connection leaves behind that none of its frames could carry.
+ *
+ * In `streamMode: 'events'` the core only ever sees frames, so the two
+ * stream-scoped fields SSE lets arrive on their own — an `id:` with no `data:`,
+ * and a `retry:` hint — are lost when no frame dispatches after them. In
+ * `chunks` mode the core's own parser reads both per chunk regardless; carrying
+ * the residue into the next connect is what keeps `'events'` level with it.
+ */
+/** Where a framed connection starts, once the residue above is applied. */
+type StreamResume = {
+  key: string
+  resumedFrom: string | undefined
+  retry: number | undefined
+}
+
+type StreamCarry = {
+  /** Which stream the residue belongs to; another stream must not inherit it. */
+  key: string
+  /** Cursor as of the last frame the core was actually handed. */
+  deliveredCursor: string | undefined
+  /** Cursor the framer reached afterwards, from frames that dispatched nothing. */
+  trailingCursor: string | undefined
+  /** A `retry:` hint no frame ever carried. */
+  retry: number | undefined
+}
+
 type ExecuteOutcome =
   | { ok: true; response: Response }
   | { ok: false; status: number; headers: Record<string, string>; body: unknown }
@@ -192,6 +222,25 @@ function fromWretchError(error: WretchError): ExecuteOutcome {
 async function* emptyChunks(): AsyncGenerator<string> {
   // A refused connect carries no stream; the core counts it as a connect
   // failure the moment it sees the status.
+}
+
+/**
+ * Release the socket behind a response we are about to reject.
+ *
+ * `cancel()` rather than draining with `text()`: the poll can be answered with
+ * the stream branch, whose body never ends, and buffering that would hang a
+ * request the caller has already given up on. Doing nothing is not an option
+ * either — the core's `executePoll` only aborts a poll on timeout or on stop,
+ * never one it rejected, so an unread body is a connection held for the life
+ * of the page.
+ */
+async function releaseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel()
+  } catch {
+    // Already consumed, already errored, or cancellation raced the close —
+    // either way nothing is left holding the connection.
+  }
 }
 
 /**
@@ -439,25 +488,37 @@ export function createFallbackTransport(
     }
   }
 
-  function rejectUnusableSnapshot(entry: ResponseKind, path: string, status: number): void {
+  /**
+   * The error a response kind that cannot be a snapshot deserves, if any.
+   *
+   * Returned rather than thrown so the caller can release the body it is about
+   * to walk away from — the SSE case in particular would otherwise hold a
+   * stream that never ends.
+   */
+  function unusableSnapshotError(
+    entry: ResponseKind,
+    path: string,
+    status: number,
+  ): FallbackUnexpectedSnapshotError | undefined {
     if (entry.kind === 'sse') {
-      throw new FallbackUnexpectedSnapshotError(
+      return new FallbackUnexpectedSnapshotError(
         `The poll of "${path}" was answered with an SSE stream instead of a snapshot. The Accept negotiation reached the wrong branch — check that the route (and any gateway in front of it) serves JSON for "Accept: ${snapshotAccept}".`,
         { channel: 'poll', path, status, contentType: SSE_ACCEPT },
       )
     }
     if (entry.kind === 'blob') {
-      throw new FallbackUnexpectedSnapshotError(
+      return new FallbackUnexpectedSnapshotError(
         `The poll of "${path}" resolved to a binary response, which cannot be a snapshot: the fallback version gate needs a JSON body carrying a version.`,
         { channel: 'poll', path, status },
       )
     }
     if (entry.kind === 'noContent') {
-      throw new FallbackUnexpectedSnapshotError(
+      return new FallbackUnexpectedSnapshotError(
         `The poll of "${path}" returned status ${status} with no body. A snapshot must carry state and a version — a bodyless response cannot advance the watermark, and treating it as an empty snapshot would report the resource as newly empty.`,
         { channel: 'poll', path, status },
       )
     }
+    return undefined
   }
 
   async function readSnapshotJson(
@@ -503,15 +564,20 @@ export function createFallbackTransport(
       strictContentType,
     )
     if (!entry) {
+      await releaseBody(response)
       throw new FallbackUnexpectedSnapshotError(
         `The poll of "${path}" returned status ${response.status} with content-type "${contentType ?? '<none>'}", which "${snapshotContract.summary}" does not declare for that status.`,
         { channel: 'poll', path, status: response.status, contentType },
       )
     }
-    rejectUnusableSnapshot(entry, path, response.status)
+    const unusable = unusableSnapshotError(entry, path, response.status)
+    if (unusable) {
+      await releaseBody(response)
+      throw unusable
+    }
 
     const json = await readSnapshotJson(response, path, contentType)
-    // Only the JSON representation survives `rejectUnusableSnapshot`.
+    // Only the JSON representation survives `unusableSnapshotError`.
     if (entry.kind !== 'json' || !validateSnapshot) return json
 
     const result = entry.schema.safeParse(json)
@@ -583,15 +649,78 @@ export function createFallbackTransport(
     }
   }
 
+  /**
+   * Residue of the last framed connection — see {@link StreamCarry}. One slot
+   * rather than a map: reconnects for a stream are consecutive, so a slot
+   * covers them, while a transport shared across several streams simply finds
+   * nothing to inherit instead of inheriting another stream's cursor. It is
+   * only ever written in `streamMode: 'events'`, and read exactly once.
+   */
+  let carry: StreamCarry | undefined
+
+  /** Stream identity across reconnects: the request the binding rebuilds each time. */
+  const streamKeyOf = (request: FallbackTransportRequest): string =>
+    `${request.method} ${request.path} ${JSON.stringify(request.query ?? null)}`
+
+  /**
+   * Where to resume this connection from, and which `retry:` hint it inherits.
+   *
+   * The core's cursor wins unless the previous connection framed an `id:` past
+   * it that no frame could report. The upgrade applies only when the core is
+   * exactly where the last delivered frame left it: anywhere else it held the
+   * cursor back on purpose — an unreadable frame, or one `eventValidation:
+   * 'drop'` withheld — and moving past that frame would make the replay skip
+   * it for good.
+   */
+  function resumeStream(
+    request: FallbackTransportRequest,
+    coreCursor: string | undefined,
+  ): StreamResume {
+    const key = streamKeyOf(request)
+    const previous = carry
+    carry = undefined
+    // An empty cursor is "no cursor" on the wire, so normalize before comparing.
+    const cursor = coreCursor === '' ? undefined : coreCursor
+    if (streamMode !== 'events' || !previous || previous.key !== key) {
+      return { key, resumedFrom: cursor, retry: undefined }
+    }
+    return {
+      key,
+      resumedFrom: cursor === previous.deliveredCursor ? previous.trailingCursor : cursor,
+      retry: previous.retry,
+    }
+  }
+
   async function* frameChunks(
     chunks: AsyncIterable<string>,
     path: string,
+    stream: StreamResume,
   ): AsyncGenerator<FallbackParsedSseFrame> {
-    const framer = new SseFramer()
-    for await (const chunk of chunks) {
-      for (const frame of framer.push(chunk)) {
-        if (validateFrame(frame, path) && eventValidation === 'drop') continue
-        yield frame
+    const framer = new SseFramer({ lastEventId: stream.resumedFrom, retry: stream.retry })
+    // Both start where the connection opened: with no frames yet, that is
+    // exactly where the core's cursor is.
+    let cursorAtLastFrame = stream.resumedFrom
+    let cursorAtLastDelivery = stream.resumedFrom
+    try {
+      for await (const chunk of chunks) {
+        for (const frame of framer.push(chunk)) {
+          cursorAtLastFrame = frame.lastEventId
+          if (validateFrame(frame, path) && eventValidation === 'drop') continue
+          cursorAtLastDelivery = frame.lastEventId
+          yield frame
+        }
+      }
+    } finally {
+      carry = {
+        key: stream.key,
+        deliveredCursor: cursorAtLastDelivery,
+        // Only an advance that happened *after* the last frame is inheritable.
+        // A cursor sitting past a frame the core never received (a dropped
+        // payload) is one the next connect must not skip over — that frame is
+        // exactly what the repair poll, or a replay, still owes us.
+        trailingCursor:
+          cursorAtLastDelivery === cursorAtLastFrame ? framer.lastEventId : cursorAtLastDelivery,
+        retry: framer.pendingRetry,
       }
     }
   }
@@ -633,14 +762,15 @@ export function createFallbackTransport(
     request: FallbackTransportRequest,
     opts: { signal: AbortSignal; lastEventId?: string },
   ): Promise<FallbackStreamResponse> {
+    const stream = resumeStream(request, opts.lastEventId)
     const channelHeaders: Record<string, string> = {
       accept: SSE_ACCEPT,
       'cache-control': 'no-cache',
     }
     // An empty cursor is "no cursor": sending `Last-Event-ID:` with no value
     // asks a spec-following server to replay from the start of the stream.
-    if (opts.lastEventId !== undefined && opts.lastEventId !== '') {
-      channelHeaders['last-event-id'] = opts.lastEventId
+    if (stream.resumedFrom !== undefined && stream.resumedFrom !== '') {
+      channelHeaders['last-event-id'] = stream.resumedFrom
     }
 
     const prepared = await prepare(request, 'stream', channelHeaders)
@@ -651,7 +781,7 @@ export function createFallbackTransport(
       path: prepared.path,
       status,
       contentType: headers['content-type'],
-      lastEventId: opts.lastEventId,
+      lastEventId: stream.resumedFrom,
     })
 
     // A refused connect resolves with no stream: the core reads the status,
@@ -663,7 +793,7 @@ export function createFallbackTransport(
 
     const chunks = readTextChunks(outcome.response.body, opts.signal)
     if (streamMode === 'events') {
-      return { status, headers, events: frameChunks(chunks, prepared.path) }
+      return { status, headers, events: frameChunks(chunks, prepared.path, stream) }
     }
     return {
       status,

--- a/packages/app/frontend-http-client/src/sse-fallback/errors.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/errors.ts
@@ -77,7 +77,7 @@ export class FallbackUnexpectedSnapshotError extends FallbackTransportError {
   }
 }
 
-export type FallbackParamsPart = 'pathParams' | 'queryParams' | 'body'
+export type FallbackParamsPart = 'pathParams' | 'queryParams' | 'headers' | 'body'
 
 /**
  * Subscription params did not match the contract's request schemas. Thrown by

--- a/packages/app/frontend-http-client/src/sse-fallback/errors.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/errors.ts
@@ -1,0 +1,158 @@
+import type { z } from 'zod/v4'
+import type { FallbackChannel } from './types.ts'
+
+export type FallbackErrorContext = {
+  channel: FallbackChannel
+  /** Request path the failure belongs to, including the path prefix. */
+  path: string
+  /** HTTP status, when the failure happened after a response was received. */
+  status?: number
+  cause?: unknown
+}
+
+/**
+ * Base class for every failure this transport rejects with.
+ *
+ * The fallback client core treats a rejected `fetchSnapshot` as a poll failure
+ * (backoff, retry, `diagnostics.onPollError`) and a rejected `openStream` as a
+ * connect failure (backoff, degradation, `diagnostics.onStreamError`). Rejecting
+ * is therefore never fatal — but it is also never silent, which is why every
+ * rejection carries the channel and path that produced it.
+ */
+export class FallbackTransportError extends Error {
+  readonly channel: FallbackChannel
+  readonly path: string
+  readonly status: number | undefined
+
+  constructor(message: string, context: FallbackErrorContext) {
+    super(message, context.cause !== undefined ? { cause: context.cause } : undefined)
+    this.name = 'FallbackTransportError'
+    this.channel = context.channel
+    this.path = context.path
+    this.status = context.status
+  }
+}
+
+/**
+ * A snapshot body did not match the contract's schema.
+ *
+ * Rejected rather than delivered: an unvalidated body reaching
+ * `snapshotToEvents` / `version.ofSnapshot` / `state.init` turns a schema drift
+ * into a wrong version watermark, and a wrong watermark silently drops the
+ * stream's events from then on. A poll failure is recoverable; a poisoned
+ * watermark is not.
+ */
+export class FallbackSnapshotValidationError extends FallbackTransportError {
+  readonly issues: readonly z.core.$ZodIssue[]
+
+  constructor(
+    message: string,
+    context: FallbackErrorContext & { issues: readonly z.core.$ZodIssue[] },
+  ) {
+    super(message, context)
+    this.name = 'FallbackSnapshotValidationError'
+    this.issues = context.issues
+  }
+}
+
+/**
+ * The poll branch answered with something that cannot be a snapshot: a
+ * representation the contract does not declare for that status, an SSE stream
+ * (the `Accept` negotiation went to the wrong branch), a binary body, or no
+ * body at all.
+ */
+export class FallbackUnexpectedSnapshotError extends FallbackTransportError {
+  readonly contentType: string | undefined
+  /** Response text, when it was read and small enough to be useful. */
+  readonly bodyPreview: string | undefined
+
+  constructor(
+    message: string,
+    context: FallbackErrorContext & { contentType?: string; bodyPreview?: string },
+  ) {
+    super(message, context)
+    this.name = 'FallbackUnexpectedSnapshotError'
+    this.contentType = context.contentType
+    this.bodyPreview = context.bodyPreview
+  }
+}
+
+export type FallbackParamsPart = 'pathParams' | 'queryParams' | 'body'
+
+/**
+ * Subscription params did not match the contract's request schemas. Thrown by
+ * `buildFallbackParams` at subscription-creation time, rather than letting the
+ * mistake become a 400/404 the subscription retries on a backoff.
+ */
+export class FallbackParamsValidationError extends Error {
+  readonly part: FallbackParamsPart
+  /** `summary` of the contract the params were built for. */
+  readonly summary: string
+  readonly issues: readonly z.core.$ZodIssue[]
+
+  constructor(
+    message: string,
+    context: { part: FallbackParamsPart; summary: string; issues: readonly z.core.$ZodIssue[] },
+  ) {
+    super(message)
+    this.name = 'FallbackParamsValidationError'
+    this.part = context.part
+    this.summary = context.summary
+    this.issues = context.issues
+  }
+}
+
+/**
+ * A param is valid per the contract but cannot be expressed in a fallback
+ * subscription request — a repeated/structured query parameter, which the
+ * binding's flat `Record<string, string>` query cannot carry.
+ */
+export class FallbackUnsupportedParamError extends Error {
+  readonly part: FallbackParamsPart
+  readonly summary: string
+  readonly param: string
+
+  constructor(
+    message: string,
+    context: { part: FallbackParamsPart; summary: string; param: string },
+  ) {
+    super(message)
+    this.name = 'FallbackUnsupportedParamError'
+    this.part = context.part
+    this.summary = context.summary
+    this.param = context.param
+  }
+}
+
+/**
+ * An SSE frame's payload did not match the contract's schema for its event
+ * name (or was not valid JSON at all).
+ *
+ * Never thrown: it is reported to `diagnostics.onEventSchemaError`, and with
+ * `eventValidation: 'drop'` the frame is withheld from the core so a poll
+ * repairs the gap instead of app code receiving a payload it cannot trust.
+ */
+export class FallbackEventValidationError extends Error {
+  readonly path: string
+  readonly event: string
+  readonly data: string
+  readonly issues: readonly z.core.$ZodIssue[] | undefined
+
+  constructor(
+    message: string,
+    context: {
+      path: string
+      event: string
+      data: string
+      issues?: readonly z.core.$ZodIssue[]
+      cause?: unknown
+    },
+  ) {
+    super(message, context.cause !== undefined ? { cause: context.cause } : undefined)
+    this.name = 'FallbackEventValidationError'
+    this.path = context.path
+    this.event = context.event
+    this.data = context.data
+    this.issues = context.issues
+  }
+}

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
@@ -171,34 +171,11 @@ describe('SseFramer', () => {
     })
   })
 
-  describe('carrying stream state across a reconnect', () => {
+  describe('resuming a stream', () => {
     it('reports the cursor the connection resumed from on an id-less frame', () => {
       const framer = new SseFramer({ lastEventId: 'e-7' })
 
       expect(framer.push('data: 1\n\n')).toEqual([{ data: '1', lastEventId: 'e-7' }])
-    })
-
-    it('stamps an inherited retry hint onto the first frame that dispatches', () => {
-      const framer = new SseFramer({ retry: 4000 })
-
-      expect(framer.push('data: 1\n\n')).toEqual([{ data: '1', retry: 4000 }])
-      // Connection-scoped, not per-frame: it is spent once it has been reported.
-      expect(framer.push('data: 2\n\n')).toEqual([{ data: '2' }])
-      expect(framer.pendingRetry).toBeUndefined()
-    })
-
-    it('holds a retry hint no frame ever carried, so the caller can inherit it', () => {
-      const framer = new SseFramer()
-
-      expect(framer.push('retry: 9000\n\n')).toEqual([])
-      expect(framer.pendingRetry).toBe(9000)
-    })
-
-    it('holds the cursor a data-less id frame left it at', () => {
-      const framer = new SseFramer({ lastEventId: 'e-1' })
-
-      expect(framer.push('data: 1\n\nid: e-2\n\n')).toEqual([{ data: '1', lastEventId: 'e-1' }])
-      expect(framer.lastEventId).toBe('e-2')
     })
   })
 

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { SseFramer } from './framer.ts'
+
+describe('SseFramer', () => {
+  it('frames a complete event', () => {
+    const framer = new SseFramer()
+
+    expect(framer.push('event: uploadFinished\ndata: {"ok":true}\n\n')).toEqual([
+      { event: 'uploadFinished', data: '{"ok":true}' },
+    ])
+  })
+
+  it('defaults a nameless frame to no event name, letting the core apply "message"', () => {
+    const framer = new SseFramer()
+
+    expect(framer.push('data: 1\n\n')).toEqual([{ data: '1' }])
+  })
+
+  it('buffers a frame split across chunks', () => {
+    const framer = new SseFramer()
+
+    expect(framer.push('event: tick\nda')).toEqual([])
+    expect(framer.push('ta: {"n":1}\n')).toEqual([])
+    expect(framer.push('\n')).toEqual([{ event: 'tick', data: '{"n":1}' }])
+  })
+
+  it('frames several events in one chunk', () => {
+    const framer = new SseFramer()
+
+    expect(framer.push('data: 1\n\ndata: 2\n\n')).toEqual([{ data: '1' }, { data: '2' }])
+  })
+
+  describe('line terminators', () => {
+    it('accepts LF, CR and CRLF', () => {
+      expect(new SseFramer().push('data: lf\n\n')).toEqual([{ data: 'lf' }])
+      expect(new SseFramer().push('data: crlf\r\n\r\n')).toEqual([{ data: 'crlf' }])
+
+      // A CR-terminated frame dispatches one byte late: until something
+      // follows the final CR there is no telling it from the first half of a
+      // CRLF, and guessing would split one terminator into two.
+      const crFramer = new SseFramer()
+      expect(crFramer.push('data: cr\r\r')).toEqual([])
+      expect(crFramer.push('data: next\r\r')).toEqual([{ data: 'cr' }])
+    })
+
+    it('holds back a trailing CR so a CRLF split across chunks is one terminator', () => {
+      const framer = new SseFramer()
+
+      // Were the CR treated as a terminator now, the following LF would look
+      // like the blank line that ends the frame and the payload would be lost.
+      expect(framer.push('data: split\r')).toEqual([])
+      expect(framer.push('\ndata: more\r\n\r\n')).toEqual([{ data: 'split\nmore' }])
+    })
+
+    it('treats a lone CR at the end of the stream as pending, not as a terminator', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('data: a\n\r')).toEqual([])
+      expect(framer.push('\n')).toEqual([{ data: 'a' }])
+    })
+  })
+
+  describe('field parsing', () => {
+    it('strips exactly one leading space after the colon', () => {
+      expect(new SseFramer().push('data:  padded\n\n')).toEqual([{ data: ' padded' }])
+      expect(new SseFramer().push('data:tight\n\n')).toEqual([{ data: 'tight' }])
+    })
+
+    it('reads a line with no colon as a field with an empty value', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('data\n\n')).toEqual([{ data: '' }])
+    })
+
+    it('ignores comment frames', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push(': heartbeat\n\n')).toEqual([])
+      expect(framer.push('data: after\n\n')).toEqual([{ data: 'after' }])
+    })
+
+    it('ignores unknown field names', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('unknown: whatever\ndata: kept\n\n')).toEqual([{ data: 'kept' }])
+    })
+
+    it('joins several data lines with newlines', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('data: one\ndata: two\ndata:\n\n')).toEqual([{ data: 'one\ntwo\n' }])
+    })
+  })
+
+  describe('ids', () => {
+    it('reports the frame id and carries the cursor onto later frames', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('id: 7\ndata: a\n\n')).toEqual([{ id: '7', data: 'a', lastEventId: '7' }])
+      // The cursor is sticky; the frame's own id is not, which is what keeps
+      // the core's version gate from reading an id-less frame as a duplicate.
+      expect(framer.push('data: b\n\n')).toEqual([{ data: 'b', lastEventId: '7' }])
+      expect(framer.lastEventId).toBe('7')
+    })
+
+    it('moves the cursor on a data-less id frame without dispatching an event', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('id: 12\n\n')).toEqual([])
+      expect(framer.lastEventId).toBe('12')
+      expect(framer.push('data: next\n\n')).toEqual([{ data: 'next', lastEventId: '12' }])
+    })
+
+    it('clears the cursor on an empty id', () => {
+      const framer = new SseFramer()
+
+      framer.push('id: 4\ndata: a\n\n')
+      expect(framer.push('id:\ndata: b\n\n')).toEqual([{ id: '', data: 'b', lastEventId: '' }])
+      expect(framer.lastEventId).toBe('')
+    })
+
+    it('ignores an id containing NUL rather than truncating it', () => {
+      const framer = new SseFramer()
+
+      framer.push('id: 9\ndata: a\n\n')
+      expect(framer.push('id: 1\u000023\ndata: b\n\n')).toEqual([{ data: 'b', lastEventId: '9' }])
+      expect(framer.lastEventId).toBe('9')
+    })
+  })
+
+  describe('retry', () => {
+    it('reads a digits-only retry hint', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('retry: 2500\ndata: a\n\n')).toEqual([{ data: 'a', retry: 2500 }])
+    })
+
+    it('ignores a non-numeric retry hint', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('retry: 2.5s\ndata: a\n\n')).toEqual([{ data: 'a' }])
+    })
+
+    it('stamps a retry-only frame onto the next dispatched frame', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('retry: 1000\n\n')).toEqual([])
+      expect(framer.push('data: a\n\n')).toEqual([{ data: 'a', retry: 1000 }])
+      // Connection-scoped, but reported once: the core clamps and remembers it.
+      expect(framer.push('data: b\n\n')).toEqual([{ data: 'b' }])
+    })
+  })
+
+  it('discards an unterminated trailing frame, as the spec requires', () => {
+    const framer = new SseFramer()
+
+    expect(framer.push('data: never dispatched\n')).toEqual([])
+    expect(framer.lastEventId).toBeUndefined()
+  })
+})

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
@@ -151,6 +151,37 @@ describe('SseFramer', () => {
     })
   })
 
+  describe('carrying stream state across a reconnect', () => {
+    it('reports the cursor the connection resumed from on an id-less frame', () => {
+      const framer = new SseFramer({ lastEventId: 'e-7' })
+
+      expect(framer.push('data: 1\n\n')).toEqual([{ data: '1', lastEventId: 'e-7' }])
+    })
+
+    it('stamps an inherited retry hint onto the first frame that dispatches', () => {
+      const framer = new SseFramer({ retry: 4000 })
+
+      expect(framer.push('data: 1\n\n')).toEqual([{ data: '1', retry: 4000 }])
+      // Connection-scoped, not per-frame: it is spent once it has been reported.
+      expect(framer.push('data: 2\n\n')).toEqual([{ data: '2' }])
+      expect(framer.pendingRetry).toBeUndefined()
+    })
+
+    it('holds a retry hint no frame ever carried, so the caller can inherit it', () => {
+      const framer = new SseFramer()
+
+      expect(framer.push('retry: 9000\n\n')).toEqual([])
+      expect(framer.pendingRetry).toBe(9000)
+    })
+
+    it('holds the cursor a data-less id frame left it at', () => {
+      const framer = new SseFramer({ lastEventId: 'e-1' })
+
+      expect(framer.push('data: 1\n\nid: e-2\n\n')).toEqual([{ data: '1', lastEventId: 'e-1' }])
+      expect(framer.lastEventId).toBe('e-2')
+    })
+  })
+
   it('discards an unterminated trailing frame, as the spec requires', () => {
     const framer = new SseFramer()
 

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.spec.ts
@@ -119,12 +119,32 @@ describe('SseFramer', () => {
       expect(framer.lastEventId).toBe('')
     })
 
+    it('holds the cursor at an id whose frame the stream cut short', () => {
+      const framer = new SseFramer()
+
+      framer.push('id: 7\ndata: a\n\n')
+      // The connection died before the terminator, so the event this `id:`
+      // belongs to was never delivered — resuming past it would skip it.
+      expect(framer.push('id: 8\ndata: b')).toEqual([])
+      expect(framer.lastEventId).toBe('7')
+    })
+
     it('ignores an id containing NUL rather than truncating it', () => {
       const framer = new SseFramer()
 
       framer.push('id: 9\ndata: a\n\n')
       expect(framer.push('id: 1\u000023\ndata: b\n\n')).toEqual([{ data: 'b', lastEventId: '9' }])
       expect(framer.lastEventId).toBe('9')
+    })
+  })
+
+  describe('event names', () => {
+    it('reads an empty event name as no name, leaving the core its "message" default', () => {
+      const framer = new SseFramer()
+
+      // The spec only overrides the `message` type when the event-type buffer
+      // is non-empty, so `event:` with no value is not a name of its own.
+      expect(framer.push('event:\ndata: 1\n\n')).toEqual([{ data: '1' }])
     })
   })
 

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.ts
@@ -4,6 +4,21 @@ const NULL_CHARACTER = '\u0000'
 const DIGITS_ONLY = /^\d+$/
 
 /**
+ * What a framer starts a connection with.
+ *
+ * A reconnect continues one logical stream, and both fields are stream-scoped
+ * rather than connection-scoped: seeding them is what lets `streamMode:
+ * 'events'` carry an `id:` or `retry:` that the previous connection received
+ * but never got to report — see `createFallbackTransport`'s stream carry.
+ */
+export type SseFramerOptions = {
+  /** Last-Event-ID the connection resumed from. */
+  lastEventId?: string
+  /** A `retry:` hint the previous connection never stamped onto a frame. */
+  retry?: number
+}
+
+/**
  * Incremental Server-Sent Events framer.
  *
  * Exists because the two things this package needs from a stream are not
@@ -35,12 +50,26 @@ export class SseFramer {
    * only `retry:` dispatches nothing — so the hint is held and stamped onto the
    * next frame that does dispatch.
    */
-  private pendingRetry: number | undefined
+  private retryHint: number | undefined
   private cursor: string | undefined
+
+  constructor(options: SseFramerOptions = {}) {
+    this.cursor = options.lastEventId
+    this.retryHint = options.retry
+  }
 
   /** The Last-Event-ID cursor as of the last processed frame. */
   get lastEventId(): string | undefined {
     return this.cursor
+  }
+
+  /**
+   * A `retry:` hint no dispatched frame has carried yet. Non-`undefined` at the
+   * end of a connection means the hint would be lost unless it is carried into
+   * the next one.
+   */
+  get pendingRetry(): number | undefined {
+    return this.retryHint
   }
 
   /**
@@ -100,7 +129,7 @@ export class SseFramer {
         this.cursor = value
       }
     } else if (field === 'retry' && DIGITS_ONLY.test(value)) {
-      this.pendingRetry = Number(value)
+      this.retryHint = Number(value)
     }
     // Any other field name is ignored, as the spec requires.
     return undefined
@@ -116,8 +145,8 @@ export class SseFramer {
 
     if (dataLines.length === 0) return undefined
 
-    const retry = this.pendingRetry
-    this.pendingRetry = undefined
+    const retry = this.retryHint
+    this.retryHint = undefined
 
     return {
       data: dataLines.join('\n'),

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.ts
@@ -36,8 +36,9 @@ export type SseFramerOptions = {
  * line (a trailing CR is held back across chunk boundaries so CRLF is never
  * split into two terminators), exactly one leading space is stripped after the
  * colon, a line with no colon is a field with an empty value, a line starting
- * with a colon is a comment, `retry:` takes ASCII digits only, and an `id:`
- * containing NUL is ignored.
+ * with a colon is a comment, `retry:` takes ASCII digits only, an `id:`
+ * containing NUL is ignored, an empty `event:` leaves the event type at
+ * `message`, and the reconnect cursor moves only when a frame is dispatched.
  */
 export class SseFramer {
   /** Unterminated tail of the last chunk, including a held-back trailing CR. */
@@ -51,10 +52,25 @@ export class SseFramer {
    * next frame that does dispatch.
    */
   private retryHint: number | undefined
+  /**
+   * The spec's *last event ID buffer*: whatever the most recent `id:` line
+   * carried. Unlike the data and event-type buffers it is never reset between
+   * frames, which is what makes the cursor sticky.
+   */
+  private idBuffer: string | undefined
+  /**
+   * The spec's *last event ID string* — the buffer's value as of the last
+   * dispatch, which is the only place it moves.
+   *
+   * An `id:` in a frame the connection cut short before its terminator must
+   * not advance it: the event that frame was carrying was never delivered, and
+   * resuming a reconnect past it would skip it for good.
+   */
   private cursor: string | undefined
 
   constructor(options: SseFramerOptions = {}) {
     this.cursor = options.lastEventId
+    this.idBuffer = options.lastEventId
     this.retryHint = options.retry
   }
 
@@ -126,7 +142,7 @@ export class SseFramer {
       // truncated — a truncated cursor would replay from the wrong point.
       if (!value.includes(NULL_CHARACTER)) {
         this.frameId = value
-        this.cursor = value
+        this.idBuffer = value
       }
     } else if (field === 'retry' && DIGITS_ONLY.test(value)) {
       this.retryHint = Number(value)
@@ -136,6 +152,9 @@ export class SseFramer {
   }
 
   private dispatch(): FallbackParsedSseFrame | undefined {
+    // The spec's first dispatch step, and it runs even for a frame that goes
+    // on to dispatch nothing: an `id:`-only frame still moves the cursor.
+    this.cursor = this.idBuffer
     const eventName = this.eventName
     const frameId = this.frameId
     const dataLines = this.dataLines
@@ -150,7 +169,10 @@ export class SseFramer {
 
     return {
       data: dataLines.join('\n'),
-      ...(eventName !== undefined && { event: eventName }),
+      // An empty `event:` leaves the event-type buffer empty, which the spec
+      // reads as `message`. Reporting `''` as a name of its own would send the
+      // frame looking for a schema by that name and count it as undeclared.
+      ...(eventName !== undefined && eventName !== '' && { event: eventName }),
       ...(frameId !== undefined && { id: frameId }),
       ...(retry !== undefined && { retry }),
       ...(this.cursor !== undefined && { lastEventId: this.cursor }),

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.ts
@@ -6,16 +6,14 @@ const DIGITS_ONLY = /^\d+$/
 /**
  * What a framer starts a connection with.
  *
- * A reconnect continues one logical stream, and both fields are stream-scoped
- * rather than connection-scoped: seeding them is what lets `streamMode:
- * 'events'` carry an `id:` or `retry:` that the previous connection received
- * but never got to report — see `createFallbackTransport`'s stream carry.
+ * The Last-Event-ID cursor is stream-scoped rather than connection-scoped, so
+ * a reconnect starts where the previous connection left the core rather than
+ * from nothing — which is what lets an id-less frame report the cursor it
+ * inherited instead of none at all.
  */
 export type SseFramerOptions = {
   /** Last-Event-ID the connection resumed from. */
   lastEventId?: string
-  /** A `retry:` hint the previous connection never stamped onto a frame. */
-  retry?: number
 }
 
 /**
@@ -71,21 +69,11 @@ export class SseFramer {
   constructor(options: SseFramerOptions = {}) {
     this.cursor = options.lastEventId
     this.idBuffer = options.lastEventId
-    this.retryHint = options.retry
   }
 
   /** The Last-Event-ID cursor as of the last processed frame. */
   get lastEventId(): string | undefined {
     return this.cursor
-  }
-
-  /**
-   * A `retry:` hint no dispatched frame has carried yet. Non-`undefined` at the
-   * end of a connection means the hint would be lost unless it is carried into
-   * the next one.
-   */
-  get pendingRetry(): number | undefined {
-    return this.retryHint
   }
 
   /**

--- a/packages/app/frontend-http-client/src/sse-fallback/framer.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/framer.ts
@@ -1,0 +1,130 @@
+import type { FallbackParsedSseFrame } from './types.ts'
+
+const NULL_CHARACTER = '\u0000'
+const DIGITS_ONLY = /^\d+$/
+
+/**
+ * Incremental Server-Sent Events framer.
+ *
+ * Exists because the two things this package needs from a stream are not
+ * available from a framer that models the browser's `EventSource`:
+ *
+ * - the **per-frame `id:`**, kept apart from the sticky Last-Event-ID cursor.
+ *   The fallback core's default version extractor reads the frame's own id, so
+ *   a framer that only reports the cursor would make every id-less frame look
+ *   like a repeat of the previous version and the version gate would drop it.
+ * - **frame-level inspection without consuming the stream**, so raw chunks can
+ *   be passed through to the core untouched while their payloads are validated
+ *   against the contract on the side.
+ *
+ * Framing follows the WHATWG event-stream rules: CR, LF and CRLF all end a
+ * line (a trailing CR is held back across chunk boundaries so CRLF is never
+ * split into two terminators), exactly one leading space is stripped after the
+ * colon, a line with no colon is a field with an empty value, a line starting
+ * with a colon is a comment, `retry:` takes ASCII digits only, and an `id:`
+ * containing NUL is ignored.
+ */
+export class SseFramer {
+  /** Unterminated tail of the last chunk, including a held-back trailing CR. */
+  private buffer = ''
+  private dataLines: string[] = []
+  private eventName: string | undefined
+  private frameId: string | undefined
+  /**
+   * `retry:` is connection-scoped rather than per-frame, and a frame carrying
+   * only `retry:` dispatches nothing — so the hint is held and stamped onto the
+   * next frame that does dispatch.
+   */
+  private pendingRetry: number | undefined
+  private cursor: string | undefined
+
+  /** The Last-Event-ID cursor as of the last processed frame. */
+  get lastEventId(): string | undefined {
+    return this.cursor
+  }
+
+  /**
+   * Feed decoded text and collect whatever frames it completed.
+   *
+   * A frame that carried no `data:` field dispatches nothing (an `id:`-only or
+   * `retry:`-only frame updates the cursor / retry hint instead), and neither
+   * do comment frames, matching what a consumer of parsed events can observe.
+   */
+  push(chunk: string): FallbackParsedSseFrame[] {
+    const frames: FallbackParsedSseFrame[] = []
+    this.buffer += chunk
+
+    let lineStart = 0
+    let index = 0
+    while (index < this.buffer.length) {
+      const character = this.buffer[index]
+      if (character !== '\n' && character !== '\r') {
+        index += 1
+        continue
+      }
+      // A CR at the very end of the buffer may be the first half of a CRLF
+      // that lands in the next chunk; leave it for then.
+      if (character === '\r' && index === this.buffer.length - 1) break
+
+      const line = this.buffer.slice(lineStart, index)
+      index += character === '\r' && this.buffer[index + 1] === '\n' ? 2 : 1
+      lineStart = index
+
+      const frame = this.handleLine(line)
+      if (frame) frames.push(frame)
+    }
+
+    this.buffer = this.buffer.slice(lineStart)
+    return frames
+  }
+
+  private handleLine(line: string): FallbackParsedSseFrame | undefined {
+    if (line === '') return this.dispatch()
+    // A comment frame (`: heartbeat`) carries no fields.
+    if (line.startsWith(':')) return undefined
+
+    const colonIndex = line.indexOf(':')
+    const field = colonIndex === -1 ? line : line.slice(0, colonIndex)
+    const rawValue = colonIndex === -1 ? '' : line.slice(colonIndex + 1)
+    const value = rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue
+
+    if (field === 'event') {
+      this.eventName = value
+    } else if (field === 'data') {
+      this.dataLines.push(value)
+    } else if (field === 'id') {
+      // Per spec an id containing NUL is ignored outright, rather than
+      // truncated — a truncated cursor would replay from the wrong point.
+      if (!value.includes(NULL_CHARACTER)) {
+        this.frameId = value
+        this.cursor = value
+      }
+    } else if (field === 'retry' && DIGITS_ONLY.test(value)) {
+      this.pendingRetry = Number(value)
+    }
+    // Any other field name is ignored, as the spec requires.
+    return undefined
+  }
+
+  private dispatch(): FallbackParsedSseFrame | undefined {
+    const eventName = this.eventName
+    const frameId = this.frameId
+    const dataLines = this.dataLines
+    this.eventName = undefined
+    this.frameId = undefined
+    this.dataLines = []
+
+    if (dataLines.length === 0) return undefined
+
+    const retry = this.pendingRetry
+    this.pendingRetry = undefined
+
+    return {
+      data: dataLines.join('\n'),
+      ...(eventName !== undefined && { event: eventName }),
+      ...(frameId !== undefined && { id: frameId }),
+      ...(retry !== undefined && { retry }),
+      ...(this.cursor !== undefined && { lastEventId: this.cursor }),
+    }
+  }
+}

--- a/packages/app/frontend-http-client/src/sse-fallback/index.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/index.ts
@@ -15,7 +15,7 @@ export {
   FallbackUnexpectedSnapshotError,
   FallbackUnsupportedParamError,
 } from './errors.ts'
-export { SseFramer } from './framer.ts'
+export { SseFramer, type SseFramerOptions } from './framer.ts'
 export { buildFallbackParams, type FallbackContractParams } from './params.ts'
 export type {
   FallbackChannel,

--- a/packages/app/frontend-http-client/src/sse-fallback/index.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/index.ts
@@ -1,0 +1,32 @@
+export {
+  type CreateFallbackTransportOptions,
+  createFallbackTransport,
+  type FallbackEventValidationMode,
+  type FallbackStreamMode,
+  type FallbackTransportDiagnostics,
+} from './createFallbackTransport.ts'
+export {
+  type FallbackErrorContext,
+  FallbackEventValidationError,
+  type FallbackParamsPart,
+  FallbackParamsValidationError,
+  FallbackSnapshotValidationError,
+  FallbackTransportError,
+  FallbackUnexpectedSnapshotError,
+  FallbackUnsupportedParamError,
+} from './errors.ts'
+export { SseFramer } from './framer.ts'
+export { buildFallbackParams, type FallbackContractParams } from './params.ts'
+export type {
+  FallbackChannel,
+  FallbackEventsOf,
+  FallbackParsedSseFrame,
+  FallbackParsedStreamResponse,
+  FallbackRawStreamResponse,
+  FallbackRequestParams,
+  FallbackSnapshotOf,
+  FallbackSnapshotResponse,
+  FallbackStreamResponse,
+  FallbackTransport,
+  FallbackTransportRequest,
+} from './types.ts'

--- a/packages/app/frontend-http-client/src/sse-fallback/params.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/params.spec.ts
@@ -1,0 +1,171 @@
+import { ContractNoBody, defineApiContract, sseResponse } from '@lokalise/api-contracts'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod/v4'
+import { FallbackParamsValidationError, FallbackUnsupportedParamError } from './errors.ts'
+import { buildFallbackParams } from './params.ts'
+
+const snapshotSchema = z.object({ version: z.number(), status: z.string() })
+
+const uploadStatusContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload status',
+  method: 'get',
+  pathResolver: (params: { uploadId: string }) => `/uploads/${params.uploadId}/status`,
+  requestPathParamsSchema: z.object({ uploadId: z.string() }),
+  requestQuerySchema: z.object({
+    verbose: z.coerce.boolean().default(false),
+    limit: z.number().optional(),
+  }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': snapshotSchema,
+        ...sseResponse({ uploadFinished: z.object({ version: z.number() }) }).content,
+      },
+    },
+  },
+})
+
+const startImportContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Start import',
+  method: 'post',
+  pathResolver: () => '/imports',
+  requestBodySchema: z.object({ fileId: z.string() }),
+  requestHeaderSchema: z.object({ 'x-tenant': z.string() }),
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+const bodylessContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Trigger reindex',
+  method: 'post',
+  requestBodySchema: ContractNoBody,
+  pathResolver: () => '/reindex',
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+const filterContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Filter items',
+  method: 'get',
+  pathResolver: () => '/items',
+  requestQuerySchema: z.object({ filter: z.object({ status: z.string() }).optional() }),
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+const listContract = defineApiContract({
+  visibility: 'public',
+  summary: 'List items',
+  method: 'get',
+  pathResolver: () => '/items',
+  requestQuerySchema: z.object({ tag: z.array(z.string()).optional() }),
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+describe('buildFallbackParams', () => {
+  it('returns the params the binding needs, with Zod defaults applied', () => {
+    const params = buildFallbackParams(uploadStatusContract, {
+      pathParams: { uploadId: 'u-1' },
+      queryParams: { limit: 5 },
+    })
+
+    expect(params).toEqual({
+      pathParams: { uploadId: 'u-1' },
+      queryParams: { verbose: false, limit: 5 },
+    })
+  })
+
+  it('omits query values that resolve to nothing', () => {
+    const params = buildFallbackParams(uploadStatusContract, {
+      pathParams: { uploadId: 'u-1' },
+      queryParams: { limit: undefined },
+    })
+
+    expect(params.queryParams).toEqual({ verbose: false })
+  })
+
+  it('passes a static header map and a request body through', () => {
+    const params = buildFallbackParams(startImportContract, {
+      body: { fileId: 'f-1' },
+      headers: { 'x-tenant': 'acme' },
+    })
+
+    expect(params).toEqual({ body: { fileId: 'f-1' }, headers: { 'x-tenant': 'acme' } })
+  })
+
+  it('accepts a contract that declares no request schemas at all', () => {
+    expect(buildFallbackParams(bodylessContract, {})).toEqual({})
+  })
+
+  describe('validation', () => {
+    it('rejects invalid path params', () => {
+      expect(() =>
+        buildFallbackParams(uploadStatusContract, {
+          // @ts-expect-error — the contract types uploadId as a string
+          pathParams: { uploadId: 42 },
+        }),
+      ).toThrowError(FallbackParamsValidationError)
+    })
+
+    it('rejects invalid query params, naming the contract', () => {
+      let caught: unknown
+      try {
+        buildFallbackParams(uploadStatusContract, {
+          pathParams: { uploadId: 'u-1' },
+          // @ts-expect-error — the contract types limit as a number
+          queryParams: { limit: 'many' },
+        })
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(FallbackParamsValidationError)
+      const error = caught as FallbackParamsValidationError
+      expect(error.part).toBe('queryParams')
+      expect(error.summary).toBe('Upload status')
+      expect(error.issues).toHaveLength(1)
+      expect(error.message).toContain('Invalid queryParams for subscription to "Upload status"')
+    })
+
+    it('rejects an invalid request body', () => {
+      expect(() =>
+        buildFallbackParams(startImportContract, {
+          // @ts-expect-error — the contract requires fileId
+          body: {},
+          headers: { 'x-tenant': 'acme' },
+        }),
+      ).toThrowError(FallbackParamsValidationError)
+    })
+
+    it('rejects a repeated query parameter, which the request shape cannot carry', () => {
+      let caught: unknown
+      try {
+        buildFallbackParams(listContract, { queryParams: { tag: ['a', 'b'] } })
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toBeInstanceOf(FallbackUnsupportedParamError)
+      const error = caught as FallbackUnsupportedParamError
+      expect(error.param).toBe('tag')
+      expect(error.message).toContain(
+        'is a list, which a fallback subscription request cannot carry',
+      )
+    })
+
+    it('rejects a structured query parameter', () => {
+      expect(() =>
+        buildFallbackParams(filterContract, { queryParams: { filter: { status: 'pending' } } }),
+      ).toThrowError(/is structured, which a fallback subscription request cannot carry/)
+    })
+  })
+
+  describe('types', () => {
+    it('requires the params the contract declares', () => {
+      expectTypeOf(buildFallbackParams<typeof startImportContract>)
+        .parameter(1)
+        .toExtend<{ body: { fileId: string }; headers: { 'x-tenant': string } }>()
+    })
+  })
+})

--- a/packages/app/frontend-http-client/src/sse-fallback/params.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/params.spec.ts
@@ -63,6 +63,41 @@ const listContract = defineApiContract({
   responsesByStatusCode: { 200: snapshotSchema },
 })
 
+const sinceContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Changes since',
+  method: 'get',
+  pathResolver: () => '/changes',
+  requestQuerySchema: z.object({
+    since: z.coerce.date().optional(),
+    page: z.coerce.number().default(1),
+  }),
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+const defaultedDateContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Changes since epoch',
+  method: 'get',
+  pathResolver: () => '/changes',
+  requestQuerySchema: z.object({
+    since: z.coerce.date().default(() => new Date('2020-01-01T00:00:00.000Z')),
+  }),
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
+const tenantContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Tenant status',
+  method: 'get',
+  pathResolver: () => '/status',
+  requestHeaderSchema: z.object({
+    authorization: z.string(),
+    'x-tenant': z.string().min(2),
+  }),
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
 describe('buildFallbackParams', () => {
   it('returns the params the binding needs, with Zod defaults applied', () => {
     const params = buildFallbackParams(uploadStatusContract, {
@@ -96,6 +131,31 @@ describe('buildFallbackParams', () => {
 
   it('accepts a contract that declares no request schemas at all', () => {
     expect(buildFallbackParams(bodylessContract, {})).toEqual({})
+  })
+
+  describe('query values a flat string map has to carry', () => {
+    it('sends what the caller supplied when the schema parses it into a Date', () => {
+      const params = buildFallbackParams(sinceContract, {
+        queryParams: { since: '2024-05-01T00:00:00.000Z' },
+      })
+
+      // The contract accepts the string, so there is no scalar the caller
+      // could have passed instead — and it is what `sendByApiContract` would
+      // have put on the query string for the same contract.
+      expect(params.queryParams).toEqual({ since: '2024-05-01T00:00:00.000Z', page: 1 })
+    })
+
+    it('serializes a Date the caller never supplied, so a default still reaches the wire', () => {
+      const params = buildFallbackParams(defaultedDateContract, { queryParams: {} })
+
+      expect(params.queryParams).toEqual({ since: '2020-01-01T00:00:00.000Z' })
+    })
+
+    it('keeps a coercion whose output is already a scalar', () => {
+      const params = buildFallbackParams(sinceContract, { queryParams: { page: '3' } })
+
+      expect(params.queryParams).toEqual({ page: 3 })
+    })
   })
 
   describe('validation', () => {
@@ -159,13 +219,58 @@ describe('buildFallbackParams', () => {
         buildFallbackParams(filterContract, { queryParams: { filter: { status: 'pending' } } }),
       ).toThrowError(/is structured, which a fallback subscription request cannot carry/)
     })
+
+    describe('headers', () => {
+      it('rejects a supplied header the contract schema refuses', () => {
+        let caught: unknown
+        try {
+          buildFallbackParams(tenantContract, {
+            headers: { authorization: 'Bearer t', 'x-tenant': 'a' },
+          })
+        } catch (error) {
+          caught = error
+        }
+
+        expect(caught).toBeInstanceOf(FallbackParamsValidationError)
+        expect((caught as FallbackParamsValidationError).part).toBe('headers')
+        expect((caught as FallbackParamsValidationError).message).toContain(
+          'Invalid headers for subscription to "Tenant status"',
+        )
+      })
+
+      it('does not demand a header the transport supplies fresh per request', () => {
+        // `authorization` belongs on the transport's own `headers` option,
+        // which is what lets `onAuthChallenge` recover an expired token —
+        // demanding it here would reject the setup this module recommends.
+        expect(buildFallbackParams(tenantContract, { headers: { 'x-tenant': 'acme' } })).toEqual({
+          headers: { 'x-tenant': 'acme' },
+        })
+      })
+
+      it('passes a header the contract does not declare through untouched', () => {
+        const params = buildFallbackParams(tenantContract, {
+          // @ts-expect-error — the contract declares no x-trace header
+          headers: { 'x-tenant': 'acme', 'x-trace': 'abc' },
+        })
+
+        expect(params.headers).toEqual({ 'x-tenant': 'acme', 'x-trace': 'abc' })
+      })
+    })
   })
 
   describe('types', () => {
     it('requires the params the contract declares', () => {
       expectTypeOf(buildFallbackParams<typeof startImportContract>)
         .parameter(1)
-        .toExtend<{ body: { fileId: string }; headers: { 'x-tenant': string } }>()
+        .toExtend<{ body: { fileId: string } }>()
+    })
+
+    it('lets the transport layer supply part of the declared headers', () => {
+      // Not `{ headers: { authorization, 'x-tenant' } }`: a request's headers
+      // come from two layers, and the rotating one belongs on the transport.
+      expectTypeOf(buildFallbackParams<typeof tenantContract>)
+        .parameter(1)
+        .toExtend<{ headers?: { authorization?: string; 'x-tenant'?: string } }>()
     })
   })
 })

--- a/packages/app/frontend-http-client/src/sse-fallback/params.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/params.ts
@@ -1,6 +1,10 @@
 import type { ApiContract, InferSchemaInput } from '@lokalise/api-contracts'
-import type { z } from 'zod/v4'
-import { FallbackParamsValidationError, FallbackUnsupportedParamError } from './errors.ts'
+import { z } from 'zod/v4'
+import {
+  type FallbackParamsPart,
+  FallbackParamsValidationError,
+  FallbackUnsupportedParamError,
+} from './errors.ts'
 import type { FallbackRequestParams } from './types.ts'
 
 type Prettify<T> = { [K in keyof T]: T[K] } & {}
@@ -8,6 +12,21 @@ type Prettify<T> = { [K in keyof T]: T[K] } & {}
 type RequiredWhenDefined<T, TKey extends string> = [T] extends [undefined]
   ? { [K in TKey]?: undefined }
   : { [K in TKey]: T }
+
+/**
+ * Like {@link RequiredWhenDefined}, but for the one part a subscription may
+ * legitimately supply only in part.
+ *
+ * A request's headers come from two layers: these, captured once, and the
+ * transport's own `headers` option, resolved fresh for every poll and every
+ * reconnect. `requestHeaderSchema` describes the request, not this layer's
+ * contribution to it, so demanding all of it here would force a rotating
+ * credential into the layer that cannot refresh it. What *is* supplied is
+ * still checked against the contract.
+ */
+type PartialWhenDefined<T, TKey extends string> = [T] extends [undefined]
+  ? { [K in TKey]?: undefined }
+  : { [K in TKey]?: Partial<T> }
 
 type ExtractRequestBody<T> = T extends { requestBodySchema: z.ZodType }
   ? T['requestBodySchema']
@@ -22,13 +41,13 @@ export type FallbackContractParams<TContract extends ApiContract> = Prettify<
   RequiredWhenDefined<InferSchemaInput<TContract['requestPathParamsSchema']>, 'pathParams'> &
     RequiredWhenDefined<InferSchemaInput<ExtractRequestBody<TContract>>, 'body'> &
     RequiredWhenDefined<InferSchemaInput<TContract['requestQuerySchema']>, 'queryParams'> &
-    RequiredWhenDefined<InferSchemaInput<TContract['requestHeaderSchema']>, 'headers'>
+    PartialWhenDefined<InferSchemaInput<TContract['requestHeaderSchema']>, 'headers'>
 >
 
 function validate(
   schema: z.ZodType | undefined,
   value: unknown,
-  part: 'pathParams' | 'queryParams' | 'body',
+  part: FallbackParamsPart,
   contract: ApiContract,
 ): unknown {
   if (!schema || value === undefined) return value
@@ -43,6 +62,32 @@ function validate(
   return result.data
 }
 
+type QueryScalar = string | number | boolean
+
+const isQueryScalar = (value: unknown): value is QueryScalar =>
+  typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+
+/**
+ * Render one query value as something a flat string map can carry.
+ *
+ * The parsed *output* comes first, so Zod defaults and normalizing transforms
+ * apply. But a query schema is free to parse a query string into a value the
+ * wire has no room for — `z.coerce.date()` yields a `Date` — and there is no
+ * scalar a caller could pass to satisfy such a schema, so rejecting it would
+ * make a contract `sendByApiContract` accepts unusable here. Falling back to
+ * what the caller supplied is therefore not a workaround: it is exactly the
+ * value `sendByApiContract` puts on the query string for the same contract,
+ * which is what keeps the two request paths agreeing on the wire.
+ */
+function renderQueryValue(output: unknown, supplied: unknown): QueryScalar | undefined {
+  if (isQueryScalar(output)) return output
+  if (isQueryScalar(supplied)) return supplied
+  // A value the caller never supplied (a Zod default) still has to reach the
+  // wire, and a date has one obvious rendering.
+  if (output instanceof Date) return output.toISOString()
+  return undefined
+}
+
 /**
  * A fallback binding's request shape carries query parameters as
  * `Record<string, string>`, so a repeated key (`?tag=a&tag=b`) has nowhere to
@@ -50,14 +95,16 @@ function validate(
  * server would read as one tag named `a,b`.
  */
 function flattenQueryParams(
-  queryParams: Record<string, unknown>,
+  parsed: Record<string, unknown>,
+  supplied: Record<string, unknown>,
   contract: ApiContract,
-): Record<string, string | number | boolean> {
-  const flattened: Record<string, string | number | boolean> = {}
-  for (const [key, value] of Object.entries(queryParams)) {
+): Record<string, QueryScalar> {
+  const flattened: Record<string, QueryScalar> = {}
+  for (const [key, value] of Object.entries(parsed)) {
     if (value === undefined || value === null) continue
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      flattened[key] = value
+    const rendered = renderQueryValue(value, supplied[key])
+    if (rendered !== undefined) {
+      flattened[key] = rendered
       continue
     }
     throw new FallbackUnsupportedParamError(
@@ -72,6 +119,20 @@ function flattenQueryParams(
 }
 
 /**
+ * The schema the headers supplied here are checked against.
+ *
+ * Every key is made optional first. A contract may declare an `authorization`
+ * header that the transport's own `headers` option supplies fresh per request
+ * — which is where a rotating credential belongs, and what this function's
+ * docs send callers to — so demanding it at subscription-creation time would
+ * reject the very setup it recommends. What *is* supplied still gets checked,
+ * which is the point.
+ */
+function suppliedHeadersSchema(schema: z.ZodType | undefined): z.ZodType | undefined {
+  return schema instanceof z.ZodObject ? schema.partial() : schema
+}
+
+/**
  * Build the params a fallback subscription is created with, typed and
  * validated against the contract.
  *
@@ -80,12 +141,17 @@ function flattenQueryParams(
  * 404/400 that the subscription then retries on a backoff — a slow, confusing
  * failure. This validates against the contract's own schemas up front and
  * throws immediately instead, and returns the parsed output so Zod defaults
- * and coercions apply exactly as they do for `sendByApiContract`.
+ * apply. Where a parsed value has no place on the wire — a query schema that
+ * coerces a string into a `Date` — the value you supplied is sent, which is
+ * what `sendByApiContract` would have put on the query string too.
  *
  * Header values that change over time (a bearer token) do NOT belong here:
  * params are captured once when the subscription is created, whereas the
  * transport's own `headers` option is resolved fresh for every poll and every
  * reconnect. That is what lets `onAuthChallenge` recover an expired token.
+ * Headers supplied here are checked against `requestHeaderSchema`, but only
+ * the ones supplied — a header the contract requires and the transport layer
+ * provides is not demanded twice.
  *
  * @example
  * ```typescript
@@ -112,12 +178,23 @@ export function buildFallbackParams<TContract extends ApiContract>(
     'pathParams',
     contract,
   ) as Record<string, string | number> | undefined
-  const queryParams = validate(
-    contract.requestQuerySchema,
-    source.queryParams,
-    'queryParams',
-    contract,
-  ) as Record<string, unknown> | undefined
+  const queryParams =
+    source.queryParams === undefined
+      ? undefined
+      : flattenQueryParams(
+          validate(
+            contract.requestQuerySchema,
+            source.queryParams,
+            'queryParams',
+            contract,
+          ) as Record<string, unknown>,
+          source.queryParams,
+          contract,
+        )
+  // Checked, but not replaced by the parse output: header values are strings on
+  // the wire either way, and swapping in Zod's object would let its unknown-key
+  // pruning silently drop a header the contract does not declare.
+  validate(suppliedHeadersSchema(contract.requestHeaderSchema), source.headers, 'headers', contract)
   const body = validate(
     typeof contract.requestBodySchema === 'object' ? contract.requestBodySchema : undefined,
     source.body,
@@ -127,7 +204,7 @@ export function buildFallbackParams<TContract extends ApiContract>(
 
   return {
     ...(pathParams !== undefined && { pathParams }),
-    ...(queryParams !== undefined && { queryParams: flattenQueryParams(queryParams, contract) }),
+    ...(queryParams !== undefined && { queryParams }),
     ...(source.headers !== undefined && { headers: source.headers }),
     ...(body !== undefined && { body }),
   }

--- a/packages/app/frontend-http-client/src/sse-fallback/params.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/params.ts
@@ -1,0 +1,134 @@
+import type { ApiContract, InferSchemaInput } from '@lokalise/api-contracts'
+import type { z } from 'zod/v4'
+import { FallbackParamsValidationError, FallbackUnsupportedParamError } from './errors.ts'
+import type { FallbackRequestParams } from './types.ts'
+
+type Prettify<T> = { [K in keyof T]: T[K] } & {}
+
+type RequiredWhenDefined<T, TKey extends string> = [T] extends [undefined]
+  ? { [K in TKey]?: undefined }
+  : { [K in TKey]: T }
+
+type ExtractRequestBody<T> = T extends { requestBodySchema: z.ZodType }
+  ? T['requestBodySchema']
+  : undefined
+
+/**
+ * Subscription params typed from a contract: the same inference
+ * `sendByApiContract` applies to a one-shot request, applied to the params a
+ * fallback subscription is created with.
+ */
+export type FallbackContractParams<TContract extends ApiContract> = Prettify<
+  RequiredWhenDefined<InferSchemaInput<TContract['requestPathParamsSchema']>, 'pathParams'> &
+    RequiredWhenDefined<InferSchemaInput<ExtractRequestBody<TContract>>, 'body'> &
+    RequiredWhenDefined<InferSchemaInput<TContract['requestQuerySchema']>, 'queryParams'> &
+    RequiredWhenDefined<InferSchemaInput<TContract['requestHeaderSchema']>, 'headers'>
+>
+
+function validate(
+  schema: z.ZodType | undefined,
+  value: unknown,
+  part: 'pathParams' | 'queryParams' | 'body',
+  contract: ApiContract,
+): unknown {
+  if (!schema || value === undefined) return value
+
+  const result = schema.safeParse(value)
+  if (!result.success) {
+    throw new FallbackParamsValidationError(
+      `Invalid ${part} for subscription to "${contract.summary}": ${result.error.message}`,
+      { part, summary: contract.summary, issues: result.error.issues },
+    )
+  }
+  return result.data
+}
+
+/**
+ * A fallback binding's request shape carries query parameters as
+ * `Record<string, string>`, so a repeated key (`?tag=a&tag=b`) has nowhere to
+ * live. Rejecting the value beats silently sending `tag=a%2Cb`, which the
+ * server would read as one tag named `a,b`.
+ */
+function flattenQueryParams(
+  queryParams: Record<string, unknown>,
+  contract: ApiContract,
+): Record<string, string | number | boolean> {
+  const flattened: Record<string, string | number | boolean> = {}
+  for (const [key, value] of Object.entries(queryParams)) {
+    if (value === undefined || value === null) continue
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      flattened[key] = value
+      continue
+    }
+    throw new FallbackUnsupportedParamError(
+      `Query parameter "${key}" of "${contract.summary}" is ${
+        Array.isArray(value) ? 'a list' : 'structured'
+      }, which a fallback subscription request cannot carry: its query is a flat string map. ` +
+        'Pass a scalar (join the values yourself if the endpoint expects one string), or move the value into the path.',
+      { part: 'queryParams', summary: contract.summary, param: key },
+    )
+  }
+  return flattened
+}
+
+/**
+ * Build the params a fallback subscription is created with, typed and
+ * validated against the contract.
+ *
+ * `createResilientSubscription` takes `params` as an untyped string map, so a
+ * misspelled path param or a query value of the wrong type surfaces as a
+ * 404/400 that the subscription then retries on a backoff — a slow, confusing
+ * failure. This validates against the contract's own schemas up front and
+ * throws immediately instead, and returns the parsed output so Zod defaults
+ * and coercions apply exactly as they do for `sendByApiContract`.
+ *
+ * Header values that change over time (a bearer token) do NOT belong here:
+ * params are captured once when the subscription is created, whereas the
+ * transport's own `headers` option is resolved fresh for every poll and every
+ * reconnect. That is what lets `onAuthChallenge` recover an expired token.
+ *
+ * @example
+ * ```typescript
+ * const subscription = createResilientSubscription(uploadStatusBinding, {
+ *   transport: createFallbackTransport(client, { contract: uploadStatusContract }),
+ *   params: buildFallbackParams(uploadStatusContract, { pathParams: { uploadId } }),
+ * })
+ * ```
+ */
+export function buildFallbackParams<TContract extends ApiContract>(
+  contract: TContract,
+  params: FallbackContractParams<TContract>,
+): FallbackRequestParams {
+  const source = params as {
+    pathParams?: Record<string, unknown>
+    queryParams?: Record<string, unknown>
+    headers?: Record<string, string>
+    body?: unknown
+  }
+
+  const pathParams = validate(
+    contract.requestPathParamsSchema,
+    source.pathParams,
+    'pathParams',
+    contract,
+  ) as Record<string, string | number> | undefined
+  const queryParams = validate(
+    contract.requestQuerySchema,
+    source.queryParams,
+    'queryParams',
+    contract,
+  ) as Record<string, unknown> | undefined
+  const body = validate(
+    typeof contract.requestBodySchema === 'object' ? contract.requestBodySchema : undefined,
+    source.body,
+    'body',
+    contract,
+  )
+
+  return {
+    ...(pathParams !== undefined && { pathParams }),
+    ...(queryParams !== undefined && { queryParams: flattenQueryParams(queryParams, contract) }),
+    ...(source.headers !== undefined && { headers: source.headers }),
+    ...(body !== undefined && { body }),
+  }
+}

--- a/packages/app/frontend-http-client/src/sse-fallback/types.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/types.spec.ts
@@ -1,0 +1,119 @@
+import { defineApiContract, sseResponse } from '@lokalise/api-contracts'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import wretch from 'wretch'
+import { z } from 'zod/v4'
+import { createFallbackTransport } from './createFallbackTransport.ts'
+import type {
+  FallbackEventsOf,
+  FallbackSnapshotOf,
+  FallbackTransport as VendoredFallbackTransport,
+} from './types.ts'
+
+// ============================================================================
+// The seam, copied verbatim from @opinionated-machine/sse-fallback
+// ============================================================================
+//
+// This package deliberately does not depend on the fallback core: the two
+// sides meet structurally, so a consumer installs whichever core version they
+// like. That only holds while the shapes match, and a mismatch that surfaced
+// as a wall of assignability errors at some app's `createResilientSubscription`
+// call would be a poor way to find out. So the core's declarations live here,
+// copied, and the assertions below fail the moment the vendored copy drifts.
+
+type CoreTransportRequest = {
+  path: string
+  method: string
+  query?: Record<string, string>
+  headers?: Record<string, string>
+  body?: unknown
+}
+
+type CoreSnapshotResponse = {
+  status: number
+  headers: Record<string, string>
+  body: unknown
+}
+
+type CoreParsedSseFrame = {
+  id?: string
+  event?: string
+  data: string
+  retry?: number
+  lastEventId?: string
+}
+
+type CoreRawStreamResponse = {
+  status: number
+  headers: Record<string, string>
+  chunks: AsyncIterable<string>
+}
+
+type CoreParsedStreamResponse = {
+  status: number
+  headers: Record<string, string>
+  events: AsyncIterable<CoreParsedSseFrame>
+}
+
+type CoreStreamResponse = CoreRawStreamResponse | CoreParsedStreamResponse
+
+type CoreFallbackTransport = {
+  fetchSnapshot(
+    request: CoreTransportRequest,
+    opts: { signal: AbortSignal },
+  ): Promise<CoreSnapshotResponse>
+  openStream(
+    request: CoreTransportRequest,
+    opts: { signal: AbortSignal; lastEventId?: string },
+  ): Promise<CoreStreamResponse>
+}
+
+const snapshotSchema = z.object({ version: z.number(), status: z.enum(['pending', 'done']) })
+
+const dualModeContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload status',
+  method: 'get',
+  pathResolver: () => '/uploads/u-1/status',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': snapshotSchema,
+        ...sseResponse({
+          uploadFinished: z.object({ version: z.number(), result: z.string() }),
+          progress: z.object({ version: z.number(), percent: z.number() }),
+        }).content,
+      },
+    },
+    404: z.object({ message: z.string() }),
+  },
+})
+
+describe('the fallback transport seam', () => {
+  it('produces a transport the fallback client core accepts', () => {
+    const transport = createFallbackTransport(wretch('https://example.com'), {
+      contract: dualModeContract,
+    })
+
+    expectTypeOf(transport).toExtend<CoreFallbackTransport>()
+    // And the other direction, so a core-provided transport (its bundled
+    // `TestTransport`, say) can be handed to anything typed against ours.
+    expectTypeOf<CoreFallbackTransport>().toExtend<VendoredFallbackTransport>()
+
+    expect(transport.fetchSnapshot).toBeTypeOf('function')
+    expect(transport.openStream).toBeTypeOf('function')
+  })
+
+  it('derives the binding snapshot type from the contract', () => {
+    expectTypeOf<FallbackSnapshotOf<typeof dualModeContract>>().toEqualTypeOf<{
+      version: number
+      status: 'pending' | 'done'
+    }>()
+  })
+
+  it('derives the binding event payload map from the contract', () => {
+    expectTypeOf<FallbackEventsOf<typeof dualModeContract>>().toEqualTypeOf<{
+      uploadFinished: { version: number; result: string }
+      progress: { version: number; percent: number }
+    }>()
+  })
+})

--- a/packages/app/frontend-http-client/src/sse-fallback/types.spec.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/types.spec.ts
@@ -88,6 +88,19 @@ const dualModeContract = defineApiContract({
   },
 })
 
+/**
+ * The JSON-only shape the README recommends for adopting the fallback before
+ * an SSE endpoint exists: a success status mapped straight to a schema, with
+ * no content map to look inside.
+ */
+const jsonOnlyContract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload snapshot',
+  method: 'get',
+  pathResolver: () => '/uploads/u-1/status',
+  responsesByStatusCode: { 200: snapshotSchema },
+})
+
 describe('the fallback transport seam', () => {
   it('produces a transport the fallback client core accepts', () => {
     const transport = createFallbackTransport(wretch('https://example.com'), {
@@ -108,6 +121,17 @@ describe('the fallback transport seam', () => {
       version: number
       status: 'pending' | 'done'
     }>()
+  })
+
+  it('derives the snapshot type from a contract with no content map', () => {
+    expectTypeOf<FallbackSnapshotOf<typeof jsonOnlyContract>>().toEqualTypeOf<{
+      version: number
+      status: 'pending' | 'done'
+    }>()
+  })
+
+  it('derives no events from a contract with no SSE branch', () => {
+    expectTypeOf<FallbackEventsOf<typeof jsonOnlyContract>>().toEqualTypeOf<Record<never, never>>()
   })
 
   it('derives the binding event payload map from the contract', () => {

--- a/packages/app/frontend-http-client/src/sse-fallback/types.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/types.ts
@@ -127,9 +127,20 @@ type SuccessEntriesOf<TContract extends ApiContract> = NonNullable<
   >]
 >
 
+/**
+ * The body descriptors a response entry declares.
+ *
+ * A content-map entry contributes one descriptor per media type. A bare Zod
+ * schema — the JSON-only shape a poll-only contract uses, and the one this
+ * package's README recommends for adopting the fallback before an SSE endpoint
+ * exists — *is* the descriptor, so it has to be picked up too; reading only
+ * `content` would resolve those contracts to `never`.
+ */
 type ContentDescriptorsOf<TEntry> = TEntry extends { content: infer TContent }
   ? TContent[keyof TContent]
-  : never
+  : TEntry extends z.ZodType
+    ? TEntry
+    : never
 
 /**
  * The snapshot type a dual-mode contract's JSON branch resolves to — the

--- a/packages/app/frontend-http-client/src/sse-fallback/types.ts
+++ b/packages/app/frontend-http-client/src/sse-fallback/types.ts
@@ -1,0 +1,164 @@
+/**
+ * The `@opinionated-machine/sse-fallback` transport seam, vendored as types.
+ *
+ * The fallback client core (`createResilientSubscription`) owns no HTTP: it
+ * asks a `FallbackTransport` for a JSON snapshot and for an SSE stream, and
+ * runs the version gate, the deadman poll and the degradation state machine on
+ * top. This package supplies that transport.
+ *
+ * These declarations are *structural copies* of the core's own, which is
+ * deliberate: TypeScript matches them by shape, so the transport built here
+ * plugs into any `@opinionated-machine/sse-fallback` version without this
+ * package taking a dependency on it — no version lock-step, and nothing to
+ * install for consumers who only use the plain HTTP client. Keep them in sync
+ * with the core if it grows a field; a mismatch shows up as an assignability
+ * error at the `createResilientSubscription({ transport })` call site rather
+ * than as a runtime surprise.
+ */
+
+import type { ApiContract } from '@lokalise/api-contracts'
+import type { z } from 'zod/v4'
+
+/** Which of the two channels a request, error or diagnostic belongs to. */
+export type FallbackChannel = 'poll' | 'stream'
+
+/**
+ * A channel-agnostic request description, built by the binding from the
+ * contract plus the subscription params. `path` is already resolved (path
+ * params substituted) and carries no query string.
+ */
+export type FallbackTransportRequest = {
+  path: string
+  method: string
+  query?: Record<string, string>
+  headers?: Record<string, string>
+  body?: unknown
+}
+
+/** What `fetchSnapshot` resolves with. Non-2xx statuses resolve, they do not reject. */
+export type FallbackSnapshotResponse = {
+  status: number
+  headers: Record<string, string>
+  body: unknown
+}
+
+/**
+ * The recommended stream shape: the transport hands over decoded text and the
+ * core does the SSE framing itself, so heartbeat comments count as byte-level
+ * liveness and every frame keeps its own `id:`.
+ */
+export type FallbackRawStreamResponse = {
+  status: number
+  headers: Record<string, string>
+  chunks: AsyncIterable<string>
+}
+
+/** One SSE frame, already framed by the transport. */
+export type FallbackParsedSseFrame = {
+  /** The `id:` field, when the frame carried one. */
+  id?: string
+  /** The `event:` field; the core treats a missing name as `'message'`. */
+  event?: string
+  /** The raw `data:` payload, before the core's `parseEventData`. */
+  data: string
+  /** The `retry:` reconnection hint in ms, when one was seen. */
+  retry?: number
+  /** The Last-Event-ID cursor as of this frame — sticky, unlike {@link id}. */
+  lastEventId?: string
+}
+
+/**
+ * The parsed-event stream shape. Costs byte-level liveness (comment frames are
+ * consumed by the framing) and buys pre-delivery schema validation — see
+ * `eventValidation: 'drop'`.
+ */
+export type FallbackParsedStreamResponse = {
+  status: number
+  headers: Record<string, string>
+  events: AsyncIterable<FallbackParsedSseFrame>
+}
+
+export type FallbackStreamResponse = FallbackRawStreamResponse | FallbackParsedStreamResponse
+
+/** The seam the fallback client core consumes. */
+export type FallbackTransport = {
+  /**
+   * Fetch a snapshot over the JSON branch. Resolves with status/headers/body
+   * even for a non-2xx response; rejects only when there is no usable
+   * snapshot (network failure, schema violation, wrong representation).
+   */
+  fetchSnapshot(
+    request: FallbackTransportRequest,
+    opts: { signal: AbortSignal },
+  ): Promise<FallbackSnapshotResponse>
+  /**
+   * Open the SSE branch. Resolves once response headers are received; rejects
+   * only on network-level failure. A non-200 status (or a
+   * non-`text/event-stream` content type) is a connect failure the core counts
+   * toward degradation.
+   */
+  openStream(
+    request: FallbackTransportRequest,
+    opts: { signal: AbortSignal; lastEventId?: string },
+  ): Promise<FallbackStreamResponse>
+}
+
+/**
+ * Subscription params, as accepted by the core's binding request builders.
+ * Structural copy of the core's `FallbackRequestParams`.
+ */
+export type FallbackRequestParams = {
+  pathParams?: Record<string, string | number>
+  queryParams?: Record<string, string | number | boolean | undefined>
+  headers?: Record<string, string>
+  body?: unknown
+}
+
+// ============================================================================
+// Contract-derived types
+// ============================================================================
+
+type SuccessStatusKey = 200 | 201 | 202 | 203 | 206 | 207 | 208 | 226 | '2xx' | 'default'
+
+type SuccessEntriesOf<TContract extends ApiContract> = NonNullable<
+  TContract['responsesByStatusCode'][Extract<
+    keyof TContract['responsesByStatusCode'],
+    SuccessStatusKey
+  >]
+>
+
+type ContentDescriptorsOf<TEntry> = TEntry extends { content: infer TContent }
+  ? TContent[keyof TContent]
+  : never
+
+/**
+ * The snapshot type a dual-mode contract's JSON branch resolves to — the
+ * `Snapshot` type parameter of a fallback binding.
+ *
+ * The core infers this structurally too; declare it explicitly when a contract
+ * shape defeats that inference, so a mistyped `version.ofSnapshot` is a
+ * compile error instead of a runtime `undefined`.
+ */
+export type FallbackSnapshotOf<TContract extends ApiContract> =
+  Extract<ContentDescriptorsOf<SuccessEntriesOf<TContract>>, z.ZodType> extends infer TSchema
+    ? TSchema extends z.ZodType
+      ? z.output<TSchema>
+      : never
+    : never
+
+type SseSchemasOf<TContract extends ApiContract> =
+  ContentDescriptorsOf<SuccessEntriesOf<TContract>> extends infer TDescriptor
+    ? TDescriptor extends { _tag: 'SseBody'; schemaByEventName: infer TSchemas }
+      ? TSchemas
+      : never
+    : never
+
+/**
+ * The `event name → payload` map a contract's SSE branch delivers — the
+ * `Events` type parameter of a fallback binding.
+ */
+export type FallbackEventsOf<TContract extends ApiContract> = {
+  [K in keyof SseSchemasOf<TContract>]: SseSchemasOf<TContract>[K] extends z.ZodType
+    ? z.output<SseSchemasOf<TContract>[K]>
+    : never
+}

--- a/packages/app/frontend-http-client/src/utils/responseUtils.ts
+++ b/packages/app/frontend-http-client/src/utils/responseUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * Flatten a `Response`'s headers into a plain object with lowercase keys, the
+ * shape both the contract client and the fallback transport hand to callers.
+ */
+export function normalizeResponseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {}
+
+  response.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+
+  return headers
+}

--- a/packages/app/frontend-http-client/test/verifyWithCore.mjs
+++ b/packages/app/frontend-http-client/test/verifyWithCore.mjs
@@ -1,0 +1,359 @@
+/**
+ * Acceptance gate: this package's `createFallbackTransport` driving the real
+ * `@opinionated-machine/sse-fallback` client core against a real HTTP server.
+ *
+ * The unit suite covers the adapter in isolation; this covers the seam — that
+ * the core actually gets what it needs out of it. It lives outside `vitest`
+ * because the core is an optional peer nobody has to install:
+ *
+ *   pnpm add -D @opinionated-machine/sse-fallback
+ *   pnpm run build && node test/verifyWithCore.mjs
+ *
+ * Run it when bumping the core, or when changing anything in `src/sse-fallback`.
+ */
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import { defineApiContract, sseResponse } from '@lokalise/api-contracts'
+import { getLocal } from 'mockttp'
+import wretch from 'wretch'
+import { z } from 'zod/v4'
+import { buildFallbackParams, createFallbackTransport } from '../dist/index.js'
+
+const CORE_PACKAGE = '@opinionated-machine/sse-fallback'
+
+let core
+try {
+  core = await import(CORE_PACKAGE)
+} catch {
+  process.stderr.write(
+    `${CORE_PACKAGE} is not installed, so there is no client core to verify against.\n` +
+      `Install it first:  pnpm add -D ${CORE_PACKAGE}\n`,
+  )
+  process.exit(1)
+}
+const { createResilientSubscription, defineFallbackBinding } = core
+
+const snapshotSchema = z.object({
+  version: z.number(),
+  status: z.enum(['pending', 'completed']),
+})
+
+const contract = defineApiContract({
+  visibility: 'public',
+  summary: 'Upload status',
+  method: 'get',
+  pathResolver: (params) => `/uploads/${params.uploadId}/status`,
+  requestPathParamsSchema: z.object({ uploadId: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': snapshotSchema,
+        ...sseResponse({
+          uploadFinished: z.object({ version: z.number(), result: z.string() }),
+          progress: z.object({ version: z.number(), percent: z.number() }),
+        }).content,
+      },
+    },
+  },
+})
+
+const binding = defineFallbackBinding(contract, {
+  snapshotToEvents: (snapshot) =>
+    snapshot.status === 'completed'
+      ? [{ event: 'uploadFinished', data: { version: snapshot.version, result: 'from-poll' } }]
+      : [],
+  version: { ofSnapshot: (snapshot) => snapshot.version },
+  terminalEvents: ['uploadFinished'],
+})
+
+const server = getLocal()
+await server.start()
+
+const results = []
+
+// ---------------------------------------------------------------------------
+// 1. The happy path over SSE: the event travels over the stream.
+// ---------------------------------------------------------------------------
+{
+  const upstream = new Readable({ read() {} })
+  await server
+    .forGet('/uploads/u-1/status')
+    .matching((request) => request.headers.accept === 'text/event-stream')
+    .thenStream(200, upstream, { 'content-type': 'text/event-stream' })
+  await server.forGet('/uploads/u-1/status').thenJson(200, { version: 1, status: 'pending' })
+
+  const transport = createFallbackTransport(wretch(server.url), { contract })
+  const subscription = createResilientSubscription(binding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-1' } }),
+  })
+
+  upstream.push(': heartbeat\n\n')
+  upstream.push(
+    `id: 7\nevent: uploadFinished\ndata: ${JSON.stringify({ version: 7, result: 'over-sse' })}\n\n`,
+  )
+
+  const finished = await subscription.waitFor('uploadFinished', { timeoutMs: 5_000 })
+  assert.deepEqual(finished, { version: 7, result: 'over-sse' })
+  assert.equal(subscription.result?.reason, 'terminal-event')
+  upstream.push(null)
+  results.push('SSE delivery + subscribe-first hydration')
+  server.reset()
+}
+
+// ---------------------------------------------------------------------------
+// 2. The whole point: SSE never delivers, the poll repairs it.
+// ---------------------------------------------------------------------------
+{
+  const upstream = new Readable({ read() {} })
+  await server
+    .forGet('/uploads/u-2/status')
+    .matching((request) => request.headers.accept === 'text/event-stream')
+    .thenStream(200, upstream, { 'content-type': 'text/event-stream' })
+
+  let polls = 0
+  await server.forGet('/uploads/u-2/status').thenCallback(() => {
+    polls += 1
+    return {
+      statusCode: 200,
+      json: polls === 1 ? { version: 1, status: 'pending' } : { version: 2, status: 'completed' },
+    }
+  })
+
+  const transport = createFallbackTransport(wretch(server.url), { contract })
+  const subscription = createResilientSubscription(binding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-2' } }),
+    // A live stream that never delivers the event: only the deadman poll saves it.
+    policy: { deadmanDelayMs: 200 },
+  })
+
+  // Keep the connection demonstrably alive so nothing but the deadman fires.
+  const heartbeat = setInterval(() => upstream.push(': heartbeat\n\n'), 50)
+  const finished = await subscription.waitFor('uploadFinished', { timeoutMs: 5_000 })
+  clearInterval(heartbeat)
+  assert.deepEqual(finished, { version: 2, result: 'from-poll' })
+  assert.ok(polls >= 2, `expected a reconciliation poll, saw ${polls}`)
+  upstream.push(null)
+  results.push('deadman poll repairs an event the live stream never sent')
+  server.reset()
+}
+
+// ---------------------------------------------------------------------------
+// 3. Last-Event-ID is forwarded on reconnect after the stream drops.
+// ---------------------------------------------------------------------------
+{
+  const first = new Readable({ read() {} })
+  const second = new Readable({ read() {} })
+  const isSse = (request) => request.headers.accept === 'text/event-stream'
+
+  const firstConnect = await server
+    .forGet('/uploads/u-3/status')
+    .matching(isSse)
+    .once()
+    .thenStream(200, first, { 'content-type': 'text/event-stream' })
+  const secondConnect = await server
+    .forGet('/uploads/u-3/status')
+    .matching(isSse)
+    .thenStream(200, second, { 'content-type': 'text/event-stream' })
+  await server.forGet('/uploads/u-3/status').thenJson(200, { version: 1, status: 'pending' })
+
+  const transport = createFallbackTransport(wretch(server.url), { contract })
+  const subscription = createResilientSubscription(binding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-3' } }),
+    policy: { sseRetryBackoff: { baseMs: 20, factor: 1, maxMs: 20 } },
+  })
+
+  first.push(`id: 11\nevent: progress\ndata: ${JSON.stringify({ version: 11, percent: 10 })}\n\n`)
+  setTimeout(() => first.push(null), 150)
+  second.push(
+    `id: 12\nevent: uploadFinished\ndata: ${JSON.stringify({ version: 12, result: 'after-reconnect' })}\n\n`,
+  )
+
+  const finished = await subscription.waitFor('uploadFinished', { timeoutMs: 8_000 })
+  assert.deepEqual(finished, { version: 12, result: 'after-reconnect' })
+
+  const [firstRequest] = await firstConnect.getSeenRequests()
+  const [secondRequest] = await secondConnect.getSeenRequests()
+  assert.equal(firstRequest.headers['last-event-id'], undefined, 'first connect carries no cursor')
+  assert.equal(
+    secondRequest.headers['last-event-id'],
+    '11',
+    `reconnect must resume from id 11, got ${secondRequest.headers['last-event-id']}`,
+  )
+  second.push(null)
+  results.push('Last-Event-ID resumes the stream after a drop')
+  server.reset()
+}
+
+// ---------------------------------------------------------------------------
+// 4. A refused stream reaches onAuthChallenge, and the retry sees a new token.
+// ---------------------------------------------------------------------------
+{
+  let token = 'expired'
+  const upstream = new Readable({ read() {} })
+  const isSse = (request) => request.headers.accept === 'text/event-stream'
+
+  const refusal = await server
+    .forGet('/uploads/u-4/status')
+    .matching(isSse)
+    .once()
+    .thenJson(401, { message: 'expired' })
+  const accepted = await server
+    .forGet('/uploads/u-4/status')
+    .matching(isSse)
+    .thenStream(200, upstream, { 'content-type': 'text/event-stream' })
+  await server.forGet('/uploads/u-4/status').thenJson(200, { version: 1, status: 'pending' })
+
+  const transport = createFallbackTransport(wretch(server.url), {
+    contract,
+    headers: () => ({ authorization: `Bearer ${token}` }),
+  })
+
+  let refreshes = 0
+  const subscription = createResilientSubscription(binding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-4' } }),
+    policy: { sseRetryBackoff: { baseMs: 20, factor: 1, maxMs: 20 } },
+    onAuthChallenge: () => {
+      refreshes += 1
+      token = 'refreshed'
+      return true
+    },
+  })
+
+  upstream.push(
+    `id: 20\nevent: uploadFinished\ndata: ${JSON.stringify({ version: 20, result: 'authorized' })}\n\n`,
+  )
+  const finished = await subscription.waitFor('uploadFinished', { timeoutMs: 8_000 })
+  assert.deepEqual(finished, { version: 20, result: 'authorized' })
+  assert.equal(refreshes, 1)
+
+  const [refusedRequest] = await refusal.getSeenRequests()
+  const [acceptedRequest] = await accepted.getSeenRequests()
+  assert.equal(refusedRequest.headers.authorization, 'Bearer expired')
+  assert.equal(
+    acceptedRequest.headers.authorization,
+    'Bearer refreshed',
+    `retry must carry the new token, got ${acceptedRequest.headers.authorization}`,
+  )
+  upstream.push(null)
+  results.push('onAuthChallenge recovery picks up a freshly resolved token')
+  server.reset()
+}
+
+// ---------------------------------------------------------------------------
+// 5. poll-only adoption: no stream endpoint at all.
+// ---------------------------------------------------------------------------
+{
+  let polls = 0
+  const endpoint = await server.forGet('/uploads/u-5/status').thenCallback(() => {
+    polls += 1
+    return {
+      statusCode: 200,
+      json: polls < 2 ? { version: 1, status: 'pending' } : { version: 5, status: 'completed' },
+    }
+  })
+
+  const transport = createFallbackTransport(wretch(server.url), { contract })
+  const subscription = createResilientSubscription(binding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-5' } }),
+    policy: { mode: 'poll-only', degradedPollIntervalMs: 100 },
+  })
+
+  const finished = await subscription.waitFor('uploadFinished', { timeoutMs: 5_000 })
+  assert.deepEqual(finished, { version: 5, result: 'from-poll' })
+  const seen = await endpoint.getSeenRequests()
+  assert.ok(seen.length > 0)
+  assert.ok(
+    seen.every((request) => request.headers.accept === 'application/json'),
+    'poll-only must never open a stream',
+  )
+  results.push('poll-only mode never opens a stream')
+  server.reset()
+}
+
+// ---------------------------------------------------------------------------
+// 6. A snapshot that violates the contract is a poll failure, not a poisoned
+//    watermark: the next valid snapshot still delivers.
+// ---------------------------------------------------------------------------
+{
+  let polls = 0
+  const pollErrors = []
+  await server.forGet('/uploads/u-6/status').thenCallback(() => {
+    polls += 1
+    return {
+      statusCode: 200,
+      json: polls === 1 ? { version: 'nine' } : { version: 9, status: 'completed' },
+    }
+  })
+
+  const transport = createFallbackTransport(wretch(server.url), { contract })
+  const subscription = createResilientSubscription(binding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-6' } }),
+    policy: {
+      mode: 'poll-only',
+      degradedPollIntervalMs: 50,
+      pollFailureBackoff: { baseMs: 20, factor: 1, maxMs: 20 },
+    },
+    diagnostics: { onPollError: (error) => pollErrors.push(error) },
+  })
+
+  const finished = await subscription.waitFor('uploadFinished', { timeoutMs: 5_000 })
+  assert.deepEqual(finished, { version: 9, result: 'from-poll' })
+  assert.equal(pollErrors.length >= 1, true)
+  assert.equal(pollErrors[0].name, 'FallbackSnapshotValidationError')
+  results.push('a schema-invalid snapshot is a retried poll failure, reported to diagnostics')
+  server.reset()
+}
+
+// ---------------------------------------------------------------------------
+// 7. Reduced state via the `events` stream mode, with a dropped bad payload.
+// ---------------------------------------------------------------------------
+{
+  const stateBinding = defineFallbackBinding(contract, {
+    snapshotEvent: 'progress',
+    version: { ofSnapshot: (snapshot) => snapshot.version, ofEvent: (event) => event.data.version },
+    state: { init: (snapshot) => snapshot, apply: (state, event) => ({ ...state, ...event.data }) },
+  })
+
+  const upstream = new Readable({ read() {} })
+  await server
+    .forGet('/uploads/u-7/status')
+    .matching((request) => request.headers.accept === 'text/event-stream')
+    .thenStream(200, upstream, { 'content-type': 'text/event-stream' })
+  await server.forGet('/uploads/u-7/status').thenJson(200, { version: 1, status: 'pending' })
+
+  const schemaErrors = []
+  const transport = createFallbackTransport(wretch(server.url), {
+    contract,
+    streamMode: 'events',
+    eventValidation: 'drop',
+    diagnostics: { onEventSchemaError: (error) => schemaErrors.push(error) },
+  })
+  const subscription = createResilientSubscription(stateBinding, {
+    transport,
+    params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-7' } }),
+    policy: { deadmanDelayMs: 60_000 },
+  })
+
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  upstream.push('id: 2\nevent: progress\ndata: {"version":2,"percent":"half"}\n\n')
+  upstream.push(`id: 3\nevent: progress\ndata: ${JSON.stringify({ version: 3, percent: 75 })}\n\n`)
+
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  assert.equal(schemaErrors.length, 1, `expected one schema error, saw ${schemaErrors.length}`)
+  assert.equal(schemaErrors[0].event, 'progress')
+  assert.equal(subscription.getState()?.percent, 75, 'the valid delta must have been applied')
+  subscription.stop()
+  upstream.push(null)
+  results.push("streamMode 'events' + eventValidation 'drop' withholds a bad payload")
+  server.reset()
+}
+
+await server.stop()
+process.stdout.write(`\nVerified against the real ${CORE_PACKAGE} core:\n`)
+for (const result of results) process.stdout.write(`  ✓ ${result}\n`)

--- a/packages/app/frontend-http-client/test/verifyWithCore.mjs
+++ b/packages/app/frontend-http-client/test/verifyWithCore.mjs
@@ -311,7 +311,7 @@ const results = []
 }
 
 // ---------------------------------------------------------------------------
-// 7. Reduced state via the `events` stream mode, with a dropped bad payload.
+// 7. `eventValidation: 'drop'` holds the gap open, and a poll repairs it.
 // ---------------------------------------------------------------------------
 {
   const stateBinding = defineFallbackBinding(contract, {
@@ -320,12 +320,23 @@ const results = []
     state: { init: (snapshot) => snapshot, apply: (state, event) => ({ ...state, ...event.data }) },
   })
 
+  // What the poll answers is the point of this case, so it is a variable
+  // rather than a fixed rule: the gap is only proven repaired if the state
+  // ends up at a snapshot the stream never delivered.
+  let snapshot = { version: 1, status: 'pending' }
+
   const upstream = new Readable({ read() {} })
   await server
     .forGet('/uploads/u-7/status')
     .matching((request) => request.headers.accept === 'text/event-stream')
+    .once()
     .thenStream(200, upstream, { 'content-type': 'text/event-stream' })
-  await server.forGet('/uploads/u-7/status').thenJson(200, { version: 1, status: 'pending' })
+  // Once `drop` ends the stream the core reconnects; that request falls
+  // through to this rule, whose JSON content type the core counts as a connect
+  // failure — which is what degrades the subscription onto the poll.
+  await server
+    .forGet('/uploads/u-7/status')
+    .thenCallback(() => ({ statusCode: 200, json: snapshot }))
 
   const schemaErrors = []
   const transport = createFallbackTransport(wretch(server.url), {
@@ -337,20 +348,44 @@ const results = []
   const subscription = createResilientSubscription(stateBinding, {
     transport,
     params: buildFallbackParams(contract, { pathParams: { uploadId: 'u-7' } }),
-    policy: { deadmanDelayMs: 60_000 },
+    policy: {
+      deadmanDelayMs: 100,
+      sseRetryBackoff: { baseMs: 20, factor: 1, maxMs: 20 },
+      pollFailureBackoff: { baseMs: 20, factor: 1, maxMs: 20 },
+    },
   })
 
   await new Promise((resolve) => setTimeout(resolve, 300))
+  assert.equal(subscription.getState()?.version, 1, 'hydrated from the first poll')
+
+  // A payload the contract rejects, followed by a valid one on the same
+  // connection.
   upstream.push('id: 2\nevent: progress\ndata: {"version":2,"percent":"half"}\n\n')
   upstream.push(`id: 3\nevent: progress\ndata: ${JSON.stringify({ version: 3, percent: 75 })}\n\n`)
+  upstream.push(null)
 
   await new Promise((resolve) => setTimeout(resolve, 300))
   assert.equal(schemaErrors.length, 1, `expected one schema error, saw ${schemaErrors.length}`)
   assert.equal(schemaErrors[0].event, 'progress')
-  assert.equal(subscription.getState()?.percent, 75, 'the valid delta must have been applied')
+  // Version 3 rode the connection that carried the withheld payload, so it is
+  // withheld too. Delivering it would advance the watermark past version 2 and
+  // turn the repair below into a stale duplicate that synthesizes nothing.
+  assert.equal(
+    subscription.getState()?.percent,
+    undefined,
+    'the frame after a dropped one must not be delivered',
+  )
+  assert.equal(subscription.getState()?.version, 1, 'the watermark must stay below the gap')
+
+  // The repair: a snapshot newer than anything the stream delivered. It is
+  // only applied because the watermark is still below it.
+  snapshot = { version: 4, status: 'completed' }
+  const repaired = await subscription.waitFor('progress', { timeoutMs: 5_000 })
+
+  assert.equal(repaired.version, 4)
+  assert.equal(subscription.getState()?.version, 4, 'the poll repaired the gap')
   subscription.stop()
-  upstream.push(null)
-  results.push("streamMode 'events' + eventValidation 'drop' withholds a bad payload")
+  results.push("eventValidation 'drop' holds the watermark below the gap so a poll repairs it")
   server.reset()
 }
 


### PR DESCRIPTION
`@opinionated-machine/sse-fallback` runs SSE with a transparent polling
fallback — polling as the correctness backbone, SSE as the latency layer —
but owns no HTTP. This adds the HTTP half.

`createFallbackTransport(wretch, { contract })` supplies the core's
`fetchSnapshot` / `openStream` pair on top of an API contract:

- the poll asks for the contract's JSON branch and validates the snapshot
  against its schema; a violation rejects the poll rather than reaching the
  version gate, where a wrong watermark would silently drop every later event
- the stream asks for the SSE branch, forwards `Last-Event-ID` on reconnect,
  and yields raw text chunks (comment frames included) so the core's
  stale-connection watchdog stays byte-level
- refusals resolve with their status, so `unretryableStatuses` and
  `onAuthChallenge` can act on them; only an unusable outcome rejects
- `Cache-Control: no-cache` on both channels, because a cached poll keeps
  "succeeding" while reporting stale state
- the header source is resolved fresh per request, which is what lets the one
  retry `onAuthChallenge` grants carry a refreshed token
- no deadline of its own: the core bounds every wait through its `signal`

SSE payloads are validated against the contract's event schemas.
`eventValidation: 'report'` (default) reports drift to diagnostics and still
delivers; `'drop'` withholds the frame from the core so the watermark does not
advance and a poll repairs the gap, which requires `streamMode: 'events'`
because that is where framing happens before the core sees anything.

Also adds `buildFallbackParams` (contract-typed, validated subscription
params), `SseFramer`, `FallbackSnapshotOf` / `FallbackEventsOf`, and a typed
error hierarchy. The transport seam is matched structurally, so this takes no
dependency on the core and nothing moves in lock-step; a type test keeps the
vendored declarations honest. `test/verifyWithCore.mjs` is an opt-in
acceptance gate that runs the adapter against the real core over HTTP.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
