### PR TITLE
fix(universal-testing-utils): declare @types/node so msw resolves against a single copy

### DIFF
--- a/packages/app/universal-testing-utils/package.json
+++ b/packages/app/universal-testing-utils/package.json
@@ -56,6 +56,7 @@
         "@lokalise/biome-config": "workspace:^",
         "@lokalise/frontend-http-client": "workspace:^",
         "@lokalise/tsconfig": "workspace:^",
+        "@types/node": "^26.4.1",
         "@vitest/coverage-v8": "^4.1.11",
         "mockttp": "^4.4.2",
         "msw": "^2.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1311,6 +1311,9 @@ importers:
       '@lokalise/tsconfig':
         specifier: workspace:^
         version: link:../../dev/tsconfig
+      '@types/node':
+        specifier: ^26.4.1
+        version: 26.5.0
       '@vitest/coverage-v8':
         specifier: ^4.1.11
         version: 4.1.11(vitest@4.1.11)


### PR DESCRIPTION
`main` currently fails `tsc` in universal-testing-utils with a dozen errors like:

```
src/MswHelper.ts(157,34): error TS2345: Argument of type '() => HttpResponse<JsonBodyType>' is not assignable to parameter of type 'HttpResponseResolver<PathParams, DefaultBodyType, JsonBodyType>'.
```

The package never declared `@types/node`, so msw, vitest and vite resolved their optional `@types/node` peer to 26.5.0 while the rest of the graph moved to 26.4.1 in #1262. The two versions ship different `undici-types` (8.9.0 vs 8.3.0), tsc loads both, and msw's `HttpResponse` no longer matches its own resolver return type.

Fix is one devDependency on `@types/node` so the peers resolve to the same copy. Lockfile change is the matching importer entry only.

Unblocks #1269 (its universal-testing-utils job fails the same way) and #1276.

No changeset: devDependency only, no published code changes.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
