### PR TITLE
feat(errors): add UPSTREAM_ERROR type mapped to HTTP 502

### DIFF
--- a/.changeset/errors-upstream-error-type.md
+++ b/.changeset/errors-upstream-error-type.md
@@ -1,0 +1,5 @@
+---
+"@lokalise/errors": minor
+---
+
+Add `ErrorType.UPSTREAM_ERROR` (`upstream-error`), mapped to HTTP status 502.

--- a/packages/app/errors/README.md
+++ b/packages/app/errors/README.md
@@ -260,6 +260,7 @@ reply.status(httpStatusByErrorType[someType]).send(payload)
 | `rate-limit`        | 429  |
 | `internal`          | 500  |
 | `unimplemented`     | 501  |
+| `upstream-error`    | 502  |
 | `unavailable`       | 503  |
 
 For other protocols (gRPC, message queues) create a similar mapping using the

--- a/packages/app/errors/src/constants.ts
+++ b/packages/app/errors/src/constants.ts
@@ -23,6 +23,8 @@ export const ErrorType = {
   INTERNAL: 'internal',
   /** Not implemented */
   UNIMPLEMENTED: 'unimplemented',
+  /** Invalid response received from an upstream service */
+  UPSTREAM_ERROR: 'upstream-error',
   /** Service unavailable */
   UNAVAILABLE: 'unavailable',
 } as const
@@ -38,5 +40,6 @@ export const httpStatusByErrorType = {
   [ErrorType.RATE_LIMIT]: 429,
   [ErrorType.INTERNAL]: 500,
   [ErrorType.UNIMPLEMENTED]: 501,
+  [ErrorType.UPSTREAM_ERROR]: 502,
   [ErrorType.UNAVAILABLE]: 503,
 } as const satisfies Record<ErrorType, number>


### PR DESCRIPTION
## Summary

- Add `ErrorType.UPSTREAM_ERROR` (`'upstream-error'`) to `@lokalise/errors`, for invalid responses received from an upstream service
- Map it to HTTP status 502 in `httpStatusByErrorType`
- Document it in the README status code table
- Changeset: minor bump for `@lokalise/errors`

The name follows the protocol-agnostic intent of `ErrorType` (it describes the condition rather than the HTTP reason phrase "Bad Gateway").

## Test plan

- [x] `biome check`, `tsc`, and `vitest run` pass in `packages/app/errors`
- [x] `satisfies Record<ErrorType, number>` on the status map enforces the new entry at compile time

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)