### PR TITLE
fix(background-jobs-common): detect duplicate processors by resolved queue name

### DIFF
--- a/.changeset/processor-uniqueness-by-queue-name.md
+++ b/.changeset/processor-uniqueness-by-queue-name.md
@@ -1,0 +1,5 @@
+---
+'@lokalise/background-jobs-common': patch
+---
+
+Detect duplicate processors by the resolved BullMQ queue name instead of the raw queue id, so that two processors whose ids differ only in how dashboard grouping is spelled out no longer both consume the same queue.

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.spec.ts
@@ -51,7 +51,7 @@ describe('BackgroundJobProcessorMonitor', () => {
 
         await monitor.registerQueueProcessor()
         await expect(monitor.registerQueueProcessor()).rejects.toMatchInlineSnapshot(
-          `[Error: Processor for queue id "test-queue" is not unique.]`,
+          `[Error: Processor for queue "test-queue" is not unique.]`,
         )
 
         await monitor.unregisterQueueProcessor()
@@ -87,7 +87,7 @@ describe('BackgroundJobProcessorMonitor', () => {
 
         await monitor.registerQueueProcessor()
         await expect(monitor.registerQueueProcessor()).rejects.toMatchInlineSnapshot(
-          `[Error: Processor for queue id "test-queue" is not unique.]`,
+          `[Error: Processor for queue "test-queue" is not unique.]`,
         )
 
         await monitor.unregisterQueueProcessor()
@@ -133,7 +133,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       await expect(
         monitorWithGroupingInTheId.registerQueueProcessor(),
       ).rejects.toMatchInlineSnapshot(
-        `[Error: Processor for queue id "group.grouped-queue" is not unique.]`,
+        `[Error: Processor for queue "group.grouped-queue" is not unique.]`,
       )
 
       monitor.unregisterQueueProcessor()

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.spec.ts
@@ -43,6 +43,7 @@ describe('BackgroundJobProcessorMonitor', () => {
         const monitor = new BackgroundJobProcessorMonitor(deps, {
           isNewProcessor: false,
           queueId: 'test-queue',
+          queueName: 'test-queue',
           processorName: 'registerQueue tests',
           ownerName: 'test-owner',
           redisConfig: factory.getRedisConfig(),
@@ -60,6 +61,7 @@ describe('BackgroundJobProcessorMonitor', () => {
         const monitor = new BackgroundJobProcessorMonitor(deps, {
           isNewProcessor: false,
           queueId: 'test-queue',
+          queueName: 'test-queue',
           processorName: 'registerQueue tests',
           ownerName: 'test-owner',
           redisConfig: factory.getRedisConfig(),
@@ -78,6 +80,7 @@ describe('BackgroundJobProcessorMonitor', () => {
         const monitor = new BackgroundJobProcessorMonitor(deps, {
           isNewProcessor: true,
           queueId: 'test-queue',
+          queueName: 'test-queue',
           processorName: 'registerQueue tests',
           ownerName: 'test-owner',
         })
@@ -94,6 +97,7 @@ describe('BackgroundJobProcessorMonitor', () => {
         const monitor = new BackgroundJobProcessorMonitor(deps, {
           isNewProcessor: true,
           queueId: 'test-queue',
+          queueName: 'test-queue',
           processorName: 'registerQueue tests',
           ownerName: 'test-owner',
         })
@@ -105,6 +109,35 @@ describe('BackgroundJobProcessorMonitor', () => {
         monitor.unregisterQueueProcessor()
       })
     })
+
+    it('throws an error for a queue already taken under a different queue id', async () => {
+      // Dashboard grouping is part of the queue name, so `{ queueId: 'grouped-queue',
+      // bullDashboardGrouping: ['group'] }` and `{ queueId: 'group.grouped-queue' }` are two
+      // spellings of one BullMQ queue.
+      const monitor = new BackgroundJobProcessorMonitor(deps, {
+        isNewProcessor: true,
+        queueId: 'grouped-queue',
+        queueName: 'group.grouped-queue',
+        processorName: 'registerQueue tests',
+        ownerName: 'test-owner',
+      })
+      const monitorWithGroupingInTheId = new BackgroundJobProcessorMonitor(deps, {
+        isNewProcessor: true,
+        queueId: 'group.grouped-queue',
+        queueName: 'group.grouped-queue',
+        processorName: 'registerQueue tests',
+        ownerName: 'test-owner',
+      })
+
+      await monitor.registerQueueProcessor()
+      await expect(
+        monitorWithGroupingInTheId.registerQueueProcessor(),
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Processor for queue id "group.grouped-queue" is not unique.]`,
+      )
+
+      monitor.unregisterQueueProcessor()
+    })
   })
 
   describe('unregisterQueue', () => {
@@ -112,6 +145,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       const monitor = new BackgroundJobProcessorMonitor(deps, {
         isNewProcessor: false,
         queueId: 'test-queue',
+        queueName: 'test-queue',
         processorName: 'registerQueue tests',
         ownerName: 'test-owner',
         redisConfig: factory.getRedisConfig(),
@@ -136,6 +170,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       monitor = new BackgroundJobProcessorMonitor(deps, {
         isNewProcessor: false,
         queueId: 'test-queue',
+        queueName: 'test-queue',
         processorName: 'registerQueue tests',
         ownerName: 'test-owner',
         redisConfig: factory.getRedisConfig(),
@@ -181,6 +216,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       monitor = new BackgroundJobProcessorMonitor(deps, {
         isNewProcessor: false,
         queueId: 'test-queue-logJobStarted',
+        queueName: 'test-queue-logJobStarted',
         processorName: 'BackgroundJobProcessorMonitor tests',
         ownerName: 'test-owner',
         redisConfig: factory.getRedisConfig(),
@@ -221,6 +257,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       monitor = new BackgroundJobProcessorMonitor(deps, {
         isNewProcessor: false,
         queueId: 'test-queue',
+        queueName: 'test-queue',
         processorName: 'BackgroundJobProcessorMonitor tests',
         ownerName: 'test-owner',
         redisConfig: factory.getRedisConfig(),
@@ -290,6 +327,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       monitor = new BackgroundJobProcessorMonitor(deps, {
         isNewProcessor: false,
         queueId: 'test-queue',
+        queueName: 'test-queue',
         processorName: 'BackgroundJobProcessorMonitor tests',
         ownerName: 'test-owner',
         redisConfig: factory.getRedisConfig(),
@@ -363,6 +401,7 @@ describe('BackgroundJobProcessorMonitor', () => {
       monitor = new BackgroundJobProcessorMonitor(deps, {
         isNewProcessor: false,
         queueId: 'test-queue-runInJobContext',
+        queueName: 'test-queue-runInJobContext',
         processorName: 'BackgroundJobProcessorMonitor tests',
         ownerName: 'test-owner',
         redisConfig: factory.getRedisConfig(),
@@ -394,6 +433,7 @@ describe('BackgroundJobProcessorMonitor', () => {
         {
           isNewProcessor: false,
           queueId: 'test-queue-runInJobContext-delegating',
+          queueName: 'test-queue-runInJobContext-delegating',
           processorName: 'BackgroundJobProcessorMonitor tests',
           ownerName: 'test-owner',
           redisConfig: factory.getRedisConfig(),

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.ts
@@ -74,7 +74,7 @@ export class BackgroundJobProcessorMonitor<
     // exactly what this guard exists to catch.
     const { queueName } = this.config
     if (queueNamesWithActiveProcessorsSet.has(queueName)) {
-      throw new Error(`Processor for queue id "${queueName}" is not unique.`)
+      throw new Error(`Processor for queue "${queueName}" is not unique.`)
     }
     queueNamesWithActiveProcessorsSet.add(queueName)
 

--- a/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/monitoring/BackgroundJobProcessorMonitor.ts
@@ -12,7 +12,7 @@ import type { BaseJobPayload, RequestContext, SafeJob } from '../types.ts'
 import { resolveJobId } from '../utils.ts'
 import { registerActiveQueueIds } from './registerActiveQueueIds.ts'
 
-const queueIdsWithActiveProcessorsSet = new Set<string>()
+const queueNamesWithActiveProcessorsSet = new Set<string>()
 
 /**
  * Whatever a job threw, if it threw at all.
@@ -24,6 +24,12 @@ export type JobFailure = { error: unknown }
 
 type BackgroundJobProcessorMonitorConfig = {
   queueId: string
+  /**
+   * BullMQ name of the queue the processor consumes, dashboard grouping prefix included. Two
+   * processors can carry different queue ids and still resolve to the same name, which makes this
+   * what uniqueness is keyed on.
+   */
+  queueName: string
   ownerName: string
   processorName: string
 } & (
@@ -63,19 +69,23 @@ export class BackgroundJobProcessorMonitor<
   }
 
   public async registerQueueProcessor(): Promise<void> {
-    if (queueIdsWithActiveProcessorsSet.has(this.config.queueId)) {
-      throw new Error(`Processor for queue id "${this.config.queueId}" is not unique.`)
+    // Keyed on the resolved queue name, not on the bare queue id: two processors whose ids differ
+    // only in how dashboard grouping is spelled out consume the same BullMQ queue, which is
+    // exactly what this guard exists to catch.
+    const { queueName } = this.config
+    if (queueNamesWithActiveProcessorsSet.has(queueName)) {
+      throw new Error(`Processor for queue id "${queueName}" is not unique.`)
     }
-    queueIdsWithActiveProcessorsSet.add(this.config.queueId)
+    queueNamesWithActiveProcessorsSet.add(queueName)
 
     if (this.config.isNewProcessor) return Promise.resolve()
     // For new processors, queue registration in redis is handled by queue manager
     // (once we get rid of the old one, we can remove this code)
-    await registerActiveQueueIds(this.config.redisConfig, [this.config])
+    await registerActiveQueueIds(this.config.redisConfig, [{ queueId: queueName }])
   }
 
   public unregisterQueueProcessor(): void {
-    queueIdsWithActiveProcessorsSet.delete(this.config.queueId)
+    queueNamesWithActiveProcessorsSet.delete(this.config.queueName)
   }
 
   public getRequestContext(job: JobType): RequestContext {

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.spec.ts
@@ -44,7 +44,7 @@ describe('AbstractBackgroundJobProcessor', () => {
       await job2.start()
       await expect(
         new FakeBackgroundJobProcessor<JobData>(deps, 'queue1', factory.getRedisConfig()).start(),
-      ).rejects.toMatchInlineSnapshot('[Error: Processor for queue id "queue1" is not unique.]')
+      ).rejects.toMatchInlineSnapshot('[Error: Processor for queue "queue1" is not unique.]')
 
       await job1.dispose()
       await job2.dispose()

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessor.ts
@@ -121,6 +121,7 @@ export abstract class AbstractBackgroundJobProcessor<
       isNewProcessor: false,
       processorName: this.constructor.name,
       ...config,
+      queueName: resolveQueueId(config),
     })
     this.config = config
     this.factory = dependencies.bullmqFactory

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.start.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.start.spec.ts
@@ -51,7 +51,7 @@ describe('AbstractBackgroundJobProcessorNew - start', () => {
     await job1.start()
     await expect(
       new FakeBackgroundJobProcessorNew<SupportedQueues, 'queue1'>(deps, 'queue1').start(),
-    ).rejects.toMatchInlineSnapshot('[Error: Processor for queue id "queue1" is not unique.]')
+    ).rejects.toMatchInlineSnapshot('[Error: Processor for queue "queue1" is not unique.]')
 
     await job1.dispose()
   })
@@ -167,7 +167,7 @@ describe('AbstractBackgroundJobProcessorNew - start of queue ids resolving to on
         deps,
         'group.queue',
       ).start(),
-    ).rejects.toMatchInlineSnapshot('[Error: Processor for queue id "group.queue" is not unique.]')
+    ).rejects.toMatchInlineSnapshot('[Error: Processor for queue "group.queue" is not unique.]')
 
     await processor.dispose()
   })

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.start.spec.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.start.spec.ts
@@ -126,3 +126,49 @@ describe('AbstractBackgroundJobProcessorNew - start', () => {
     await processor.dispose()
   })
 })
+
+describe('AbstractBackgroundJobProcessorNew - start of queue ids resolving to one queue', () => {
+  // Dashboard grouping is part of the queue name, so both of these are the BullMQ queue
+  // `group.queue`, however differently their ids are spelled.
+  const collidingQueues = [
+    {
+      queueId: 'queue',
+      bullDashboardGrouping: ['group'],
+      jobPayloadSchema: z.object({ metadata: z.object({ correlationId: z.string() }) }),
+    },
+    {
+      queueId: 'group.queue',
+      jobPayloadSchema: z.object({ metadata: z.object({ correlationId: z.string() }) }),
+    },
+  ] as const satisfies QueueConfiguration[]
+
+  type CollidingQueues = typeof collidingQueues
+
+  let factory: TestDependencyFactory
+  let deps: BackgroundJobProcessorDependenciesNew<CollidingQueues, 'queue' | 'group.queue'>
+
+  beforeEach(async () => {
+    factory = new TestDependencyFactory()
+    deps = factory.createNew(collidingQueues)
+
+    await factory.clearRedis()
+  })
+
+  afterEach(async () => {
+    await factory.dispose()
+  })
+
+  it('throws an error for the second processor of the same queue', async () => {
+    const processor = new FakeBackgroundJobProcessorNew<CollidingQueues, 'queue'>(deps, 'queue')
+    await processor.start()
+
+    await expect(
+      new FakeBackgroundJobProcessorNew<CollidingQueues, 'group.queue'>(
+        deps,
+        'group.queue',
+      ).start(),
+    ).rejects.toMatchInlineSnapshot('[Error: Processor for queue id "group.queue" is not unique.]')
+
+    await processor.dispose()
+  })
+})

--- a/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
+++ b/packages/app/background-jobs-common/src/background-job-processor/processors/AbstractBackgroundJobProcessorNew.ts
@@ -144,6 +144,7 @@ export abstract class AbstractBackgroundJobProcessorNew<
       isNewProcessor: true,
       processorName: this.constructor.name,
       ...config,
+      queueName: resolveQueueId(this.queueManager.getQueueConfig(config.queueId)),
     })
   }
 


### PR DESCRIPTION
## What

The duplicate-processor guard is keyed on the resolved BullMQ queue name instead of the raw `queueId`.

Dashboard grouping is encoded into the queue name, so `{ queueId: 'a', bullDashboardGrouping: ['group'] }` and `{ queueId: 'group.a' }` are two spellings of the queue `group.a`. Their `queueId`s differ, so `registerQueueProcessor` accepted both and let two processors consume one queue, which is the case the guard exists to reject.

## Changes

- `BackgroundJobProcessorMonitor` takes the resolved `queueName` and keys the uniqueness set, and the error it throws, on that.
- The Redis queue-id registration is handed the resolved name directly. It used to resolve grouping out of the monitor's own config object, which worked only because both processors spread their entire config into it.
- Both processors pass the resolved name: the deprecated one from its own config, the new one from the queue manager's configuration for its queue id.
- Tests cover it at both levels: two monitor configs resolving to one name, and two processors started through `AbstractBackgroundJobProcessorNew`.

## Scope

The branch name refers to worker slot saturation metrics. That work is not part of this PR: `@lokalise/fastify-extras` already exports `bullMqMetricsPlugin`, which reports queue depth per state and job durations, and this fix is the part that stands on its own.

## Verification

`biome check` clean, `tsc` clean, declaration build clean, 265 tests passing. The two failures in `ignores missing job error during automatic purging` are pre-existing on `main` and unrelated, confirmed by running those specs with this branch's changes stashed.

## AI Assistance Tracking

We're running a metric to understand where AI assists our engineering work. Please select exactly one of the options below:

Mark "Yes" if AI helped in any part of this work, for example: generating code, refactoring, debugging support, explaining something, reviewing an idea, or suggesting an approach.

- [x] **Yes, AI assisted with this PR**
- [ ] **No, AI did not assist with this PR**
