### PR TITLE
chore: remove duplicated fastq entries from pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5434,21 +5434,6 @@ packages:
   fastq@1.20.3:
     resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
 
-  fastq@1.20.3:
-    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
-
-  fastq@1.20.3:
-    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
-
-  fastq@1.20.3:
-    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
-
-  fastq@1.20.3:
-    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
-
-  fastq@1.20.3:
-    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
-
   fastseries@1.7.2:
     resolution: {integrity: sha512-dTPFrPGS8SNSzAt7u/CbMKCJ3s01N04s4JFbORHcmyvVfVKmbhMD1VtRbh5enGHxkaQDqWyLefiKOGGmohGDDQ==}
 
@@ -12264,26 +12249,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
       xtend: 4.0.2
-
-  fastq@1.20.3:
-    dependencies:
-      reusify: 1.1.0
-
-  fastq@1.20.3:
-    dependencies:
-      reusify: 1.1.0
-
-  fastq@1.20.3:
-    dependencies:
-      reusify: 1.1.0
-
-  fastq@1.20.3:
-    dependencies:
-      reusify: 1.1.0
-
-  fastq@1.20.3:
-    dependencies:
-      reusify: 1.1.0
 
   fastq@1.20.3:
     dependencies:


### PR DESCRIPTION
## Summary

`pnpm install` fails on `main` with:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: duplicated mapping key (5238:3)
```

`fastq@1.20.3` was repeated six times in both the `packages:` and `snapshots:` sections. Each of the last five Dependabot commits (#1265, #1266, #1267, #1268, #1274) added one more copy. This PR removes the redundant copies, leaving a single entry per section. The diff is deletions only.

Verified with `pnpm install --frozen-lockfile`, which completes without rewriting the lockfile.

No changeset: no published package code changed.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)